### PR TITLE
docs: Kenntnisse-Redesign — Freischalt-Techtree + Berater-Zuweisung (GDD §10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-04-14 (Design: Kenntnisse-Redesign — Freischalt-Techtree + Berater-Zuweisung)
+
+- **Kenntnisse-System grundlegend neu designt** (GDD §10): Level+Decay-Modell wird durch Freischalt-Techtree ersetzt — Kenntnisse werden einmalig erarbeitet und bleiben permanent. Kein Decay auf Wissen.
+- **Zwei Effekt-Ebenen** definiert: Primäreffekt (immer aktiv nach Freischaltung), Sekundäreffekt (aktiv wenn Kenntnis einem Berater zugewiesen).
+- **Berater-Zuweisung** als neue Mechanik: jeder Berater ab Rang 2 hat 1 Kenntnis-Slot. Max. 5 aktive Sekundäreffekte gleichzeitig (einer pro Berater). Erzeugt echte Spezialisierungsentscheidungen.
+- **Roguelike-Variabilität**: pro Run nur zufällige Teilmenge der Kenntnisse verfügbar (z.B. 5 von 7).
+- **Roadmap Phase 3a** um drei Design-Punkte erweitert: Kenntnisse-Redesign, Handel-Redesign, Flottenbewegung-Redesign — je mit eigenem Branch.
+- Vollständige Berater×Kenntnisse-Matrix (35 Kombinationen) und konkrete Sekundäreffekt-Werte sind TODOs nach erstem Playtest.
+
 ## 2026-04-12 (GDD-Review: Inkonsistenzen behoben, techs → knowledge umbenannt)
 
 - **CC max_level 10 → 5** in GDD §4 korrigiert (war nur noch dort veraltet).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -364,9 +364,10 @@ Dieser Schnitt macht Sinn, weil Phase 2 die Mechaniken implementiert und stabili
 
 ### Phase 3a: Content & Balancing + Kernmechaniken
 
-- [ ] **Gebäude- und Forschungskosten kalibrieren** — Kosten, Produktionswerte und Voraussetzungsketten aller 25 Gebäude und 10 Forschungen auf Basis des Decay- und AP-Systems aus Phase 2 überprüfen und anpassen
-- [ ] **Supply-Kosten auf Plausibilität testen** — offene Frage: kann ein Anfänger einen Battlecruiser unterhalten? Supply-Cap-Modell (CC_flat 15 + HousingLevel × 8, max 200) gegen Schiffskosten abgleichen
-- [ ] **Forschungshandel-Mechanik definieren und umsetzen** — Designfrage: Level-Transfer, Wissenstransfer oder Lizenz-Modell; ADR erforderlich vor Implementierung (`docs/adr/`)
+- [ ] **Gebäude- und Forschungskosten kalibrieren** — Kosten, Produktionswerte und Voraussetzungsketten aller 12 Gebäude und 10 Kenntnisse auf Basis des Decay- und AP-Systems aus Phase 2 überprüfen und anpassen
+- [ ] **Supply-Kosten auf Plausibilität testen** — Supply-Cap-Modell (CC_level×10 + HousingComplex×8, max 200) gegen Schiffskosten (Korvette 14, Frachter 6, Sonde 0) abgleichen
+- [ ] **Kenntnisse-System redesignen** — aktuell Level+Decay wie Gebäude; Designfrage: Freischalt-Techtree (einmalig erforscht, bleibt) vs. beibehaltenes Decay-Modell; ADR erforderlich vor Implementierung (`docs/adr/`) → Branch: `claude/design-forschung-redesign`
+- [ ] **Handel redesignen** — aktuelles Marktplatz-Modell (Angebotspreise, AP-Kosten, Richtung 0/1) ist für großen 4X-Scope ausgelegt; für 2-4 Spieler/Singleplayer einen einfacheren, brettspielnahen Mechanismus definieren; ADR erforderlich → Branch: `claude/design-handel-redesign`
 - [ ] **Interstellare Flottenbewegung freischalten** — aktuell in `FleetController::storeOrder` explizit gesperrt; Wurmloch/Sternentor-Mechanik designen (ADR erforderlich vor Implementierung); `GalaxyService::getPath()` unterstützt systemübergreifende Pfade bereits
 
 ---

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -653,7 +653,7 @@ Neue Schiffstypen und deren Kampfwerte werden ausschließlich in dieser Config k
 
 ## 10. Kenntnisse (ehem. Forschung)
 
-7 Wissensgebiete — kein akademisches Studium, sondern praktisches Kolonialwissen, das durch Analyse-AP vorangetrieben wird:
+7 Wissensgebiete — kein akademisches Studium, sondern praktisches Kolonialwissen, das durch Analyse-AP (Analytiker-Berater) erarbeitet wird:
 
 | Key | Name (DE) | Name (EN) |
 |-----|-----------|-----------|
@@ -665,25 +665,63 @@ Neue Schiffstypen und deren Kampfwerte werden ausschließlich in dieser Config k
 | trade | Handel & Logistik | Trade & Logistics |
 | defense | Verteidigung & Überlebenstaktik | Defence & Survival Tactics |
 
-Kenntnisse werden über Aktionspunkte (AP) vorangetrieben. Details zum AP-System: §12.
+### Freischalt-Modell (Phase 3 Redesign)
 
-### Supply-Cap-Bonus
+Kenntnisse werden **einmalig erarbeitet** (Analytiker-AP) und bleiben **permanent freigeschaltet**. Es gibt kein Decay auf Kenntnissen — Wissen geht nicht verloren. Die natürliche Begrenzung erfolgt über AP-Knappheit und Rundenstruktur.
 
-Jede Kenntnis erhöht den Supply-Cap nicht-linear pro Level (Glockenform):
+> **TODO Implementierung:** Das bestehende Level+Decay-Modell (wie Gebäude) wird durch dieses Freischalt-Modell ersetzt. Migration und Code-Anpassung ausstehend.
 
-| Level | Cap-Bonus (dieses Level) | Kumuliert |
-|-------|--------------------------|-----------|
-| 1 | +3 | 3 |
-| 2 | +5 | 8 |
-| 3 | +5 | 13 |
-| 4 | +4 | 17 |
-| 5 | +3 | **20** |
+### Zwei Effekt-Ebenen
 
-Konfiguration: `config/game.php → supply.knowledge_cap_per_level`. Details zur Supply-Formel: §6.
+Jede Kenntnis hat:
 
-Bestimmte Kenntnisse beeinflussen auch die Moral der Kolonie (agronomy +1/Level, health +2/Level, defense -1/Level) — Details siehe §13.
+- **Primäreffekt** — aktiv sobald freigeschaltet, unabhängig von Beratern (z.B. Supply-Cap-Bonus, Moraleffekt)
+- **Sekundäreffekt** — nur aktiv wenn die Kenntnis einem Berater zugewiesen ist; variiert je nach Berater-Typ
 
-*Weitere Spielmechanik (AP-Kosten, Voraussetzungen) — wird in Phase 3 ergänzt.*
+Beispiele für Sekundäreffekte (konkrete Werte folgen nach erstem Playtest):
+
+| Kenntnis | Berater | Sekundäreffekt |
+|----------|---------|----------------|
+| geology | advisor_engineer | −10% Gebäudekosten |
+| geology | advisor_trader | +10% Rohstoff-Verkaufspreis |
+| health | advisor_scientist | +1 Analyse-AP/Tick |
+| defense | advisor_pilot | −1 AP-Kosten für Angriff |
+| trade | advisor_trader | +15% Handelsgewinn |
+| cartography | advisor_pilot | +1 Bewegungsreichweite |
+
+> **TODO Design:** Vollständige 7×5-Matrix (alle Kenntnisse × alle Berater) ausarbeiten — nach erstem Playtest, wenn klar ist welche Kombinationen strategisch interessant sind.
+
+### Berater-Zuweisung
+
+Freigeschaltete Kenntnisse können einem Berater zugewiesen werden (UI: Drag & Drop). Der Sekundäreffekt der Kenntnis wird durch den zugewiesenen Berater bestimmt.
+
+**Slots je Berater nach Rang:**
+
+| Rang | Kenntnis-Slots |
+|------|----------------|
+| 1 | 0 |
+| 2 | 1 |
+| 3 | 1 |
+
+Rang-Aufstieg schaltet bei Rang 2 den Slot frei; Rang 3 erhöht den Slot nicht weiter (dafür steigt der AP-Bonus — §12).
+
+**Max. aktive Sekundäreffekte:** 5 (je ein Slot pro Berater, wenn alle auf Rang 2+). Bei 7 Kenntnissen und 5 Slots muss der Spieler 2 Kenntnisse ohne Sekundäreffekt lassen — das erzeugt echte Spezialisierungsentscheidungen.
+
+> **Balancing-Notiz:** Slot-Anzahl und Kenntnisanzahl sind Ausgangswerte für den ersten Playtest. Nach Erfahrungen aus dem Betrieb können zusätzliche Kenntnisse und/oder ein zweiter Slot bei Rang 3 eingeführt werden.
+
+### Roguelike-Variabilität
+
+Pro Run ist nicht der vollständige Kenntnisbaum verfügbar — nur eine zufällige Teilmenge (z.B. 5 von 7). Das erzeugt unterschiedliche Spezialisierungspfade ohne das System komplexer zu machen, analog zum variablen Spielfeld bei Catan.
+
+> **TODO Implementierung:** Run-Mechanik mit zufälliger Kenntnisauswahl — ausstehend für Phase 3 Run-Struktur (§14).
+
+### Supply-Cap-Bonus (Primäreffekt, bleibt erhalten)
+
+Jede freigeschaltete Kenntnis erhöht den Supply-Cap. Da es kein Levelsystem mehr gibt, wird der Bonus als Pauschalwert beim Freischalten gewährt:
+
+> **TODO Design:** Pauschalen Supply-Cap-Bonus pro Kenntnis definieren (ersetzt die bisherige Level-Glockenformel). Richtwert: +8–12 pro Kenntnis, sodass alle 7 Kenntnisse zusammen ~60–80 Cap-Bonus ergeben.
+
+Bestimmte Kenntnisse beeinflussen auch die Moral der Kolonie (agronomy, health, defense) — Details siehe §13.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Kenntnisse-System neu designt** (GDD §10): Level+Decay → permanentes Freischalt-Modell
- **Berater-Zuweisung** als neue Mechanik: Rang 2+ = 1 Kenntnis-Slot, max. 5 aktive Sekundäreffekte
- **Roadmap Phase 3a** um Kenntnisse-, Handel- und Flottenbewegung-Redesign erweitert

## Änderungen

- `docs/GDD.md` §10: vollständig neu geschrieben (Freischalt-Modell, Zwei-Effekt-Ebenen, Berater-Zuweisung, Roguelike-Variabilität, TODOs)
- `ROADMAP.md`: Phase 3a aktualisiert (veraltete Gebäude/Schiffs-Zahlen, 3 neue Design-Punkte mit Branch-Referenzen)
- `CHANGELOG.md`: Eintrag 2026-04-14 ergänzt

## Nur Design — kein Code

Dieser PR enthält ausschließlich Dokumentation. Die Implementierung (Migration colony_researches, PersonellService, Decay-Logik) folgt in einem separaten Branch nach Abschluss der weiteren Design-Sprints (Handel, Flottenbewegung).

## Offene TODOs (bewusst zurückgestellt)

- Vollständige 7x5-Matrix (Kenntnisse x Berater) mit konkreten Sekundäreffekten — nach erstem Playtest
- Pauschalen Supply-Cap-Bonus pro Kenntnis definieren
- Run-Mechanik mit zufälliger Kenntnisauswahl (§14)