### PR TITLE
docs: Flottenbewegung — interstellare Bewegung bewusst nicht implementiert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-04-15 (Design: Flottenbewegung — interstellare Bewegung bewusst nicht implementiert)
+
+- **Interstellare Bewegung gestrichen** (GDD §8, ROADMAP): Flotten operieren ausschließlich im eigenen System — bewusste Designentscheidung, kein vergessenes Feature.
+- **Sprungtor als narratives Element** definiert: im System sichtbar, nicht nutzbar, bewachbar (`defend`-Order). Verbindung zur Nexus-Lore (warum siedelt Nexus hier?).
+- **"Gäste von außerhalb"** kommen via Events und Bar — keine Bewegungsmechanik nötig.
+- ROADMAP: Flottenbewegung als erledigt markiert, interstellare Bewegung in "Bewusste Designentscheidungen"-Tabelle aufgenommen.
+
 ## 2026-04-15 (Design: Handelsmechanik — Bar als einziger Handelsort, Nexus-Fallback, Lore)
 
 - **Handelssystem komplett redesignt** (GDD §11): Bar/Cantina ist der einzige Handelsort — NPC-Gäste, Spieler-zu-Spieler, Kauf und Verkauf alles über dieselbe Mechanik.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -368,7 +368,7 @@ Dieser Schnitt macht Sinn, weil Phase 2 die Mechaniken implementiert und stabili
 - [ ] **Supply-Kosten auf Plausibilität testen** — Supply-Cap-Modell (CC_level×10 + HousingComplex×8, max 200) gegen Schiffskosten (Korvette 14, Frachter 6, Sonde 0) abgleichen
 - [ ] **Kenntnisse-System redesignen** — aktuell Level+Decay wie Gebäude; Designfrage: Freischalt-Techtree (einmalig erforscht, bleibt) vs. beibehaltenes Decay-Modell; ADR erforderlich vor Implementierung (`docs/adr/`) → Branch: `claude/design-forschung-redesign`
 - [ ] **Handel redesignen** — aktuelles Marktplatz-Modell (Angebotspreise, AP-Kosten, Richtung 0/1) ist für großen 4X-Scope ausgelegt; für 2-4 Spieler/Singleplayer einen einfacheren, brettspielnahen Mechanismus definieren; ADR erforderlich → Branch: `claude/design-handel-redesign`
-- [ ] **Interstellare Flottenbewegung freischalten** — aktuell in `FleetController::storeOrder` explizit gesperrt; Wurmloch/Sternentor-Mechanik designen (ADR erforderlich vor Implementierung); `GalaxyService::getPath()` unterstützt systemübergreifende Pfade bereits
+- [ ] **Flottenbewegung redesignen** — nicht nur freischalten; Kernfrage: wie sieht Bewegung im neuen kleinen Scope aus (Wurmloch? Direktflug? Sektorkarte?)? ADR erforderlich → Branch: `claude/design-flotte-bewegung`
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -368,7 +368,7 @@ Dieser Schnitt macht Sinn, weil Phase 2 die Mechaniken implementiert und stabili
 - [ ] **Supply-Kosten auf Plausibilität testen** — Supply-Cap-Modell (CC_level×10 + HousingComplex×8, max 200) gegen Schiffskosten (Korvette 14, Frachter 6, Sonde 0) abgleichen
 - [ ] **Kenntnisse-System redesignen** — aktuell Level+Decay wie Gebäude; Designfrage: Freischalt-Techtree (einmalig erforscht, bleibt) vs. beibehaltenes Decay-Modell; ADR erforderlich vor Implementierung (`docs/adr/`) → Branch: `claude/design-forschung-redesign`
 - [ ] **Handel redesignen** — aktuelles Marktplatz-Modell (Angebotspreise, AP-Kosten, Richtung 0/1) ist für großen 4X-Scope ausgelegt; für 2-4 Spieler/Singleplayer einen einfacheren, brettspielnahen Mechanismus definieren; ADR erforderlich → Branch: `claude/design-handel-redesign`
-- [ ] **Flottenbewegung redesignen** — nicht nur freischalten; Kernfrage: wie sieht Bewegung im neuen kleinen Scope aus (Wurmloch? Direktflug? Sektorkarte?)? ADR erforderlich → Branch: `claude/design-flotte-bewegung`
+- [x] **Flottenbewegung redesignt** — Entscheidung: interstellare Bewegung wird nicht implementiert; Flotten operieren ausschließlich im eigenen System; Sprungtor als narratives Element → Branch: `claude/design-flotte-bewegung`
 
 ---
 
@@ -395,7 +395,8 @@ Dieser Schnitt macht Sinn, weil Phase 2 die Mechaniken implementiert und stabili
 
 | Thema | Entscheidung | Begründung |
 |---|---|---|
-| **Modulare Schiffe** | Nicht implementieren | Die Kolonie steht im Vordergrund. Die 6 Schiffstypen + 4 Attribute erzeugen bereits sinnvolle Kompositionsentscheidungen. Bei 1 Tick/Tag wäre der Feedback-Loop für Modul-Fehler zu langsam. |
+| **Interstellare Bewegung** | Nicht implementieren | Bei einer Kolonie im Fokus findet alles im eigenen System statt. Sprungtor existiert als narratives Element. Gäste von außerhalb kommen via Events/Bar. Phase 4+ nachrüstbar. |
+| **Modulare Schiffe** | Nicht implementieren | Die Kolonie steht im Vordergrund. Die 3 Schiffstypen erzeugen bereits sinnvolle Kompositionsentscheidungen. Bei 1 Tick/Tag wäre der Feedback-Loop für Modul-Fehler zu langsam. |
 | **Angriffe auf Kolonien** | Nicht implementieren | Nur PvP-Schiffskämpfe (Schiff vs. Schiff). Kolonien sind kein Angriffsziel. |
 | **Kolonisierung** | Nicht implementieren | Jeder Spieler hat genau eine Kolonie. |
 | **Rassen-System** | Zurückstellen auf Phase 4 | `race_id` ist im Schema, wird nicht ausgewertet. Rassenspezifische Effekte zu definieren setzt Playtest-Daten voraus — sonst blind balancen. |

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -589,9 +589,9 @@ Bewegt eine Flotte zu Zielkoordinaten `[x, y, spot]` innerhalb eines Sternensyst
 - `FleetService::addOrder()` berechnet den Pfad via `GalaxyService::getPath()` und legt für jeden Tick auf dem Weg eine 'move'-Order an; nur die letzte Order trägt den eigentlichen Order-Typ
 - Pro Tick des Weges werden Navigation-AP gesperrt (Gesamtkosten = Wegkosten + Order-Kosten)
 
-**Einschränkungen Phase 2:**
+**Einschränkungen (bewusste Designentscheidung):**
 - Ausschließlich innerhalb eines Sternensystems (gleiche `system_id`)
-- Interstellare Bewegung (zwischen Systemen) erfordert eine noch zu definierende Wurmloch-/Sternentor-Mechanik und ist für Phase 3 vorgesehen
+- Interstellare Bewegung wird **nicht implementiert** — siehe unten
 
 **Datenspeicherung:**
 - Koordinaten in `fleet_orders.coordinates` werden als JSON gespeichert (`json_encode`)
@@ -599,6 +599,18 @@ Bewegt eine Flotte zu Zielkoordinaten `[x, y, spot]` innerhalb eines Sternensyst
 
 Nach Ausführung wird die Position der Flotte (`fleets.x`, `fleets.y`, `fleets.spot`) aktualisiert.
 INNN-Ereignis `galaxy.fleet_arrived` wird für den Flottenbesitzer erzeugt.
+
+### Interstellare Bewegung — bewusst nicht implementiert
+
+Flotten operieren ausschließlich im eigenen Sternensystem. Interstellare Bewegung zwischen Systemen wird nicht implementiert.
+
+**Begründung:** Bei einem Scope von einer Kolonie pro Spieler und wenigen Schiffen findet fast alles im eigenen System statt — Erkundung, Ressourcenbergung, Bewachung, PvP. Eine interstellare Bewegungsmechanik würde Komplexität hinzufügen ohne spielerischen Mehrwert für Phase 3.
+
+**Das Sprungtor als narratives Element:** Im System ist ein Sprungtor sichtbar (Galaxiekarte), das theoretisch den Weg zu anderen Systemen öffnen könnte. Es wird nicht benutzt — aber es kann bewacht werden (`defend`-Order). Narrativ: Warum siedelt Nexus ausgerechnet in diesem System? Das Sprungtor deutet eine Antwort an ohne sie zu geben.
+
+**"Gäste von außerhalb"** kommen via Events und Bar — Händler, Schmuggler, Boten aus anderen Systemen erscheinen ohne dass eine Bewegungsmechanik implementiert sein muss.
+
+> **Phase 4+:** Wenn Multiplayer-PvP zwischen Systemen gewünscht wird, kann interstellare Bewegung dann als eigene Mechanik nachgerüstet werden. `GalaxyService::getPath()` unterstützt systemübergreifende Pfade bereits technisch.
 
 ### Trade-Order
 


### PR DESCRIPTION
## Summary

Interstellare Bewegung wird nicht implementiert — bewusste Designentscheidung für den Mini-4X-Scope, kein vergessenes Feature.

## Änderungen

- `docs/GDD.md` §8: Abschnitt "Interstellare Bewegung — bewusst nicht implementiert" ergänzt
- `ROADMAP.md`: Flottenbewegung als erledigt markiert, in "Bewusste Designentscheidungen"-Tabelle aufgenommen
- `CHANGELOG.md`: Eintrag 2026-04-15

## Designentscheidung

Bei einer Kolonie im Fokus und wenigen Schiffen findet alles im eigenen System statt. Das **Sprungtor** existiert als narratives Element auf der Galaxiekarte — sichtbar, nicht nutzbar, bewachbar (`defend`-Order). Verbindet sich mit der Nexus-Lore: warum siedelt Nexus ausgerechnet in diesem System?

"Gäste von außerhalb" (Händler, Schmuggler) kommen via Events und Bar — ohne Bewegungsmechanik.

Phase 4+: `GalaxyService::getPath()` unterstützt systemübergreifende Pfade bereits technisch — nachrüstbar wenn Multiplayer-PvP zwischen Systemen gewünscht wird.