### PR TITLE
docs: Design-Sprint DS-3 abgeschlossen (Reisender Händler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-04-21 (Design-Sprint: DS-1, DS-2, DS-3 abgeschlossen)
+
+- **DS-1 Kolonieansicht:** Hex-Grid, zwei Zonen (Kolonie + Exploration), CC-Level schaltet Ringe frei (max Lv5, Klein/Mittel/Groß = 2/3/4 Ringe), Harvester als Sondergebäude mit Tile-Position, Organika aus Agrardom, Quellen versiegen graduell. Run-Ende: Vertrauen kritisch → abgesetzt, Nexus-Schulden zu hoch → zurückgerufen.
+- **DS-2 Systemansicht:** 2D top-down Grid 12×12 (unsichtbar, erscheint nur im Flottenbefehlsmodus), Scan/Tiefenscan-Erkundung, fixe Objekte (Stern, Heimatplanet, Sprungtor, Nexus-Außenposten), prozedurale Objekte pro Run.
+- **DS-3 Reisender Händler:** Erscheint ab Tick 15–20, dann alle 10–15 Ticks (~6–7 Besuche/Run), 3–4 Items/Besuch, Credits-Preise, höhere Preise auf schwierigeren Runs. Item-Kategorien: AP-Paket, Schiff (mit Eigenname), Information, Einmal-Item, Exotics (Phase 4+).
+- GDD §4a, §8a und §13/§14 entsprechend aktualisiert (Vertrauen statt Moral, Direktor/Direktorin als Spieler-Titel, Nexus-Narrativ).
+
 ## 2026-04-18
 
 - Forschungshandel (`trade_researches`) vollständig entfernt — im neuen Singleplayer-Roguelike-Design nicht mehr vorgesehen; Migration `2026_04_18_000001` droppt die Tabelle, zugehörige Models/Views/Routen/Tests bereinigt

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -712,7 +712,25 @@ Vereinzelte NPC-Fraktionen sind im System präsent. Das System wirkt unbesiedelt
 
 ### Reisender Händler
 
-Ein reisender Händler erscheint gelegentlich im System für eine begrenzte Anzahl Ticks. Er bietet seltene Waren an (keine Standardressourcen — Shortcuts, Blaupausen, temporäre Söldner, Informationen). Sein Inventar wird in DS-3 definiert.
+Ein reisender Händler erscheint gelegentlich im System für eine begrenzte Anzahl Ticks. Er bietet seltene Waren an — keine Standardressourcen, sondern Shortcuts und Chancen die im normalen Spielverlauf nicht erreichbar sind.
+
+**Erscheinungsfrequenz:** Erstmals ab Tick 15–20 (Kolonie soll sich erst etablieren). Danach alle 10–15 Ticks zufällig. Ergibt ~6–7 Besuche pro 100-Tick-Run. Ist der Händler weg, ist er weg — Roguelike-Druck.
+
+**Inventar:** 3–4 Items pro Besuch (Mobile-optimiert, kein Scrollen nötig).
+
+**Preisstruktur:** Alles in Credits. Kein Tauschhandel in Phase 3. Exotics/Tausch für Phase 4+ denkbar.
+
+**Schwierigkeitsskalierung:** Höhere Preise auf schwierigeren Runs — nicht schlechteres Sortiment (das wäre frustrierend).
+
+**Item-Kategorien:**
+
+| Kategorie | Beschreibung | Seltenheit |
+|-----------|-------------|-----------|
+| **AP-Paket** | Sofortiger AP-Schub für ein bestimmtes Gebäude oder eine Kenntnis — beschleunigt, bypassed aber keine Voraussetzungen | gelegentlich |
+| **Schiff** | Gebrauchtes Schiff mit Eigenname — ersetzt ein bestehendes Schiff (Hangar bleibt konstant). Phase 4+: besondere Eigenschaften denkbar | selten |
+| **Information** | Alle versteckten Event-Spots im System sofort enthüllt | selten |
+| **Einmal-Item** | Reparatur-Kit, Vertrauens-Schub, Credits-Notfallkredit | häufig |
+| **Exotics** | Platzhalter Phase 4+ | sehr selten |
 
 ### Multiplayer
 


### PR DESCRIPTION
## Summary

- DS-3 (Reisender Händler / Item-System) finalisiert und im GDD dokumentiert
- Changelog für Design-Sprint-Phase DS-1/DS-2/DS-3 nachgepflegt

## Designentscheidungen DS-3

- Erscheint ab Tick 15–20, danach alle 10–15 Ticks (~6–7 Besuche/Run)
- 3–4 Items pro Besuch, Preise in Credits
- Höhere Preise auf schwierigeren Runs (nicht schlechteres Sortiment)
- Item-Kategorien: AP-Paket, Schiff (mit Eigenname, ersetzt bestehendes), Information, Einmal-Item, Exotics (Phase 4+)

## Test plan

- [ ] Keine Code-Änderungen — reine Dokumentation
- [ ] GDD-Text auf Konsistenz mit DS-1/DS-2 geprüft