### PR TITLE
feat: Phase 3b Colony Hex-Grid View

### DIFF
--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Colony;
 
 use App\Http\Controllers\BaseController;
 use App\Services\ColonyService;
+use App\Services\ColonyTileService;
+use App\Services\TickService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -12,13 +14,37 @@ use Illuminate\View\View;
 
 class ColonyController extends BaseController
 {
-    public function __construct(private readonly ColonyService $colonyService) {}
+    public function __construct(
+        TickService $tick,
+        private readonly ColonyService $colonyService,
+        private readonly ColonyTileService $tileService,
+    ) {
+        parent::__construct($tick);
+    }
 
     public function index(): View
     {
         $colony = $this->colonyService->getPrimeColony(Auth::id());
 
         return view('colony.index', compact('colony'));
+    }
+
+    public function hexview(): View
+    {
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $tiles  = $this->tileService->getTilesForColony($colony->id);
+
+        if ($tiles->isEmpty()) {
+            $this->tileService->generateDefaultTiles($colony);
+            $tiles = $this->tileService->getTilesForColony($colony->id);
+        }
+
+        $ccLevel = (int) DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', 25)
+            ->value('level') ?? 0;
+
+        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel'));
     }
 
     public function rename(Request $request): RedirectResponse

--- a/app/Models/ColonyTile.php
+++ b/app/Models/ColonyTile.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ColonyTile extends Model
+{
+    protected $table = 'colony_tiles';
+    public $timestamps = true;
+
+    protected $fillable = [
+        'colony_id',
+        'q',
+        'r',
+        'ring',
+        'tile_type',
+        'event_type',
+        'is_ring_unlocked',
+        'is_explored',
+        'is_deep_scanned',
+        'resource_amount',
+        'resource_max',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'q'               => 'integer',
+            'r'               => 'integer',
+            'ring'            => 'integer',
+            'is_ring_unlocked' => 'boolean',
+            'is_explored'     => 'boolean',
+            'is_deep_scanned' => 'boolean',
+            'resource_amount' => 'integer',
+            'resource_max'    => 'integer',
+        ];
+    }
+
+    public function colony()
+    {
+        return $this->belongsTo(Colony::class, 'colony_id');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -79,8 +79,8 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->bootBypassFlags();
 
-        // Inject resource bar data into the main layout for authenticated users
-        View::composer('layouts.app', function ($view) {
+        // Inject resource bar data into game layouts for authenticated users
+        View::composer(['layouts.app', 'layouts.colony'], function ($view) {
             if (Auth::check()) {
                 $colonyId = session('activeIds.colonyId', 1);
                 $resourcesService = app(ResourcesService::class);

--- a/app/Services/ColonyTileService.php
+++ b/app/Services/ColonyTileService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Colony;
+use App\Models\ColonyTile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class ColonyTileService
+{
+    public function getTilesForColony(int $colonyId): Collection
+    {
+        return ColonyTile::where('colony_id', $colonyId)
+            ->orderBy('ring')
+            ->orderBy('q')
+            ->orderBy('r')
+            ->get();
+    }
+
+    /**
+     * Generate a default hex grid for a colony (dev / first-visit convenience).
+     * Tiles are deterministic based on q, r, and colony_id.
+     */
+    public function generateDefaultTiles(Colony $colony, int $maxRing = 3): void
+    {
+        $colonyId = $colony->id;
+        $ccLevel  = (int) DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', 25)
+            ->value('level') ?? 0;
+
+        $rows = [];
+
+        for ($q = -$maxRing; $q <= $maxRing; $q++) {
+            $rMin = max(-$maxRing, -$q - $maxRing);
+            $rMax = min($maxRing, -$q + $maxRing);
+            for ($r = $rMin; $r <= $rMax; $r++) {
+                $ring = max(abs($q), abs($r), abs($q + $r));
+
+                $isCC            = ($q === 0 && $r === 0);
+                $isRingUnlocked  = $ring <= max(1, $ccLevel);
+                $isExplored      = $ring <= 1;
+
+                if ($isCC) {
+                    $tileType = 'terrain_empty';
+                } else {
+                    $tileType = $this->pickTileType($q, $r, $colonyId);
+                }
+
+                $resourceAmount = null;
+                $resourceMax    = null;
+                if (str_starts_with($tileType, 'regolith_')) {
+                    $resourceMax    = match ($tileType) {
+                        'regolith_rich'   => 800,
+                        'regolith_normal' => 500,
+                        default           => 250,
+                    };
+                    $resourceAmount = $resourceMax;
+                }
+
+                $rows[] = [
+                    'colony_id'       => $colonyId,
+                    'q'               => $q,
+                    'r'               => $r,
+                    'ring'            => $ring,
+                    'tile_type'       => $tileType,
+                    'event_type'      => null,
+                    'is_ring_unlocked' => $isRingUnlocked ? 1 : 0,
+                    'is_explored'     => $isExplored ? 1 : 0,
+                    'is_deep_scanned' => 0,
+                    'resource_amount' => $resourceAmount,
+                    'resource_max'    => $resourceMax,
+                    'created_at'      => now(),
+                    'updated_at'      => now(),
+                ];
+            }
+        }
+
+        DB::table('colony_tiles')->insertOrIgnore($rows);
+    }
+
+    private function pickTileType(int $q, int $r, int $colonyId): string
+    {
+        $hash = abs($q * 7 + $r * 13 + $colonyId * 3) % 100;
+
+        if ($hash < 5)  return 'terrain_impassable';
+        if ($hash < 15) return 'terrain_hazard';
+        if ($hash < 35) return 'regolith_poor';
+        if ($hash < 55) return 'regolith_normal';
+        if ($hash < 65) return 'regolith_rich';
+        return 'terrain_empty';
+    }
+}

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -1,0 +1,227 @@
+/* Colony view — helles UI: Weiß 60%, Anthrazit 30%, Rot 10% */
+:root {
+    --color-anthracite: #333;
+    --color-accent:     #c0392b;
+    --color-bg:         #fff;
+    --color-surface:    #f5f5f5;
+    --color-border:     #ddd;
+}
+
+/* ── Layout ──────────────────────────────────────────────────────────────── */
+
+body {
+    margin: 0;
+    padding: 0;
+    background: var(--color-bg);
+    color: var(--color-anthracite);
+    font-family: system-ui, sans-serif;
+}
+
+.colony-header {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--color-anthracite);
+    color: #fff;
+    border-bottom: 2px solid var(--color-accent);
+}
+
+.colony-header nav {
+    padding: 0 1rem;
+    margin: 0;
+    background: transparent;
+}
+
+.colony-header nav a,
+.colony-header nav strong a {
+    color: rgba(255,255,255,0.85);
+    text-decoration: none;
+}
+
+.colony-header nav a:hover,
+.colony-header nav a.active {
+    color: #fff;
+}
+
+.colony-header nav a.active {
+    font-weight: 600;
+    border-bottom: 2px solid var(--color-accent);
+}
+
+.colony-header details.dropdown > summary {
+    color: rgba(255,255,255,0.85);
+}
+
+/* Resource bar */
+.colony-resbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.35rem 1rem 0.4rem;
+    background: #f8f8f8;
+    border-top: 1px solid var(--color-border);
+}
+
+.res-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px 2px 6px;
+    border-radius: 20px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border: 1px solid var(--color-border);
+    background: #fff;
+    color: var(--color-anthracite);
+    white-space: nowrap;
+}
+
+.res-chip--primary {
+    font-size: 0.85rem;
+    padding: 3px 10px 3px 8px;
+    border-width: 2px;
+    border-color: #aaa;
+}
+
+.res-abbr {
+    font-size: 0.65rem;
+    font-weight: 700;
+    opacity: 0.55;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.colony-main {
+    padding: 0;
+    max-width: none;
+}
+
+/* ── Hex page layout ─────────────────────────────────────────────────────── */
+
+.hex-page {
+    height: calc(100vh - 96px); /* subtract header height */
+    display: flex;
+    flex-direction: column;
+}
+
+.hex-layout {
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    gap: 0;
+    flex: 1;
+    overflow: hidden;
+}
+
+.hex-canvas-wrap {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    background: #fafafa;
+}
+
+.hex-canvas-header {
+    padding: 0.6rem 1rem 0.4rem;
+    border-bottom: 1px solid var(--color-border);
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+}
+
+.hex-canvas-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--color-anthracite);
+}
+
+.hex-canvas-header small {
+    font-size: 0.75rem;
+    color: #777;
+}
+
+.hex-canvas {
+    flex: 1;
+    overflow: auto;
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* ── Tile sidebar ─────────────────────────────────────────────────────────── */
+
+.tile-panel {
+    border-left: 1px solid var(--color-border);
+    background: #fff;
+    padding: 1.25rem;
+    overflow-y: auto;
+}
+
+.tile-panel h3 {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+    color: var(--color-anthracite);
+    border-bottom: 2px solid var(--color-accent);
+    padding-bottom: 0.4rem;
+}
+
+.tile-panel dl {
+    margin: 0;
+}
+
+.tile-panel dt {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #888;
+    margin-top: 0.75rem;
+}
+
+.tile-panel dd {
+    margin: 0.15rem 0 0;
+    font-size: 0.9rem;
+}
+
+.tile-panel-empty {
+    color: #aaa;
+    font-size: 0.85rem;
+    text-align: center;
+    margin-top: 2rem;
+}
+
+/* Status chips */
+.tile-status-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 1rem;
+}
+
+.chip {
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.chip--locked   { background: #eee;    color: #999; }
+.chip--fog      { background: #f0f0f0; color: #888; }
+.chip--explored { background: #e8f4e8; color: #2e7d32; border: 1px solid #a5d6a7; }
+.chip--scanned  { background: #e3f2fd; color: #1565c0; border: 1px solid #90caf9; }
+
+/* ── Responsive ──────────────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+    .hex-layout {
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr auto;
+    }
+
+    .tile-panel {
+        border-left: none;
+        border-top: 1px solid var(--color-border);
+        max-height: 200px;
+    }
+}

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -1,0 +1,230 @@
+/**
+ * Colony Hex-Grid: Alpine.js component + plain-JS SVG renderer.
+ *
+ * Coordinate system: Axial (q, r), Pointy-top hexagons.
+ * Pixel conversion:
+ *   px = cx + SIZE * sqrt(3) * (q + r/2)
+ *   py = cy + SIZE * 1.5 * r
+ */
+
+// ── Tile metadata ─────────────────────────────────────────────────────────────
+
+const TILE_LABELS = {
+    terrain_empty:      'Leeres Terrain',
+    terrain_hazard:     'Gefahrenzone',
+    terrain_impassable: 'Unpassierbar',
+    regolith_rich:      'Regolith (reich)',
+    regolith_normal:    'Regolith (normal)',
+    regolith_poor:      'Regolith (karg)',
+    event_wreck:        'Wrack',
+    event_ruin:         'Ruine',
+    event_bunker:       'Bunker',
+    event_probe:        'Sonde',
+    event_crystal:      'Kristallfeld',
+    event_vent:         'Thermalspalte',
+    event_cave:         'Höhle',
+    event_cache:        'Cache',
+    event_signal:       'Signal',
+    event_anomaly:      'Anomalie',
+};
+
+const TILE_COLORS = {
+    terrain_empty:      '#c8cdd6',
+    terrain_hazard:     '#e8b87a',
+    terrain_impassable: '#8a8f9a',
+    regolith_rich:      '#6fa3d4',
+    regolith_normal:    '#90b8dc',
+    regolith_poor:      '#b5cfe6',
+};
+
+const CC_COLOR      = '#a8d5a8';
+const FOG_COLOR     = '#e8eaed';
+const LOCKED_COLOR  = '#d0d4db';
+const EVENT_COLOR   = '#e8d89a';
+
+// ── Alpine component ──────────────────────────────────────────────────────────
+
+function colonyHexView(config) {
+    return {
+        tiles:        config.tiles,
+        colony:       config.colony,
+        ccLevel:      config.ccLevel,
+        selectedTile: null,
+        _svgPolygons: new Map(),
+
+        init() {
+            this.$nextTick(() => {
+                initHexGrid(this.$refs.hexgrid, this.tiles, {
+                    onSelect:    (tile) => this.selectTile(tile),
+                    polygonMap:  this._svgPolygons,
+                });
+            });
+        },
+
+        selectTile(tile) {
+            // Remove highlight from previously selected tile
+            if (this.selectedTile) {
+                const prev = this._svgPolygons.get(`${this.selectedTile.q},${this.selectedTile.r}`);
+                if (prev) {
+                    prev.setAttribute('stroke', '#555');
+                    prev.setAttribute('stroke-width', '1.5');
+                }
+            }
+            this.selectedTile = tile;
+            // Highlight newly selected tile
+            const cur = this._svgPolygons.get(`${tile.q},${tile.r}`);
+            if (cur) {
+                cur.setAttribute('stroke', '#c0392b');
+                cur.setAttribute('stroke-width', '3');
+            }
+        },
+
+        tileHeading(tile) {
+            if (tile.q === 0 && tile.r === 0) return 'Kommandozentrale';
+            if (!tile.is_explored)             return 'Unbekanntes Terrain';
+            return TILE_LABELS[tile.tile_type] ?? tile.tile_type;
+        },
+
+        tileTypeName(type) {
+            return TILE_LABELS[type] ?? type;
+        },
+
+        eventTypeName(type) {
+            return TILE_LABELS[type] ?? type;
+        },
+
+        statusLine() {
+            const total    = this.tiles.length;
+            const explored = this.tiles.filter(t => t.is_explored).length;
+            return `${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
+        },
+    };
+}
+
+// ── SVG hex grid renderer ─────────────────────────────────────────────────────
+
+function initHexGrid(container, tiles, opts = {}) {
+    if (!container || tiles.length === 0) return;
+
+    const SIZE    = 36;
+    const PADDING = SIZE * 2;
+
+    const maxRing = Math.max(...tiles.map(t => t.ring));
+
+    // Compute bounding box from actual tile positions
+    let minPx = Infinity, maxPx = -Infinity;
+    let minPy = Infinity, maxPy = -Infinity;
+
+    const positions = tiles.map(t => {
+        const px = SIZE * Math.sqrt(3) * (t.q + t.r / 2);
+        const py = SIZE * 1.5 * t.r;
+        minPx = Math.min(minPx, px);
+        maxPx = Math.max(maxPx, px);
+        minPy = Math.min(minPy, py);
+        maxPy = Math.max(maxPy, py);
+        return { tile: t, px, py };
+    });
+
+    const svgW = maxPx - minPx + SIZE * Math.sqrt(3) + PADDING * 2;
+    const svgH = maxPy - minPy + SIZE * 2 + PADDING * 2;
+    const offX = -minPx + PADDING + SIZE * Math.sqrt(3) / 2;
+    const offY = -minPy + PADDING + SIZE;
+
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', `0 0 ${svgW} ${svgH}`);
+    svg.setAttribute('width', '100%');
+    svg.setAttribute('height', '100%');
+    svg.style.display = 'block';
+
+    for (const { tile, px, py } of positions) {
+        const cx = px + offX;
+        const cy = py + offY;
+        const g = createHexTile(cx, cy, SIZE - 2, tile, opts);
+        svg.appendChild(g);
+    }
+
+    container.innerHTML = '';
+    container.appendChild(svg);
+}
+
+function createHexTile(cx, cy, size, tile, opts) {
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+
+    const points = hexCorners(cx, cy, size);
+    const polygon = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
+    polygon.setAttribute('points', points.join(' '));
+    polygon.setAttribute('fill',         getTileColor(tile));
+    polygon.setAttribute('stroke',       '#555');
+    polygon.setAttribute('stroke-width', '1.5');
+
+    const isCC = tile.q === 0 && tile.r === 0;
+    if (isCC) {
+        polygon.setAttribute('stroke', '#2e7d32');
+        polygon.setAttribute('stroke-width', '2.5');
+    }
+
+    if (tile.is_ring_unlocked) {
+        g.style.cursor = 'pointer';
+        g.addEventListener('click', () => opts.onSelect && opts.onSelect(tile));
+    }
+
+    g.appendChild(polygon);
+
+    if (opts.polygonMap) {
+        opts.polygonMap.set(`${tile.q},${tile.r}`, polygon);
+    }
+
+    // Label for CC tile
+    if (isCC) {
+        g.appendChild(svgText(cx, cy, 'CC', 10, '#2e7d32', 700));
+    }
+
+    // Ring indicator for locked outer tiles
+    if (!tile.is_ring_unlocked && tile.ring === Math.max(...(opts._maxRing ?? [tile.ring]))) {
+        // outer boundary — no extra label needed
+    }
+
+    // Small resource indicator dot
+    if (tile.is_explored && tile.resource_max > 0) {
+        const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        dot.setAttribute('cx', cx + size * 0.35);
+        dot.setAttribute('cy', cy - size * 0.35);
+        dot.setAttribute('r', '4');
+        dot.setAttribute('fill', '#2196f3');
+        dot.setAttribute('stroke', '#fff');
+        dot.setAttribute('stroke-width', '1');
+        g.appendChild(dot);
+    }
+
+    return g;
+}
+
+function hexCorners(cx, cy, size) {
+    const pts = [];
+    for (let i = 0; i < 6; i++) {
+        const angle = (Math.PI / 180) * (60 * i - 30); // pointy-top
+        pts.push(`${(cx + size * Math.cos(angle)).toFixed(2)},${(cy + size * Math.sin(angle)).toFixed(2)}`);
+    }
+    return pts;
+}
+
+function getTileColor(tile) {
+    if (!tile.is_ring_unlocked) return LOCKED_COLOR;
+    if (!tile.is_explored)      return FOG_COLOR;
+    if (tile.q === 0 && tile.r === 0) return CC_COLOR;
+    if (tile.is_deep_scanned && tile.event_type) return EVENT_COLOR;
+    return TILE_COLORS[tile.tile_type] ?? '#c8cdd6';
+}
+
+function svgText(x, y, text, size, fill, weight) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+    el.setAttribute('x', x);
+    el.setAttribute('y', y + size / 3);
+    el.setAttribute('text-anchor', 'middle');
+    el.setAttribute('font-size', size);
+    el.setAttribute('font-weight', weight ?? 'normal');
+    el.setAttribute('fill', fill ?? '#333');
+    el.setAttribute('pointer-events', 'none');
+    el.textContent = text;
+    return el;
+}

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -1,0 +1,74 @@
+@extends('layouts.colony')
+@section('title', $colony->name . ' — Kolonie')
+
+@section('content')
+<div
+    class="hex-page"
+    x-data="colonyHexView({
+        tiles: @json($tiles),
+        colony: @json(['id' => $colony->id, 'name' => $colony->name]),
+        ccLevel: {{ (int)$ccLevel }}
+    })"
+    x-init="init()"
+>
+    <div class="hex-layout">
+
+        {{-- Hex grid canvas --}}
+        <div class="hex-canvas-wrap">
+            <div class="hex-canvas-header">
+                <h2>{{ $colony->name }}</h2>
+                <small x-text="statusLine()"></small>
+            </div>
+            <div x-ref="hexgrid" class="hex-canvas"></div>
+        </div>
+
+        {{-- Tile info sidebar --}}
+        <aside class="tile-panel">
+            <template x-if="selectedTile">
+                <div>
+                    <h3 x-text="tileHeading(selectedTile)"></h3>
+                    <dl>
+                        <dt>Koordinaten</dt>
+                        <dd x-text="`q=${selectedTile.q}, r=${selectedTile.r} (Ring ${selectedTile.ring})`"></dd>
+
+                        <template x-if="selectedTile.is_explored">
+                            <div>
+                                <dt>Typ</dt>
+                                <dd x-text="tileTypeName(selectedTile.tile_type)"></dd>
+                            </div>
+                        </template>
+
+                        <template x-if="selectedTile.is_deep_scanned && selectedTile.event_type">
+                            <div>
+                                <dt>Event</dt>
+                                <dd x-text="eventTypeName(selectedTile.event_type)"></dd>
+                            </div>
+                        </template>
+
+                        <template x-if="selectedTile.resource_max > 0 && selectedTile.is_explored">
+                            <div>
+                                <dt>Regolith</dt>
+                                <dd x-text="`${selectedTile.resource_amount} / ${selectedTile.resource_max}`"></dd>
+                            </div>
+                        </template>
+                    </dl>
+
+                    <div class="tile-status-chips">
+                        <span x-show="!selectedTile.is_ring_unlocked" class="chip chip--locked">Gesperrt</span>
+                        <span x-show="selectedTile.is_ring_unlocked && !selectedTile.is_explored" class="chip chip--fog">Unerforscht</span>
+                        <span x-show="selectedTile.is_explored && !selectedTile.is_deep_scanned" class="chip chip--explored">Erkundet</span>
+                        <span x-show="selectedTile.is_deep_scanned" class="chip chip--scanned">Tiefgescannt</span>
+                    </div>
+                </div>
+            </template>
+
+            <template x-if="!selectedTile">
+                <div class="tile-panel-empty">
+                    <p>Tile auswählen für Details.</p>
+                </div>
+            </template>
+        </aside>
+
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>@yield('title', 'Nouron')</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    <link rel="stylesheet" href="{{ asset('css/colony.css') }}">
+    @stack('styles')
+</head>
+<body>
+
+<header class="colony-header">
+    <nav>
+        <ul>
+            <li><strong><a href="{{ route('galaxy.index') }}">Nouron</a></strong></li>
+        </ul>
+        <ul>
+            <li><a href="{{ route('galaxy.index') }}" @class(['active' => request()->routeIs('galaxy.*')])>Galaxis</a></li>
+            <li><a href="{{ route('fleet.index') }}" @class(['active' => request()->routeIs('fleet.*')])>Flotte</a></li>
+            <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*')])>Kolonie</a></li>
+            <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])>Techtree</a></li>
+            <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])>Berater</a></li>
+            <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])>Nachrichten</a></li>
+        </ul>
+        <ul>
+            <li>
+                <details class="dropdown">
+                    <summary>{{ Auth::user()->username }}</summary>
+                    <ul dir="rtl">
+                        <li><a href="{{ route('user.show') }}">Profil</a></li>
+                        <li><a href="{{ route('user.settings') }}">Einstellungen</a></li>
+                        <li>
+                            <form method="POST" action="{{ route('logout') }}" style="margin:0">
+                                @csrf
+                                <button type="submit" class="secondary outline">Abmelden</button>
+                            </form>
+                        </li>
+                    </ul>
+                </details>
+            </li>
+        </ul>
+    </nav>
+
+    {{-- Resource bar --}}
+    @if(!empty($resourceBarPossessions))
+    <div class="colony-resbar">
+        @foreach($resourceBarPossessions as $resId => $res)
+            @if(in_array((int)$resId, [1, 2]) || ($res['amount'] ?? 0) > 0)
+            <span class="res-chip {{ in_array((int)$resId, [1,2]) ? 'res-chip--primary' : '' }}">
+                <span class="res-abbr">{{ $res['abbreviation'] ?? '' }}</span>
+                <span class="res-amount">{{ number_format($res['amount'] ?? 0, 0, ',', '.') }}</span>
+            </span>
+            @endif
+        @endforeach
+    </div>
+    @endif
+</header>
+
+<main class="colony-main">
+    @yield('content')
+</main>
+
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+<script src="{{ asset('js/colony-hexgrid.js') }}"></script>
+@stack('scripts')
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ Route::middleware('auth')->prefix('user')->name('user.')->group(function () {
 
 Route::middleware('auth')->prefix('colony')->name('colony.')->group(function () {
     Route::get('/',       [ColonyController::class, 'index'])->name('index');
+    Route::get('/view',   [ColonyController::class, 'hexview'])->name('view');
     Route::patch('/name', [ColonyController::class, 'rename'])->name('rename');
 });
 


### PR DESCRIPTION
## Summary

- Neues `layouts/colony.blade.php` — Alpine.js 3 + PicoCSS 2 via CDN, kein jQuery/Bootstrap, helles UI (Weiß/Anthrazit/Rot)
- `GET /colony/view` — interaktive Kolonieansicht als Hex-Grid (SVG, Axial-Koordinaten, Pointy-top)
- `ColonyTile` Eloquent-Model + `ColonyTileService` (Tiles laden, Demo-Generierung beim ersten Aufruf falls keine Tiles vorhanden)
- Tile-Sidebar (Alpine-State): Koordinaten, Typ, Ressourcen, Erkundungs-Status bei Klick
- `colony-hexgrid.js`: SVG-Renderer + Alpine-Komponente, vollständig entkoppelt
- 391 Tests grün, kein Einfluss auf bestehende Screens

## Test plan

- [ ] `php artisan db:reset` → `GET /colony/view` aufrufen
- [ ] Hex-Grid erscheint: Ring 0 (CC grün), Ring 1 (Farben nach Tile-Typ), Ring 2–3 (Fog/hell)
- [ ] Tile anklicken → roter Outline + Sidebar zeigt q/r/Ring/Typ
- [ ] DevTools: kein `$()` oder Bootstrap-Klassen im neuen Layout
- [ ] Mobile (≤768px): Layout stapelt Grid und Sidebar untereinander