### PR TITLE
feat: Colony-View UI-Polish + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-04-25 (Phase 3b: Colony Hex-Grid View + UI-Polish)
+
+- **Colony Hex-Grid View** (`GET /colony/view`): neuer Game-Screen mit interaktivem SVG-Hex-Grid (Axial-Koordinaten, Pointy-top), Alpine.js State-Management, Tile-Sidebar mit Koordinaten/Typ/Ressourcen-Info. Auto-Generierung von Demo-Tiles (Ring 0–3) beim ersten Aufruf. `ColonyTile`-Model + `ColonyTileService` eingeführt.
+- **Neues Layout `layouts/colony.blade.php`**: Alpine.js 3 + PicoCSS 2 via CDN, kein Bootstrap/jQuery. Helles UI (Weiß/Anthrazit/Rot), kompakte Navbar (44px), zentrierte Ressourcenleiste. Veraltete Ressourcentypen (ENRG/LNRG/ANRG) aus der Anzeige gefiltert; alle 6 neuen Ressourcen immer sichtbar, ausgegraut wenn Menge = 0.
+- **Navigation** (`app.blade.php`): "Kolonie"-Link zeigt jetzt auf `colony.view`, "Techtree" als eigenständiger Nav-Eintrag ergänzt.
+- **Frontend-Stack final**: Alpine.js + PicoCSS + SVG. Kein Mix mit jQuery/Bootstrap in neuen Screens. Bekanntes Problem beim Einbetten von `@json()` in HTML-Attributen gelöst (via `<script>`-Tag).
+- **Fix**: `remember_token`-Spalte zur `user`-Tabelle hinzugefügt (Laravel Auth-Anforderung, fehlte nach Schema-Import). Migration + schema.sqlite.sql + testdata.sqlite.sql angepasst.
+
 ## 2026-04-23 (Design-Sprint: DS-4 Pre-Phase-3b abgeschlossen)
 
 - **Tech-Stack entschieden:** SVG + plain JS für Spielfelder (Hex-Grid, System-Grid), Alpine.js via CDN für UI-Shell, jQuery AJAX für Server-Calls, Blade+AJAX Hybrid Backend mit 8 neuen JSON-Endpunkten.

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -236,11 +236,22 @@ body {
     min-height: 400px;
 }
 
-/* The JS sets width="100%" and maxWidth on the SVG element directly,
-   so we only need to make sure the flex child doesn't collapse. */
 .hex-canvas svg {
     width: 100%;
     height: auto;
+    max-width: 580px;
+}
+
+.hex-canvas svg polygon {
+    transition: filter 0.1s ease;
+}
+
+.hex-canvas svg g.tile--unlocked {
+    cursor: pointer;
+}
+
+.hex-canvas svg g.tile--unlocked:hover polygon {
+    filter: brightness(1.14);
 }
 
 /* ── Tile info sidebar (right column) ───────────────────────────────────── */

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -31,16 +31,29 @@ const TILE_LABELS = {
 const TILE_COLORS = {
     terrain_empty:      '#c8cdd6',
     terrain_hazard:     '#e8b87a',
-    terrain_impassable: '#8a8f9a',
-    regolith_rich:      '#6fa3d4',
-    regolith_normal:    '#90b8dc',
-    regolith_poor:      '#b5cfe6',
+    terrain_impassable: '#7a7f8a',
+    regolith_rich:      '#5a9fd4',
+    regolith_normal:    '#7fb5dc',
+    regolith_poor:      '#a8cfe6',
 };
 
-const CC_COLOR      = '#a8d5a8';
-const FOG_COLOR     = '#e8eaed';
-const LOCKED_COLOR  = '#d0d4db';
+const TILE_STROKES = {
+    terrain_empty:      '#a0a8b4',
+    terrain_hazard:     '#c08040',
+    terrain_impassable: '#555',
+    regolith_rich:      '#3a7ab0',
+    regolith_normal:    '#5090c0',
+    regolith_poor:      '#7aaace',
+};
+
+const CC_COLOR      = '#7ec87e';
+const CC_STROKE     = '#2e7d32';
+const FOG_COLOR     = '#dde0e5';
+const FOG_STROKE    = '#b8bec6';
+const LOCKED_COLOR  = '#c8ccd4';
+const LOCKED_STROKE = '#a8adb8';
 const EVENT_COLOR   = '#e8d89a';
+const EVENT_STROKE  = '#b09a40';
 
 // ── Alpine component ──────────────────────────────────────────────────────────
 
@@ -106,8 +119,8 @@ function colonyHexView(config) {
 function initHexGrid(container, tiles, opts = {}) {
     if (!container || tiles.length === 0) return;
 
-    const SIZE    = 36;
-    const PADDING = SIZE * 2;
+    const SIZE    = 40;
+    const PADDING = SIZE * 1.5;
 
     const maxRing = Math.max(...tiles.map(t => t.ring));
 
@@ -134,7 +147,6 @@ function initHexGrid(container, tiles, opts = {}) {
     svg.setAttribute('viewBox', `0 0 ${svgW} ${svgH}`);
     svg.setAttribute('width', '100%');
     svg.style.display = 'block';
-    svg.style.maxWidth = `${svgW}px`;
 
     for (const { tile, px, py } of positions) {
         const cx = px + offX;
@@ -158,13 +170,12 @@ function createHexTile(cx, cy, size, tile, opts) {
     polygon.setAttribute('stroke-width', '1.5');
 
     const isCC = tile.q === 0 && tile.r === 0;
-    if (isCC) {
-        polygon.setAttribute('stroke', '#2e7d32');
-        polygon.setAttribute('stroke-width', '2.5');
-    }
+    const [stroke, strokeW] = getTileStroke(tile, isCC);
+    polygon.setAttribute('stroke',       stroke);
+    polygon.setAttribute('stroke-width', strokeW);
 
     if (tile.is_ring_unlocked) {
-        g.style.cursor = 'pointer';
+        g.classList.add('tile--unlocked');
         g.addEventListener('click', () => opts.onSelect && opts.onSelect(tile));
     }
 
@@ -209,11 +220,19 @@ function hexCorners(cx, cy, size) {
 }
 
 function getTileColor(tile) {
-    if (!tile.is_ring_unlocked) return LOCKED_COLOR;
-    if (!tile.is_explored)      return FOG_COLOR;
-    if (tile.q === 0 && tile.r === 0) return CC_COLOR;
+    if (!tile.is_ring_unlocked)               return LOCKED_COLOR;
+    if (!tile.is_explored)                    return FOG_COLOR;
+    if (tile.q === 0 && tile.r === 0)         return CC_COLOR;
     if (tile.is_deep_scanned && tile.event_type) return EVENT_COLOR;
     return TILE_COLORS[tile.tile_type] ?? '#c8cdd6';
+}
+
+function getTileStroke(tile, isCC) {
+    if (isCC)                    return [CC_STROKE,     '2.5'];
+    if (!tile.is_ring_unlocked)  return [LOCKED_STROKE, '1'];
+    if (!tile.is_explored)       return [FOG_STROKE,    '1'];
+    if (tile.is_deep_scanned && tile.event_type) return [EVENT_STROKE, '1.5'];
+    return [TILE_STROKES[tile.tile_type] ?? '#8a9aaa', '1.5'];
 }
 
 function svgText(x, y, text, size, fill, weight) {


### PR DESCRIPTION
## Summary

- Hex-Tiles größer (SIZE 36→40), tile-spezifische Stroke-Farben statt einheitliches `#555`
- Hover-Effekt auf klickbaren Tiles via CSS `brightness(1.14)` + Transition
- Fog vs. Locked-Tiles visuell besser unterschieden
- SVG `max-width: 580px` per CSS (statt JS `maxWidth`)
- Ressourcenleiste: alle 6 Ressourcen immer sichtbar, ausgegraut (dashed border + opacity) bei Menge = 0
- CHANGELOG 2026-04-25 ergänzt

## Test plan

- [ ] `GET /colony/view` → Tiles größer, Hover-Effekt sichtbar
- [ ] Fog-Tiles (Ring 2–3) und Locked-Tiles optisch unterscheidbar
- [ ] Ressourcenleiste zeigt alle 6 Ressourcen (Co/Or ausgegraut wenn 0)
- [ ] 391 Tests grün