### PR TITLE
feat: Colony Tile Detail Modal

### DIFF
--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -44,7 +44,29 @@ class ColonyController extends BaseController
             ->where('building_id', 25)
             ->value('level') ?? 0;
 
-        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel'));
+        $buildings = DB::table('colony_buildings')
+            ->join('buildings', 'colony_buildings.building_id', '=', 'buildings.id')
+            ->where('colony_buildings.colony_id', $colony->id)
+            ->select(
+                'colony_buildings.building_id',
+                'colony_buildings.instance_id',
+                'colony_buildings.level',
+                'colony_buildings.status_points',
+                'colony_buildings.ap_spend',
+                'colony_buildings.tile_x',
+                'colony_buildings.tile_y',
+                'buildings.name as building_key',
+                'buildings.max_level',
+                'buildings.ap_for_levelup',
+                'buildings.max_status_points',
+            )
+            ->get()
+            ->map(function ($b) {
+                $b->label = __('techtree.' . $b->building_key);
+                return $b;
+            });
+
+        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings'));
     }
 
     public function rename(Request $request): RedirectResponse

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -360,6 +360,228 @@ body {
 .chip--explored { background: #e8f4e8; color: #2e7d32; border: 1px solid #a5d6a7; }
 .chip--scanned  { background: #e3f2fd; color: #1565c0; border: 1px solid #90caf9; }
 
+/* ── Sidebar action button ───────────────────────────────────────────────── */
+
+.tile-panel-actions {
+    margin-top: 1.25rem;
+}
+
+.tile-detail-btn {
+    width: 100%;
+    padding: 0.45rem 1rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #fff;
+    background: var(--color-accent);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    letter-spacing: 0.02em;
+    transition: background 0.15s ease;
+}
+
+.tile-detail-btn:hover {
+    background: #a93226;
+}
+
+/* ── Tile detail modal ───────────────────────────────────────────────────── */
+
+/* PicoCSS styles <dialog> — we override to get a clean, sized overlay */
+dialog.tile-modal {
+    padding: 0;
+    border: none;
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    max-width: 480px;
+    width: calc(100vw - 2rem);
+    background: #fff;
+}
+
+dialog.tile-modal::backdrop {
+    background: rgba(0,0,0,0.35);
+}
+
+dialog.tile-modal > article {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+}
+
+.tile-modal-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 1rem 1.25rem 0.85rem;
+    border-bottom: 2px solid var(--color-accent);
+    position: relative;
+}
+
+.tile-modal-header h3 {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--color-anthracite);
+    padding-right: 1.5rem;
+}
+
+.tile-modal-header small {
+    font-size: 0.75rem;
+    color: #888;
+}
+
+.tile-modal-close {
+    position: absolute;
+    top: 0.7rem;
+    right: 0.9rem;
+    background: none;
+    border: none;
+    font-size: 1.1rem;
+    color: #999;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    width: auto;
+}
+
+.tile-modal-close:hover {
+    color: var(--color-anthracite);
+}
+
+.tile-modal-body {
+    padding: 1rem 1.25rem 0.5rem;
+    max-height: 60vh;
+    overflow-y: auto;
+}
+
+.tile-modal-footer {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.75rem 1.25rem 1rem;
+    border-top: 1px solid var(--color-border);
+    justify-content: flex-end;
+}
+
+/* Modal action buttons */
+.tile-modal-action {
+    padding: 0.4rem 1rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    border-radius: 4px;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent);
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.tile-modal-action:hover:not(:disabled) {
+    background: #a93226;
+}
+
+.tile-modal-action:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.tile-modal-action--secondary {
+    background: #fff;
+    color: var(--color-anthracite);
+    border-color: var(--color-border);
+}
+
+.tile-modal-action--secondary:hover {
+    background: #f5f5f5;
+}
+
+/* ── Modal building section ──────────────────────────────────────────────── */
+
+.modal-building-section {
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.modal-section-title {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #888;
+    margin: 0 0 0.5rem;
+}
+
+.modal-building-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.modal-building-header strong {
+    font-size: 0.95rem;
+    color: var(--color-anthracite);
+}
+
+.modal-level-badge {
+    font-size: 0.7rem;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 10px;
+    background: #e8f4e8;
+    color: #2e7d32;
+    border: 1px solid #a5d6a7;
+}
+
+/* ── Modal dl + bars ─────────────────────────────────────────────────────── */
+
+.modal-dl {
+    margin: 0 0 0.5rem;
+}
+
+.modal-dl dt {
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #888;
+    margin-top: 0.6rem;
+}
+
+.modal-dl dd {
+    margin: 0.1rem 0 0;
+    font-size: 0.88rem;
+}
+
+.modal-bar-group {
+    margin-top: 0.75rem;
+}
+
+.modal-bar-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.72rem;
+    color: #666;
+    margin-bottom: 0.25rem;
+}
+
+.modal-bar-wrap {
+    height: 8px;
+    background: #eee;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.modal-bar {
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.modal-bar--status   { background: #e74c3c; }
+.modal-bar--ap       { background: #27ae60; }
+.modal-bar--resource { background: #2196f3; }
+
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 
 /* Stack grid + sidebar at 900px and below */

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -62,6 +62,7 @@ function colonyHexView(config) {
         tiles:        config.tiles,
         colony:       config.colony,
         ccLevel:      config.ccLevel,
+        buildings:    config.buildings ?? [],
         selectedTile: null,
         _svgPolygons: new Map(),
 
@@ -104,6 +105,16 @@ function colonyHexView(config) {
 
         eventTypeName(type) {
             return TILE_LABELS[type] ?? type;
+        },
+
+        buildingForTile(tile) {
+            if (!tile) return null;
+            // CC is always at (0,0), building_id 25
+            if (tile.q === 0 && tile.r === 0) {
+                return this.buildings.find(b => b.building_id === 25) ?? null;
+            }
+            // Other buildings matched by tile_x/tile_y (currently all NULL in DB)
+            return this.buildings.find(b => b.tile_x === tile.q && b.tile_y === tile.r) ?? null;
         },
 
         statusLine() {

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -4,9 +4,10 @@
 @section('content')
 <script>
 window.__colonyViewData = {
-    tiles:   @json($tiles),
-    colony:  @json(['id' => $colony->id, 'name' => $colony->name]),
-    ccLevel: {{ (int)$ccLevel }}
+    tiles:     @json($tiles),
+    colony:    @json(['id' => $colony->id, 'name' => $colony->name]),
+    ccLevel:   {{ (int)$ccLevel }},
+    buildings: @json($buildings),
 };
 </script>
 <div class="hex-page" x-data="colonyHexView(window.__colonyViewData)">
@@ -63,6 +64,12 @@ window.__colonyViewData = {
                             <span x-show="selectedTile.is_explored && !selectedTile.is_deep_scanned" class="chip chip--explored">Erkundet</span>
                             <span x-show="selectedTile.is_deep_scanned" class="chip chip--scanned">Tiefgescannt</span>
                         </div>
+
+                        <div class="tile-panel-actions">
+                            <button class="tile-detail-btn" @click="$refs.tileModal.showModal()">
+                                Details &amp; Aktionen
+                            </button>
+                        </div>
                     </div>
                 </template>
 
@@ -75,5 +82,107 @@ window.__colonyViewData = {
         </aside>
 
     </div>
+
+    {{-- Tile detail modal --}}
+    <dialog x-ref="tileModal" class="tile-modal" @click.self="$refs.tileModal.close()">
+        <article>
+            <header class="tile-modal-header">
+                <button class="tile-modal-close" @click="$refs.tileModal.close()" aria-label="Schließen">&#x2715;</button>
+                <h3 x-text="selectedTile ? tileHeading(selectedTile) : ''"></h3>
+                <small x-text="selectedTile ? `q=${selectedTile.q}, r=${selectedTile.r} · Ring ${selectedTile.ring}` : ''"></small>
+            </header>
+
+            <div class="tile-modal-body">
+
+                {{-- Status chips --}}
+                <div class="tile-status-chips" style="margin-bottom:1rem">
+                    <template x-if="selectedTile">
+                        <div style="display:flex;gap:.4rem;flex-wrap:wrap">
+                            <span x-show="selectedTile && !selectedTile.is_ring_unlocked" class="chip chip--locked">Gesperrt</span>
+                            <span x-show="selectedTile && selectedTile.is_ring_unlocked && !selectedTile.is_explored" class="chip chip--fog">Unerforscht</span>
+                            <span x-show="selectedTile && selectedTile.is_explored && !selectedTile.is_deep_scanned" class="chip chip--explored">Erkundet</span>
+                            <span x-show="selectedTile && selectedTile.is_deep_scanned" class="chip chip--scanned">Tiefgescannt</span>
+                        </div>
+                    </template>
+                </div>
+
+                {{-- Tile properties --}}
+                <template x-if="selectedTile && selectedTile.is_explored">
+                    <dl class="modal-dl">
+                        <dt>Typ</dt>
+                        <dd x-text="tileTypeName(selectedTile.tile_type)"></dd>
+
+                        <template x-if="selectedTile.is_deep_scanned && selectedTile.event_type">
+                            <div>
+                                <dt>Event</dt>
+                                <dd x-text="eventTypeName(selectedTile.event_type)"></dd>
+                            </div>
+                        </template>
+
+                        <template x-if="selectedTile.resource_max > 0">
+                            <div>
+                                <dt>Regolith-Vorkommen</dt>
+                                <dd>
+                                    <span x-text="`${selectedTile.resource_amount} / ${selectedTile.resource_max}`"></span>
+                                    <div class="modal-bar-wrap" style="margin-top:.3rem">
+                                        <div class="modal-bar modal-bar--resource"
+                                             :style="`width:${Math.round(selectedTile.resource_amount / selectedTile.resource_max * 100)}%`"></div>
+                                    </div>
+                                </dd>
+                            </div>
+                        </template>
+                    </dl>
+                </template>
+
+                {{-- Building on tile --}}
+                <template x-if="selectedTile && buildingForTile(selectedTile)">
+                    <div class="modal-building-section">
+                        <h4 class="modal-section-title">Gebäude</h4>
+                        <div class="modal-building-header">
+                            <strong x-text="buildingForTile(selectedTile).label"></strong>
+                            <span class="modal-level-badge" x-text="`Lv. ${buildingForTile(selectedTile).level}`"></span>
+                        </div>
+
+                        <dl class="modal-dl">
+                            <dt>Max. Stufe</dt>
+                            <dd x-text="buildingForTile(selectedTile).max_level ?? '∞'"></dd>
+                        </dl>
+
+                        {{-- Status bar --}}
+                        <div class="modal-bar-group">
+                            <div class="modal-bar-label">
+                                <span>Zustand</span>
+                                <span x-text="`${buildingForTile(selectedTile).status_points} / ${buildingForTile(selectedTile).max_status_points ?? 20}`"></span>
+                            </div>
+                            <div class="modal-bar-wrap">
+                                <div class="modal-bar modal-bar--status"
+                                     :style="`width:${Math.round(buildingForTile(selectedTile).status_points / (buildingForTile(selectedTile).max_status_points ?? 20) * 100)}%`"></div>
+                            </div>
+                        </div>
+
+                        {{-- AP progress bar --}}
+                        <div class="modal-bar-group">
+                            <div class="modal-bar-label">
+                                <span>AP investiert</span>
+                                <span x-text="`${buildingForTile(selectedTile).ap_spend} / ${buildingForTile(selectedTile).ap_for_levelup}`"></span>
+                            </div>
+                            <div class="modal-bar-wrap">
+                                <div class="modal-bar modal-bar--ap"
+                                     :style="`width:${Math.round(buildingForTile(selectedTile).ap_spend / buildingForTile(selectedTile).ap_for_levelup * 100)}%`"></div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+            </div>
+
+            <footer class="tile-modal-footer">
+                <button class="tile-modal-action" disabled title="Noch nicht implementiert">Ausbauen</button>
+                <button class="tile-modal-action" disabled title="Noch nicht implementiert">Erkunden</button>
+                <button class="tile-modal-action tile-modal-action--secondary" @click="$refs.tileModal.close()">Schließen</button>
+            </footer>
+        </article>
+    </dialog>
+
 </div>
 @endsection


### PR DESCRIPTION
## Summary

- Adds a native `<dialog>`-based tile detail modal to the colony hex-grid view (Alpine.js, no Bootstrap)
- Sidebar now has a **"Details & Aktionen"** button that opens the modal for the selected tile
- Modal shows: tile type, status chips, resource deposit bar, and — for tiles with a building — name, level badge, status bar (red), AP progress bar (green)
- `ColonyController::hexview()` loads `colony_buildings` joined with `buildings` master data; names translated via `lang/de/techtree.php`
- Action buttons (Ausbauen, Erkunden) present but disabled — Phase 3c

## Dependencies

Stacks on `feat/phase3b-colony-view-polish` (PR #88).

## Test plan

- [ ] Open `/colony/view`, click CC tile (center), confirm "Details & Aktionen" appears
- [ ] Click "Details & Aktionen" — modal shows "Kommandozentrale Lv. 10", status bar, AP bar
- [ ] Click an unexplored tile — modal shows chip "Unerforscht", no building section
- [ ] Click an explored regolith tile — modal shows resource deposit bar
- [ ] Close modal via ✕, Schließen button, and backdrop click
- [ ] 391 tests pass