### PR TITLE
feat: colony:seed-demo — Demo-Koloniezustand für UI-Tests

### DIFF
--- a/app/Console/Commands/ColonySeedDemo.php
+++ b/app/Console/Commands/ColonySeedDemo.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seeds a "~80% built out" demo colony state for development/UI testing.
+ *
+ * Deletes existing colony_tiles for the colony, regenerates all 37 tiles
+ * (rings 0-3) with realistic exploration/scan state, and assigns the
+ * colony's existing buildings to specific tile coordinates.
+ *
+ * Usage: php artisan colony:seed-demo [colony_id]   (default: 1)
+ */
+class ColonySeedDemo extends Command
+{
+    protected $signature = 'colony:seed-demo {colony_id=1}';
+    protected $description = 'Seed a demo built-out colony state for UI testing (dev only)';
+
+    public function handle(): int
+    {
+        $colonyId = (int) $this->argument('colony_id');
+
+        if (! DB::table('glx_colonies')->where('id', $colonyId)->exists()) {
+            $this->error("Colony {$colonyId} not found.");
+            return 1;
+        }
+
+        DB::table('colony_tiles')->where('colony_id', $colonyId)->delete();
+
+        $tiles = $this->buildTiles($colonyId);
+        DB::table('colony_tiles')->insert($tiles);
+        $this->info(count($tiles) . ' tiles inserted.');
+
+        $placed = $this->placeBuildingsOnTiles($colonyId);
+        $this->info("{$placed} buildings placed on tiles.");
+
+        return 0;
+    }
+
+    // ── Tile generation ───────────────────────────────────────────────────────
+
+    private function buildTiles(int $colonyId): array
+    {
+        $maxRing = 3;
+        $rows    = [];
+
+        // Tiles that get deep-scanned with events (ring 2 only)
+        $eventTiles = [
+            [ 0,  2, 'event_ruin'],
+            [-2,  1, 'event_crystal'],
+            [ 0, -2, 'event_cache'],
+            [ 2, -2, 'event_wreck'],
+        ];
+        $eventMap = [];
+        foreach ($eventTiles as [$eq, $er, $etype]) {
+            $eventMap["{$eq},{$er}"] = $etype;
+        }
+
+        // Ring 3 tiles that are NOT yet unlocked (8 of 18 stay locked)
+        $lockedRing3 = [
+            [ 3,  0], [ 3, -1], [ 3, -2], [ 3, -3],
+            [ 2,  1], [ 1,  2], [ 0,  3], [-1,  3],
+        ];
+        $lockedSet = [];
+        foreach ($lockedRing3 as [$lq, $lr]) {
+            $lockedSet["{$lq},{$lr}"] = true;
+        }
+
+        // Ring 3 tiles that are unlocked but not yet explored (4 of the 10 remaining)
+        $unexploredRing3 = [
+            [-2,  3], [-3,  3], [-3,  2],  [ 2, -3],
+        ];
+        $unexploredSet = [];
+        foreach ($unexploredRing3 as [$uq, $ur]) {
+            $unexploredSet["{$uq},{$ur}"] = true;
+        }
+
+        for ($q = -$maxRing; $q <= $maxRing; $q++) {
+            $rMin = max(-$maxRing, -$q - $maxRing);
+            $rMax = min($maxRing,  -$q + $maxRing);
+
+            for ($r = $rMin; $r <= $rMax; $r++) {
+                $ring = max(abs($q), abs($r), abs($q + $r));
+                $key  = "{$q},{$r}";
+                $isCC = ($q === 0 && $r === 0);
+
+                // Unlock state
+                $isRingUnlocked = match ($ring) {
+                    0, 1, 2 => true,
+                    default  => ! isset($lockedSet[$key]),
+                };
+
+                // Exploration state
+                $isExplored = match (true) {
+                    $ring <= 2                                  => true,
+                    $ring === 3 && ! isset($lockedSet[$key])
+                                && ! isset($unexploredSet[$key]) => true,
+                    default                                      => false,
+                };
+
+                // Deep scan: all ring 0+1, event tiles in ring 2, a few ring 3
+                $isDeepScanned = $isExplored && ($ring <= 1 || isset($eventMap[$key]));
+
+                $eventType = $isDeepScanned ? ($eventMap[$key] ?? null) : null;
+
+                // Tile type
+                $tileType = $isCC ? 'terrain_empty' : $this->pickTileType($q, $r, $colonyId);
+
+                // Resource deposit
+                $resourceMax = $resourceAmount = null;
+                if (str_starts_with($tileType, 'regolith_')) {
+                    $resourceMax = match ($tileType) {
+                        'regolith_rich'   => 800,
+                        'regolith_normal' => 500,
+                        default           => 250,
+                    };
+                    // ~80% depleted for "built out" feel
+                    $hash           = abs($q * 11 + $r * 17 + $colonyId * 5) % 100;
+                    $resourceAmount = (int) ($resourceMax * (0.15 + ($hash / 100) * 0.45));
+                }
+
+                $rows[] = [
+                    'colony_id'        => $colonyId,
+                    'q'                => $q,
+                    'r'                => $r,
+                    'ring'             => $ring,
+                    'tile_type'        => $tileType,
+                    'event_type'       => $eventType,
+                    'is_ring_unlocked' => $isRingUnlocked ? 1 : 0,
+                    'is_explored'      => $isExplored    ? 1 : 0,
+                    'is_deep_scanned'  => $isDeepScanned ? 1 : 0,
+                    'resource_amount'  => $resourceAmount,
+                    'resource_max'     => $resourceMax,
+                    'created_at'       => now(),
+                    'updated_at'       => now(),
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    private function pickTileType(int $q, int $r, int $colonyId): string
+    {
+        $hash = abs($q * 7 + $r * 13 + $colonyId * 3) % 100;
+
+        if ($hash < 5)  return 'terrain_impassable';
+        if ($hash < 15) return 'terrain_hazard';
+        if ($hash < 35) return 'regolith_poor';
+        if ($hash < 55) return 'regolith_normal';
+        if ($hash < 65) return 'regolith_rich';
+        return 'terrain_empty';
+    }
+
+    // ── Building placement ────────────────────────────────────────────────────
+
+    private function placeBuildingsOnTiles(int $colonyId): int
+    {
+        // Fixed placement map: building_id → [tile_x (q), tile_y (r)]
+        // Ring 1 = production/civil core; Ring 2 = expanded facilities
+        $placement = [
+            25 => null,          // CC always at (0,0), matched by code, no tile_x/tile_y needed
+            27 => [ 1,  0],      // Erzmine          — ring 1
+            28 => [ 0,  1],      // Wohnkomplex       — ring 1
+            30 => [-1,  1],      // Depot             — ring 1
+            31 => [-1,  0],      // Forschungslabor   — ring 1
+            41 => [ 0, -1],      // Silikatmine       — ring 1
+            42 => [ 1, -1],      // Wasserextraktor   — ring 1
+            44 => [ 2,  0],      // Ziviler Raumhafen — ring 2
+            46 => [ 1,  1],      // Krankenhaus       — ring 2
+            32 => [ 2, -1],      // Tempel            — ring 2
+            52 => [-2,  0],      // Bar               — ring 2
+            50 => [-1, -1],      // Denkmal           — ring 2
+            65 => [ 1, -2],      // Recyclingstation  — ring 2
+            68 => [-2,  1],      // Militär Raumhafen — ring 2
+        ];
+
+        $placed = 0;
+        foreach ($placement as $buildingId => $coords) {
+            if ($coords === null) continue;
+
+            [$tx, $ty] = $coords;
+            $updated = DB::table('colony_buildings')
+                ->where('colony_id', $colonyId)
+                ->where('building_id', $buildingId)
+                ->update(['tile_x' => $tx, 'tile_y' => $ty]);
+
+            if ($updated) $placed++;
+        }
+
+        return $placed;
+    }
+}

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -360,204 +360,43 @@ body {
 .chip--explored { background: #e8f4e8; color: #2e7d32; border: 1px solid #a5d6a7; }
 .chip--scanned  { background: #e3f2fd; color: #1565c0; border: 1px solid #90caf9; }
 
-/* ── Sidebar action button ───────────────────────────────────────────────── */
+/* ── Sidebar: tile dl ────────────────────────────────────────────────────── */
 
-.tile-panel-actions {
-    margin-top: 1.25rem;
-}
-
-.tile-detail-btn {
-    width: 100%;
-    padding: 0.45rem 1rem;
-    font-size: 0.82rem;
-    font-weight: 600;
-    color: #fff;
-    background: var(--color-accent);
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    letter-spacing: 0.02em;
-    transition: background 0.15s ease;
-}
-
-.tile-detail-btn:hover {
-    background: #a93226;
-}
-
-/* ── Tile detail modal ───────────────────────────────────────────────────── */
-
-/* PicoCSS styles <dialog> — we override to get a clean, sized overlay */
-dialog.tile-modal {
-    padding: 0;
-    border: none;
-    border-radius: 8px;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
-    max-width: 480px;
-    width: calc(100vw - 2rem);
-    background: #fff;
-}
-
-dialog.tile-modal::backdrop {
-    background: rgba(0,0,0,0.35);
-}
-
-dialog.tile-modal > article {
-    margin: 0;
-    padding: 0;
-    border: none;
-    background: transparent;
-}
-
-.tile-modal-header {
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-    padding: 1rem 1.25rem 0.85rem;
-    border-bottom: 2px solid var(--color-accent);
-    position: relative;
-}
-
-.tile-modal-header h3 {
-    margin: 0;
-    font-size: 1.05rem;
-    font-weight: 700;
-    color: var(--color-anthracite);
-    padding-right: 1.5rem;
-}
-
-.tile-modal-header small {
-    font-size: 0.75rem;
-    color: #888;
-}
-
-.tile-modal-close {
-    position: absolute;
-    top: 0.7rem;
-    right: 0.9rem;
-    background: none;
-    border: none;
-    font-size: 1.1rem;
-    color: #999;
-    cursor: pointer;
-    padding: 0;
-    line-height: 1;
-    width: auto;
-}
-
-.tile-modal-close:hover {
-    color: var(--color-anthracite);
-}
-
-.tile-modal-body {
-    padding: 1rem 1.25rem 0.5rem;
-    max-height: 60vh;
-    overflow-y: auto;
-}
-
-.tile-modal-footer {
-    display: flex;
-    gap: 0.5rem;
-    padding: 0.75rem 1.25rem 1rem;
-    border-top: 1px solid var(--color-border);
-    justify-content: flex-end;
-}
-
-/* Modal action buttons */
-.tile-modal-action {
-    padding: 0.4rem 1rem;
-    font-size: 0.82rem;
-    font-weight: 600;
-    border-radius: 4px;
-    border: 1px solid var(--color-accent);
-    background: var(--color-accent);
-    color: #fff;
-    cursor: pointer;
-    transition: background 0.15s ease;
-}
-
-.tile-modal-action:hover:not(:disabled) {
-    background: #a93226;
-}
-
-.tile-modal-action:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-}
-
-.tile-modal-action--secondary {
-    background: #fff;
-    color: var(--color-anthracite);
-    border-color: var(--color-border);
-}
-
-.tile-modal-action--secondary:hover {
-    background: #f5f5f5;
-}
-
-/* ── Modal building section ──────────────────────────────────────────────── */
-
-.modal-building-section {
-    margin-top: 1rem;
-    padding-top: 0.75rem;
-    border-top: 1px solid var(--color-border);
-}
-
-.modal-section-title {
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: #888;
+.tile-heading {
     margin: 0 0 0.5rem;
-}
-
-.modal-building-header {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
-}
-
-.modal-building-header strong {
-    font-size: 0.95rem;
+    font-size: 1rem;
     color: var(--color-anthracite);
 }
 
-.modal-level-badge {
-    font-size: 0.7rem;
-    font-weight: 700;
-    padding: 2px 7px;
-    border-radius: 10px;
-    background: #e8f4e8;
-    color: #2e7d32;
-    border: 1px solid #a5d6a7;
+.tile-dl {
+    margin: 0.75rem 0 0;
 }
 
-/* ── Modal dl + bars ─────────────────────────────────────────────────────── */
-
-.modal-dl {
-    margin: 0 0 0.5rem;
-}
-
-.modal-dl dt {
+.tile-dl dt {
     font-size: 0.72rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: #888;
-    margin-top: 0.6rem;
+    margin-top: 0.65rem;
 }
 
-.modal-dl dd {
+.tile-dl dd {
     margin: 0.1rem 0 0;
     font-size: 0.88rem;
 }
 
-.modal-bar-group {
-    margin-top: 0.75rem;
+/* ── Sidebar: bars (resource deposit, building status/AP) ────────────────── */
+
+.sidebar-resource {
+    margin-top: 0.9rem;
 }
 
-.modal-bar-label {
+.sidebar-bar-group {
+    margin-top: 0.65rem;
+}
+
+.sidebar-bar-label {
     display: flex;
     justify-content: space-between;
     font-size: 0.72rem;
@@ -565,22 +404,96 @@ dialog.tile-modal > article {
     margin-bottom: 0.25rem;
 }
 
-.modal-bar-wrap {
-    height: 8px;
-    background: #eee;
+.sidebar-bar-wrap {
+    height: 7px;
+    background: #e8e8e8;
     border-radius: 4px;
     overflow: hidden;
 }
 
-.modal-bar {
+.sidebar-bar {
     height: 100%;
     border-radius: 4px;
     transition: width 0.3s ease;
+    min-width: 2px;
 }
 
-.modal-bar--status   { background: #e74c3c; }
-.modal-bar--ap       { background: #27ae60; }
-.modal-bar--resource { background: #2196f3; }
+.sidebar-bar--status   { background: #e74c3c; }
+.sidebar-bar--ap       { background: #27ae60; }
+.sidebar-bar--resource { background: #2196f3; }
+
+/* ── Sidebar: building section ───────────────────────────────────────────── */
+
+.sidebar-building {
+    margin-top: 1rem;
+    padding-top: 0.85rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.sidebar-section-title {
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #999;
+    margin-bottom: 0.45rem;
+}
+
+.sidebar-building-name {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-bottom: 0.3rem;
+}
+
+.sidebar-building-name strong {
+    font-size: 0.92rem;
+    color: var(--color-anthracite);
+}
+
+.sidebar-level-badge {
+    font-size: 0.68rem;
+    font-weight: 700;
+    padding: 2px 6px;
+    border-radius: 10px;
+    background: #e8f4e8;
+    color: #2e7d32;
+    border: 1px solid #a5d6a7;
+    white-space: nowrap;
+}
+
+/* ── Sidebar: action buttons ─────────────────────────────────────────────── */
+
+.sidebar-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1.1rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.sidebar-action-btn {
+    flex: 1;
+    padding: 0.42rem 0.5rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    border-radius: 4px;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent);
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.15s ease;
+    white-space: nowrap;
+}
+
+.sidebar-action-btn:hover:not(:disabled) {
+    background: #a93226;
+}
+
+.sidebar-action-btn:disabled {
+    opacity: 0.38;
+    cursor: not-allowed;
+}
 
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 
@@ -603,8 +516,7 @@ dialog.tile-modal > article {
     .tile-panel {
         border-left: none;
         border-top: 1px solid var(--color-border);
-        /* Limit sidebar height on mobile so it doesn't push the grid far up */
-        max-height: 260px;
+        max-height: 380px;
     }
 
     .tile-panel-empty {

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -29,12 +29,33 @@ window.__colonyViewData = {
             </div>
 
             <div class="tile-panel-body">
+
+                {{-- Empty state --}}
+                <template x-if="!selectedTile">
+                    <div class="tile-panel-empty">
+                        <p>Hex-Tile anklicken<br>um Details anzuzeigen.</p>
+                    </div>
+                </template>
+
+                {{-- Selected tile details --}}
                 <template x-if="selectedTile">
                     <div>
-                        <h3 x-text="tileHeading(selectedTile)"></h3>
-                        <dl>
+
+                        {{-- Tile heading --}}
+                        <h3 class="tile-heading" x-text="tileHeading(selectedTile)"></h3>
+
+                        {{-- Status chips --}}
+                        <div class="tile-status-chips">
+                            <span x-show="!selectedTile.is_ring_unlocked" class="chip chip--locked">Gesperrt</span>
+                            <span x-show="selectedTile.is_ring_unlocked && !selectedTile.is_explored" class="chip chip--fog">Unerforscht</span>
+                            <span x-show="selectedTile.is_explored && !selectedTile.is_deep_scanned" class="chip chip--explored">Erkundet</span>
+                            <span x-show="selectedTile.is_deep_scanned" class="chip chip--scanned">Tiefgescannt</span>
+                        </div>
+
+                        {{-- Tile properties --}}
+                        <dl class="tile-dl">
                             <dt>Koordinaten</dt>
-                            <dd x-text="`q=${selectedTile.q}, r=${selectedTile.r} (Ring ${selectedTile.ring})`"></dd>
+                            <dd x-text="`q=${selectedTile.q}, r=${selectedTile.r} · Ring ${selectedTile.ring}`"></dd>
 
                             <template x-if="selectedTile.is_explored">
                                 <div>
@@ -49,140 +70,70 @@ window.__colonyViewData = {
                                     <dd x-text="eventTypeName(selectedTile.event_type)"></dd>
                                 </div>
                             </template>
-
-                            <template x-if="selectedTile.resource_max > 0 && selectedTile.is_explored">
-                                <div>
-                                    <dt>Regolith</dt>
-                                    <dd x-text="`${selectedTile.resource_amount} / ${selectedTile.resource_max}`"></dd>
-                                </div>
-                            </template>
                         </dl>
 
-                        <div class="tile-status-chips">
-                            <span x-show="!selectedTile.is_ring_unlocked" class="chip chip--locked">Gesperrt</span>
-                            <span x-show="selectedTile.is_ring_unlocked && !selectedTile.is_explored" class="chip chip--fog">Unerforscht</span>
-                            <span x-show="selectedTile.is_explored && !selectedTile.is_deep_scanned" class="chip chip--explored">Erkundet</span>
-                            <span x-show="selectedTile.is_deep_scanned" class="chip chip--scanned">Tiefgescannt</span>
-                        </div>
+                        {{-- Resource deposit --}}
+                        <template x-if="selectedTile.resource_max > 0 && selectedTile.is_explored">
+                            <div class="sidebar-resource">
+                                <div class="sidebar-bar-label">
+                                    <span>Regolith</span>
+                                    <span x-text="`${selectedTile.resource_amount} / ${selectedTile.resource_max}`"></span>
+                                </div>
+                                <div class="sidebar-bar-wrap">
+                                    <div class="sidebar-bar sidebar-bar--resource"
+                                         :style="`width:${Math.round(selectedTile.resource_amount / selectedTile.resource_max * 100)}%`"></div>
+                                </div>
+                            </div>
+                        </template>
 
-                        <div class="tile-panel-actions">
-                            <button class="tile-detail-btn" @click="$refs.tileModal.showModal()">
-                                Details &amp; Aktionen
-                            </button>
-                        </div>
+                        {{-- Building on tile --}}
+                        <template x-if="buildingForTile(selectedTile)">
+                            <div class="sidebar-building">
+                                <div class="sidebar-section-title">Gebäude</div>
+
+                                <div class="sidebar-building-name">
+                                    <strong x-text="buildingForTile(selectedTile).label"></strong>
+                                    <span class="sidebar-level-badge" x-text="`Lv. ${buildingForTile(selectedTile).level}`"></span>
+                                </div>
+
+                                <div class="sidebar-bar-group">
+                                    <div class="sidebar-bar-label">
+                                        <span>Zustand</span>
+                                        <span x-text="`${buildingForTile(selectedTile).status_points} / ${buildingForTile(selectedTile).max_status_points ?? 20}`"></span>
+                                    </div>
+                                    <div class="sidebar-bar-wrap">
+                                        <div class="sidebar-bar sidebar-bar--status"
+                                             :style="`width:${Math.round(buildingForTile(selectedTile).status_points / (buildingForTile(selectedTile).max_status_points ?? 20) * 100)}%`"></div>
+                                    </div>
+                                </div>
+
+                                <div class="sidebar-bar-group">
+                                    <div class="sidebar-bar-label">
+                                        <span>AP investiert</span>
+                                        <span x-text="`${buildingForTile(selectedTile).ap_spend} / ${buildingForTile(selectedTile).ap_for_levelup}`"></span>
+                                    </div>
+                                    <div class="sidebar-bar-wrap">
+                                        <div class="sidebar-bar sidebar-bar--ap"
+                                             :style="`width:${Math.round(buildingForTile(selectedTile).ap_spend / buildingForTile(selectedTile).ap_for_levelup * 100)}%`"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+
+                        {{-- Action buttons --}}
+                        <template x-if="selectedTile.is_ring_unlocked">
+                            <div class="sidebar-actions">
+                                <button class="sidebar-action-btn" disabled title="Noch nicht implementiert">Ausbauen</button>
+                                <button class="sidebar-action-btn" disabled title="Noch nicht implementiert">Erkunden</button>
+                            </div>
+                        </template>
+
                     </div>
                 </template>
 
-                <template x-if="!selectedTile">
-                    <div class="tile-panel-empty">
-                        <p>Hex-Tile anklicken<br>um Details anzuzeigen.</p>
-                    </div>
-                </template>
             </div>
         </aside>
 
     </div>
-
-    {{-- Tile detail modal --}}
-    <dialog x-ref="tileModal" class="tile-modal" @click.self="$refs.tileModal.close()">
-        <article>
-            <header class="tile-modal-header">
-                <button class="tile-modal-close" @click="$refs.tileModal.close()" aria-label="Schließen">&#x2715;</button>
-                <h3 x-text="selectedTile ? tileHeading(selectedTile) : ''"></h3>
-                <small x-text="selectedTile ? `q=${selectedTile.q}, r=${selectedTile.r} · Ring ${selectedTile.ring}` : ''"></small>
-            </header>
-
-            <div class="tile-modal-body">
-
-                {{-- Status chips --}}
-                <div class="tile-status-chips" style="margin-bottom:1rem">
-                    <template x-if="selectedTile">
-                        <div style="display:flex;gap:.4rem;flex-wrap:wrap">
-                            <span x-show="selectedTile && !selectedTile.is_ring_unlocked" class="chip chip--locked">Gesperrt</span>
-                            <span x-show="selectedTile && selectedTile.is_ring_unlocked && !selectedTile.is_explored" class="chip chip--fog">Unerforscht</span>
-                            <span x-show="selectedTile && selectedTile.is_explored && !selectedTile.is_deep_scanned" class="chip chip--explored">Erkundet</span>
-                            <span x-show="selectedTile && selectedTile.is_deep_scanned" class="chip chip--scanned">Tiefgescannt</span>
-                        </div>
-                    </template>
-                </div>
-
-                {{-- Tile properties --}}
-                <template x-if="selectedTile && selectedTile.is_explored">
-                    <dl class="modal-dl">
-                        <dt>Typ</dt>
-                        <dd x-text="tileTypeName(selectedTile.tile_type)"></dd>
-
-                        <template x-if="selectedTile.is_deep_scanned && selectedTile.event_type">
-                            <div>
-                                <dt>Event</dt>
-                                <dd x-text="eventTypeName(selectedTile.event_type)"></dd>
-                            </div>
-                        </template>
-
-                        <template x-if="selectedTile.resource_max > 0">
-                            <div>
-                                <dt>Regolith-Vorkommen</dt>
-                                <dd>
-                                    <span x-text="`${selectedTile.resource_amount} / ${selectedTile.resource_max}`"></span>
-                                    <div class="modal-bar-wrap" style="margin-top:.3rem">
-                                        <div class="modal-bar modal-bar--resource"
-                                             :style="`width:${Math.round(selectedTile.resource_amount / selectedTile.resource_max * 100)}%`"></div>
-                                    </div>
-                                </dd>
-                            </div>
-                        </template>
-                    </dl>
-                </template>
-
-                {{-- Building on tile --}}
-                <template x-if="selectedTile && buildingForTile(selectedTile)">
-                    <div class="modal-building-section">
-                        <h4 class="modal-section-title">Gebäude</h4>
-                        <div class="modal-building-header">
-                            <strong x-text="buildingForTile(selectedTile).label"></strong>
-                            <span class="modal-level-badge" x-text="`Lv. ${buildingForTile(selectedTile).level}`"></span>
-                        </div>
-
-                        <dl class="modal-dl">
-                            <dt>Max. Stufe</dt>
-                            <dd x-text="buildingForTile(selectedTile).max_level ?? '∞'"></dd>
-                        </dl>
-
-                        {{-- Status bar --}}
-                        <div class="modal-bar-group">
-                            <div class="modal-bar-label">
-                                <span>Zustand</span>
-                                <span x-text="`${buildingForTile(selectedTile).status_points} / ${buildingForTile(selectedTile).max_status_points ?? 20}`"></span>
-                            </div>
-                            <div class="modal-bar-wrap">
-                                <div class="modal-bar modal-bar--status"
-                                     :style="`width:${Math.round(buildingForTile(selectedTile).status_points / (buildingForTile(selectedTile).max_status_points ?? 20) * 100)}%`"></div>
-                            </div>
-                        </div>
-
-                        {{-- AP progress bar --}}
-                        <div class="modal-bar-group">
-                            <div class="modal-bar-label">
-                                <span>AP investiert</span>
-                                <span x-text="`${buildingForTile(selectedTile).ap_spend} / ${buildingForTile(selectedTile).ap_for_levelup}`"></span>
-                            </div>
-                            <div class="modal-bar-wrap">
-                                <div class="modal-bar modal-bar--ap"
-                                     :style="`width:${Math.round(buildingForTile(selectedTile).ap_spend / buildingForTile(selectedTile).ap_for_levelup * 100)}%`"></div>
-                            </div>
-                        </div>
-                    </div>
-                </template>
-
-            </div>
-
-            <footer class="tile-modal-footer">
-                <button class="tile-modal-action" disabled title="Noch nicht implementiert">Ausbauen</button>
-                <button class="tile-modal-action" disabled title="Noch nicht implementiert">Erkunden</button>
-                <button class="tile-modal-action tile-modal-action--secondary" @click="$refs.tileModal.close()">Schließen</button>
-            </footer>
-        </article>
-    </dialog>
-
 </div>
 @endsection


### PR DESCRIPTION
## Summary

Neuer Artisan-Command für Entwicklungs-/UI-Testzwecke:

```
php artisan colony:seed-demo [colony_id]   # Default: colony_id=1
```

**Was er macht:**
- Löscht vorhandene `colony_tiles` für die Kolonie
- Generiert 37 Tiles (Ring 0–3) mit realistischem Demo-Zustand:
  - Ring 0+1: alle erkundet, deep-scanned
  - Ring 2: alle erkundet, 4 deep-scanned mit Events (`event_ruin`, `event_crystal`, `event_cache`, `event_wreck`)
  - Ring 3: 10/18 freigeschaltet, 6/10 erkundet, Rest Nebel/gesperrt
  - Regolith-Vorkommen 15–60% depleted (realistischer "built out" Zustand)
- Weist vorhandenen `colony_buildings` feste Tile-Koordinaten zu:
  - Ring 1: Erzmine, Wohnkomplex, Depot, Forschungslabor, Silikatmine, Wasserextraktor
  - Ring 2: Ziviler Raumhafen, Krankenhaus, Tempel, Bar, Denkmal, Recyclingstation, Militär-Raumhafen

## Test plan

- [ ] `php artisan colony:seed-demo 1` ausführen → "37 tiles inserted. 13 buildings placed on tiles."
- [ ] `/colony/view` öffnen → Hex-Grid zeigt verschiedene Tile-Typen, Ring 2 fast vollständig erkundet, Ring 3 mit Nebel/gesperrten Tiles
- [ ] CC-Tile klicken → Sidebar zeigt Kommandozentrale mit Status-/AP-Bar
- [ ] Ring-1-Tile klicken (z.B. Erzmine bei q=1,r=0) → Sidebar zeigt "Erzmine Lv.5" mit Bars
- [ ] Ring-2-Tile mit Event klicken → Sidebar zeigt "Event: ..." (Tiefgescannt-Chip)
- [ ] 391 Tests grün