### PR TITLE
feat: Phase 3c — Colony Actions (Explore, Deep Scan, Build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-04-28
+
+- **GDD §4 Bauregeln** (`docs/GDD.md`): Harvester/Regolith-Trennungsregel formal dokumentiert. Neue Tabelle und Bullet-Regeln: Harvester darf ausschließlich auf `regolith_*`-Tiles stehen, reguläre Gebäude nur auf Terrain-Tiles. Querverweis in §4a (Kolonieoberfläche) ergänzt.
+- **Phase 3c — Kolonieaktionen** (PR #93): Drei Kernaktionen implementiert: (1) **Erkunden** — Tile-Typ aufdecken für 1 Nav-AP, kontextsensitiver Button in Sidebar; (2) **Sondieren (Deep Scan)** — Event auf Signal-Tiles aufdecken für 2 Nav-AP; nur ~15–20 % der Exploration-Zone-Tiles senden ein Signal (pulsierender SVG-Indikator, Chip `chip--signal`); (3) **Bauen** — globaler Button im Canvas-Header, Gebäude-Auswahlliste in Sidebar, Platzierung auf Terrain-Tile kostet 1 Construction-AP, danach AP investieren bis Level-Up. `has_signal`-Feld in Tile-Daten: `event_type` bleibt verborgen bis Sondieren. Lokalisierung: `lang/de/colony.php` + `lang/en/colony.php` für alle UI-Strings und Fehlermeldungen. 391 Tests grün.
+
 ## 2026-04-26 (Phase 3b: Buildings-Cleanup + Colony-Sidebar Redesign + Hex-Grid Visuals)
 
 - **Buildings-Cleanup-Migration**: 13 veraltete Gebäude (IDs 42, 45, 48, 51, 53, 54, 55, 56, 64, 65, 66, 68, 70) aus der DB entfernt. Verbleibende 11 Gebäude von `techs_*`-Keys auf `building_*`-Keys umbenannt (GDD §4). CC max_level 10→5 korrigiert. FK-Referenzen in `researches`, `ships`, `personell` bereinigt.

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers\Colony;
 use App\Http\Controllers\BaseController;
 use App\Services\ColonyService;
 use App\Services\ColonyTileService;
+use App\Services\Techtree\PersonellService;
 use App\Services\TickService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -18,6 +20,7 @@ class ColonyController extends BaseController
         TickService $tick,
         private readonly ColonyService $colonyService,
         private readonly ColonyTileService $tileService,
+        private readonly PersonellService $personellService,
     ) {
         parent::__construct($tick);
     }
@@ -69,6 +72,180 @@ class ColonyController extends BaseController
         return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings'));
     }
 
+    // ── Tile actions ──────────────────────────────────────────────────────────
+
+    public function exploreTile(Request $request): JsonResponse
+    {
+        $data   = $request->validate(['q' => 'required|integer', 'r' => 'required|integer']);
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+
+        return response()->json(
+            $this->tileService->exploreTile($colony->id, (int) $data['q'], (int) $data['r'])
+        );
+    }
+
+    public function deepScanTile(Request $request): JsonResponse
+    {
+        $data   = $request->validate(['q' => 'required|integer', 'r' => 'required|integer']);
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+
+        return response()->json(
+            $this->tileService->deepScanTile($colony->id, (int) $data['q'], (int) $data['r'])
+        );
+    }
+
+    // ── Building actions ──────────────────────────────────────────────────────
+
+    public function availableBuildings(): JsonResponse
+    {
+        $colony  = $this->colonyService->getPrimeColony(Auth::id());
+        $ccLevel = (int) DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)->where('building_id', 25)->value('level') ?? 0;
+
+        // Building IDs already placed on a tile
+        $placed = DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->whereNotNull('tile_x')
+            ->pluck('building_id')
+            ->toArray();
+
+        $buildings = DB::table('buildings')
+            ->select('id', 'name', 'ap_for_levelup', 'max_status_points', 'max_level',
+                     'required_building_id', 'required_building_level')
+            ->get()
+            ->filter(function ($b) use ($ccLevel, $placed) {
+                if ($b->id === 25) return false;  // CC — already exists
+                if ($b->id === 27) return false;  // Harvester — special regolith placement
+                if (in_array($b->id, $placed)) return false;
+                // Prerequisite: if requires CC, check CC level
+                if ($b->required_building_id === 25 && $ccLevel < (int) ($b->required_building_level ?? 1)) {
+                    return false;
+                }
+                return true;
+            })
+            ->map(fn($b) => [
+                'building_id'       => $b->id,
+                'key'               => $b->name,
+                'label'             => __('techtree.' . $b->name),
+                'ap_for_levelup'    => $b->ap_for_levelup,
+                'max_level'         => $b->max_level,
+                'max_status_points' => $b->max_status_points,
+            ])
+            ->values();
+
+        return response()->json(['buildings' => $buildings]);
+    }
+
+    public function placeBuilding(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'building_id' => 'required|integer',
+            'q'           => 'required|integer',
+            'r'           => 'required|integer',
+        ]);
+
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+
+        $tile = DB::table('colony_tiles')
+            ->where('colony_id', $colony->id)
+            ->where('q', $data['q'])
+            ->where('r', $data['r'])
+            ->first();
+
+        if (!$tile)
+            return response()->json(['ok' => false, 'error' => __('colony.error_tile_not_found')]);
+        if (!$tile->is_explored)
+            return response()->json(['ok' => false, 'error' => __('colony.error_not_explored')]);
+        if (!str_starts_with($tile->tile_type, 'terrain_') || $tile->tile_type === 'terrain_impassable')
+            return response()->json(['ok' => false, 'error' => __('colony.error_tile_not_buildable')]);
+
+        $occupied = DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('tile_x', $data['q'])
+            ->where('tile_y', $data['r'])
+            ->exists();
+        if ($occupied)
+            return response()->json(['ok' => false, 'error' => __('colony.error_tile_occupied')]);
+
+        if ($this->personellService->getConstructionPoints($colony->id) < 1)
+            return response()->json(['ok' => false, 'error' => __('colony.error_no_construction_ap')]);
+
+        $building = DB::table('buildings')->where('id', $data['building_id'])->first();
+        if (!$building)
+            return response()->json(['ok' => false, 'error' => __('colony.error_building_not_found')]);
+
+        $existing = DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', $data['building_id'])
+            ->first();
+
+        if ($existing) {
+            DB::table('colony_buildings')
+                ->where('colony_id', $colony->id)
+                ->where('building_id', $data['building_id'])
+                ->update(['tile_x' => $data['q'], 'tile_y' => $data['r'], 'ap_spend' => 1]);
+        } else {
+            DB::table('colony_buildings')->insert([
+                'colony_id'     => $colony->id,
+                'building_id'   => $data['building_id'],
+                'instance_id'   => 1,
+                'level'         => 0,
+                'status_points' => $building->max_status_points ?? 20,
+                'ap_spend'      => 1,
+                'tile_x'        => $data['q'],
+                'tile_y'        => $data['r'],
+            ]);
+        }
+
+        $this->personellService->lockActionPoints('construction', $colony->id, 1);
+
+        $row = $this->fetchBuildingRow($colony->id, $data['building_id']);
+
+        return response()->json(['ok' => true, 'building' => $row]);
+    }
+
+    public function investBuilding(Request $request): JsonResponse
+    {
+        $data   = $request->validate(['building_id' => 'required|integer']);
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+
+        if ($this->personellService->getConstructionPoints($colony->id) < 1)
+            return response()->json(['ok' => false, 'error' => __('colony.error_no_construction_ap')]);
+
+        $row = DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', $data['building_id'])
+            ->first();
+
+        if (!$row)
+            return response()->json(['ok' => false, 'error' => __('colony.error_building_not_found')]);
+
+        $building   = DB::table('buildings')->where('id', $data['building_id'])->first();
+        $newApSpend = min($row->ap_spend + 1, $building->ap_for_levelup);
+
+        DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', $data['building_id'])
+            ->update(['ap_spend' => $newApSpend]);
+
+        $this->personellService->lockActionPoints('construction', $colony->id, 1);
+
+        $leveledUp = false;
+        if ($newApSpend >= $building->ap_for_levelup) {
+            DB::table('colony_buildings')
+                ->where('colony_id', $colony->id)
+                ->where('building_id', $data['building_id'])
+                ->update(['level' => $row->level + 1, 'ap_spend' => 0]);
+            $leveledUp = true;
+        }
+
+        return response()->json([
+            'ok'        => true,
+            'building'  => $this->fetchBuildingRow($colony->id, $data['building_id']),
+            'leveled_up' => $leveledUp,
+        ]);
+    }
+
     public function rename(Request $request): RedirectResponse
     {
         $request->validate([
@@ -83,5 +260,33 @@ class ColonyController extends BaseController
 
         return redirect()->route('colony.index')
             ->with('success', 'Kolonienname wurde aktualisiert.');
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function fetchBuildingRow(int $colonyId, int $buildingId): object
+    {
+        $row = DB::table('colony_buildings')
+            ->join('buildings', 'colony_buildings.building_id', '=', 'buildings.id')
+            ->where('colony_buildings.colony_id', $colonyId)
+            ->where('colony_buildings.building_id', $buildingId)
+            ->select(
+                'colony_buildings.building_id',
+                'colony_buildings.instance_id',
+                'colony_buildings.level',
+                'colony_buildings.status_points',
+                'colony_buildings.ap_spend',
+                'colony_buildings.tile_x',
+                'colony_buildings.tile_y',
+                'buildings.name as building_key',
+                'buildings.max_level',
+                'buildings.ap_for_levelup',
+                'buildings.max_status_points',
+            )
+            ->first();
+
+        $row->label = __('techtree.' . $row->building_key);
+
+        return $row;
     }
 }

--- a/app/Services/ColonyTileService.php
+++ b/app/Services/ColonyTileService.php
@@ -4,18 +4,72 @@ namespace App\Services;
 
 use App\Models\Colony;
 use App\Models\ColonyTile;
+use App\Services\Techtree\PersonellService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class ColonyTileService
 {
+    public function __construct(
+        private readonly PersonellService $personellService,
+    ) {}
+
     public function getTilesForColony(int $colonyId): Collection
     {
         return ColonyTile::where('colony_id', $colonyId)
             ->orderBy('ring')
             ->orderBy('q')
             ->orderBy('r')
-            ->get();
+            ->get()
+            ->map(fn($t) => $this->transformTile($t));
+    }
+
+    public function exploreTile(int $colonyId, int $q, int $r): array
+    {
+        $tile = ColonyTile::where('colony_id', $colonyId)->where('q', $q)->where('r', $r)->first();
+
+        if (!$tile)                   return ['ok' => false, 'error' => __('colony.error_tile_not_found')];
+        if (!$tile->is_ring_unlocked) return ['ok' => false, 'error' => __('colony.error_ring_locked')];
+        if ($tile->is_explored)       return ['ok' => false, 'error' => __('colony.error_already_explored')];
+
+        if ($this->personellService->getAvailableActionPoints('navigation', $colonyId) < 1) {
+            return ['ok' => false, 'error' => __('colony.error_no_nav_ap')];
+        }
+
+        $tile->is_explored = true;
+        $tile->save();
+        $this->personellService->lockActionPoints('navigation', $colonyId, 1);
+
+        return ['ok' => true, 'tile' => $this->transformTile($tile)];
+    }
+
+    public function deepScanTile(int $colonyId, int $q, int $r): array
+    {
+        $tile = ColonyTile::where('colony_id', $colonyId)->where('q', $q)->where('r', $r)->first();
+
+        if (!$tile)                    return ['ok' => false, 'error' => __('colony.error_tile_not_found')];
+        if (!$tile->is_explored)       return ['ok' => false, 'error' => __('colony.error_not_explored')];
+        if ($tile->event_type === null) return ['ok' => false, 'error' => __('colony.error_no_signal')];
+        if ($tile->is_deep_scanned)    return ['ok' => false, 'error' => __('colony.error_already_scanned')];
+
+        if ($this->personellService->getAvailableActionPoints('navigation', $colonyId) < 2) {
+            return ['ok' => false, 'error' => __('colony.error_no_nav_ap_2')];
+        }
+
+        $tile->is_deep_scanned = true;
+        $tile->save();
+        $this->personellService->lockActionPoints('navigation', $colonyId, 2);
+
+        return ['ok' => true, 'tile' => $this->transformTile($tile)];
+    }
+
+    private function transformTile(ColonyTile $tile): array
+    {
+        $arr = $tile->toArray();
+        $arr['has_signal'] = $tile->event_type !== null && (bool) $tile->is_explored && !(bool) $tile->is_deep_scanned;
+        // Hide the actual event until the tile is deep-scanned (sondiert)
+        $arr['event_type'] = $tile->is_deep_scanned ? $tile->event_type : null;
+        return $arr;
     }
 
     /**

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+
+    // ── Tile actions ──────────────────────────────────────────────────────────
+
+    'explore'           => 'Erkunden',
+    'deep_scan'         => 'Sondieren',
+    'invest_ap'         => 'AP investieren',
+
+    // ── Building actions ──────────────────────────────────────────────────────
+
+    'build'             => 'Bauen',
+    'cancel'            => 'Abbrechen',
+    'select_tile_hint'  => 'Tile anklicken zum Platzieren',
+
+    // ── Sidebar labels ────────────────────────────────────────────────────────
+
+    'tile_info'         => 'Tile-Info',
+    'click_tile_hint'   => 'Hex-Tile anklicken um Details anzuzeigen.',
+    'building_section'  => 'Gebäude',
+    'construction_site' => 'Baustelle',
+    'max_level'         => 'Max. Stufe',
+    'condition'         => 'Zustand',
+    'ap_invested'       => 'AP investiert',
+    'resource_regolith' => 'Regolith',
+
+    // ── Status chips ──────────────────────────────────────────────────────────
+
+    'chip_locked'       => 'Gesperrt',
+    'chip_unexplored'   => 'Unerforscht',
+    'chip_explored'     => 'Erkundet',
+    'chip_scanned'      => 'Sondiert',
+    'chip_signal'       => 'Signal',
+
+    // ── Build mode ────────────────────────────────────────────────────────────
+
+    'build_mode_title'  => 'Gebäude bauen',
+    'build_mode_hint'   => 'Gebäude wählen, dann Terrain-Tile anklicken.',
+    'no_buildings'      => 'Keine Gebäude verfügbar.',
+
+    // ── Error messages ────────────────────────────────────────────────────────
+
+    'error_tile_not_found'      => 'Tile nicht gefunden.',
+    'error_ring_locked'         => 'Ring nicht freigeschaltet.',
+    'error_already_explored'    => 'Tile bereits erkundet.',
+    'error_not_explored'        => 'Tile muss zuerst erkundet werden.',
+    'error_no_signal'           => 'Kein Signal auf diesem Tile.',
+    'error_already_scanned'     => 'Tile bereits sondiert.',
+    'error_no_nav_ap'           => 'Nicht genug Navigations-AP.',
+    'error_no_nav_ap_2'         => 'Nicht genug Navigations-AP (2 benötigt).',
+    'error_tile_not_buildable'  => 'Nur bebaubare Terrain-Tiles erlaubt.',
+    'error_tile_occupied'       => 'Tile bereits belegt.',
+    'error_no_construction_ap'  => 'Nicht genug Bau-AP.',
+    'error_building_not_found'  => 'Gebäude nicht gefunden.',
+
+];

--- a/lang/en/colony.php
+++ b/lang/en/colony.php
@@ -1,0 +1,57 @@
+<?php
+
+return [
+
+    // ── Tile actions ──────────────────────────────────────────────────────────
+
+    'explore'           => 'Explore',
+    'deep_scan'         => 'Probe',
+    'invest_ap'         => 'Invest AP',
+
+    // ── Building actions ──────────────────────────────────────────────────────
+
+    'build'             => 'Build',
+    'cancel'            => 'Cancel',
+    'select_tile_hint'  => 'Click a tile to place',
+
+    // ── Sidebar labels ────────────────────────────────────────────────────────
+
+    'tile_info'         => 'Tile Info',
+    'click_tile_hint'   => 'Click a hex tile to view details.',
+    'building_section'  => 'Building',
+    'construction_site' => 'Construction Site',
+    'max_level'         => 'Max. Level',
+    'condition'         => 'Condition',
+    'ap_invested'       => 'AP invested',
+    'resource_regolith' => 'Regolith',
+
+    // ── Status chips ──────────────────────────────────────────────────────────
+
+    'chip_locked'       => 'Locked',
+    'chip_unexplored'   => 'Unexplored',
+    'chip_explored'     => 'Explored',
+    'chip_scanned'      => 'Probed',
+    'chip_signal'       => 'Signal',
+
+    // ── Build mode ────────────────────────────────────────────────────────────
+
+    'build_mode_title'  => 'Build Structure',
+    'build_mode_hint'   => 'Select a building, then click a terrain tile.',
+    'no_buildings'      => 'No buildings available.',
+
+    // ── Error messages ────────────────────────────────────────────────────────
+
+    'error_tile_not_found'      => 'Tile not found.',
+    'error_ring_locked'         => 'Ring not unlocked.',
+    'error_already_explored'    => 'Tile already explored.',
+    'error_not_explored'        => 'Tile must be explored first.',
+    'error_no_signal'           => 'No signal on this tile.',
+    'error_already_scanned'     => 'Tile already probed.',
+    'error_no_nav_ap'           => 'Not enough navigation AP.',
+    'error_no_nav_ap_2'         => 'Not enough navigation AP (2 required).',
+    'error_tile_not_buildable'  => 'Only buildable terrain tiles allowed.',
+    'error_tile_occupied'       => 'Tile already occupied.',
+    'error_no_construction_ap'  => 'Not enough construction AP.',
+    'error_building_not_found'  => 'Building not found.',
+
+];

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -490,6 +490,125 @@ body {
     cursor: not-allowed;
 }
 
+/* ── Canvas-header build button ─────────────────────────────────────────── */
+
+.build-btn {
+    margin-left: auto;
+    padding: 0.3rem 0.85rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    border-radius: 4px;
+    border: 1px solid var(--color-accent);
+    background: transparent;
+    color: var(--color-accent);
+    cursor: pointer;
+    letter-spacing: 0.03em;
+    transition: background 0.15s ease, color 0.15s ease;
+    flex-shrink: 0;
+}
+
+.build-btn:hover {
+    background: var(--color-accent);
+    color: #fff;
+}
+
+.build-btn--active {
+    background: var(--color-accent);
+    color: #fff;
+}
+
+/* ── Build mode sidebar ──────────────────────────────────────────────────── */
+
+.build-mode-hint {
+    font-size: 0.82rem;
+    color: #777;
+    margin: 0 0 0.75rem;
+}
+
+.build-mode-selected {
+    font-size: 0.82rem;
+    color: var(--color-accent);
+    margin: 0 0 0.75rem;
+    padding: 0.35rem 0.6rem;
+    background: #fff0ee;
+    border-left: 3px solid var(--color-accent);
+    border-radius: 2px;
+}
+
+.build-mode-empty {
+    font-size: 0.82rem;
+    color: #aaa;
+    margin: 0;
+}
+
+.building-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.building-list-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.45rem 0.7rem;
+    border-radius: 5px;
+    border: 1px solid var(--color-border);
+    background: #fafafa;
+    cursor: pointer;
+    transition: background 0.1s ease, border-color 0.1s ease;
+}
+
+.building-list-item:hover {
+    background: #f0f4ff;
+    border-color: #b0c0e8;
+}
+
+.building-list-item--selected {
+    background: #fff0ee;
+    border-color: var(--color-accent);
+}
+
+.building-list-name {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-anthracite);
+}
+
+.building-list-ap {
+    font-size: 0.72rem;
+    color: #888;
+    font-weight: 500;
+}
+
+/* ── Signal chip ─────────────────────────────────────────────────────────── */
+
+.chip--signal {
+    background: #fff8dc;
+    color: #8a6500;
+    border: 1px solid #e0c040;
+    animation: chip-signal-pulse 2s ease-in-out infinite;
+}
+
+@keyframes chip-signal-pulse {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0.5; }
+}
+
+/* ── SVG signal pulse (class applied to SVG circle element) ──────────────── */
+
+@keyframes signal-pulse {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0.25; }
+}
+
+.signal-pulse {
+    animation: signal-pulse 1.8s ease-in-out infinite;
+}
+
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 
 /* Stack grid + sidebar at 900px and below */

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -74,37 +74,154 @@ const BUILDING_ABBR = {
 
 function colonyHexView(config) {
     return {
-        tiles:        config.tiles,
-        colony:       config.colony,
-        ccLevel:      config.ccLevel,
-        buildings:    config.buildings ?? [],
-        selectedTile: null,
-        _svgPolygons: new Map(),
+        tiles:             config.tiles,
+        colony:            config.colony,
+        ccLevel:           config.ccLevel,
+        buildings:         config.buildings ?? [],
+        routes:            config.routes ?? {},
+        i18n:              config.i18n ?? {},
+        selectedTile:      null,
+        buildMode:         false,
+        pendingBuilding:   null,
+        availableBuildings: [],
+        _svgPolygons:      new Map(),
 
         init() {
-            this.$nextTick(() => {
-                initHexGrid(this.$refs.hexgrid, this.tiles, {
-                    onSelect:   (tile) => this.selectTile(tile),
-                    polygonMap: this._svgPolygons,
-                    buildings:  this.buildings,
-                });
+            this.$nextTick(() => this.redrawGrid());
+        },
+
+        // ── Grid rendering ────────────────────────────────────────────────────
+
+        redrawGrid() {
+            initHexGrid(this.$refs.hexgrid, this.tiles, {
+                onSelect:        (tile) => this.onTileClick(tile),
+                polygonMap:      this._svgPolygons,
+                buildings:       this.buildings,
+                buildMode:       this.buildMode,
+                pendingBuilding: this.pendingBuilding,
             });
+        },
+
+        // ── Tile selection ────────────────────────────────────────────────────
+
+        onTileClick(tile) {
+            if (this.buildMode && this.pendingBuilding) {
+                const isValid = tile.is_explored
+                    && tile.tile_type.startsWith('terrain_')
+                    && tile.tile_type !== 'terrain_impassable'
+                    && !this.buildingForTile(tile);
+                if (isValid) this.doPlaceBuilding(tile);
+                return;
+            }
+            this.selectTile(tile);
         },
 
         selectTile(tile) {
             if (this.selectedTile) {
                 const prev = this._svgPolygons.get(`${this.selectedTile.q},${this.selectedTile.r}`);
                 if (prev) {
-                    prev.setAttribute('stroke', prev._defaultStroke ?? '#555');
+                    prev.setAttribute('stroke',       prev._defaultStroke  ?? '#555');
                     prev.setAttribute('stroke-width', prev._defaultStrokeW ?? '1.5');
                 }
             }
             this.selectedTile = tile;
             const cur = this._svgPolygons.get(`${tile.q},${tile.r}`);
             if (cur) {
-                cur.setAttribute('stroke', '#c0392b');
+                cur.setAttribute('stroke',       '#c0392b');
                 cur.setAttribute('stroke-width', '3');
             }
+        },
+
+        // ── Build mode ────────────────────────────────────────────────────────
+
+        async toggleBuildMode() {
+            if (this.buildMode) {
+                this.buildMode       = false;
+                this.pendingBuilding = null;
+                this.$nextTick(() => this.redrawGrid());
+                return;
+            }
+            const data             = await this.get(this.routes.buildingsAvailable);
+            this.availableBuildings = data.buildings ?? [];
+            this.buildMode          = true;
+            this.selectedTile       = null;
+            this.$nextTick(() => this.redrawGrid());
+        },
+
+        selectPendingBuilding(building) {
+            this.pendingBuilding = building;
+            this.$nextTick(() => this.redrawGrid());
+        },
+
+        // ── Tile actions ──────────────────────────────────────────────────────
+
+        async doExploreTile(tile) {
+            const res = await this.post(this.routes.explore, { q: tile.q, r: tile.r });
+            if (res.ok) {
+                this.updateTile(res.tile);
+                this.selectedTile = res.tile;
+                this.$nextTick(() => this.redrawGrid());
+            } else {
+                alert(res.error);
+            }
+        },
+
+        async doDeepScan(tile) {
+            const res = await this.post(this.routes.deepScan, { q: tile.q, r: tile.r });
+            if (res.ok) {
+                this.updateTile(res.tile);
+                this.selectedTile = res.tile;
+                this.$nextTick(() => this.redrawGrid());
+            } else {
+                alert(res.error);
+            }
+        },
+
+        // ── Building actions ──────────────────────────────────────────────────
+
+        async doPlaceBuilding(tile) {
+            const res = await this.post(this.routes.placeBuilding, {
+                building_id: this.pendingBuilding.building_id,
+                q: tile.q,
+                r: tile.r,
+            });
+            if (res.ok) {
+                this.updateBuilding(res.building);
+                this.buildMode       = false;
+                this.pendingBuilding = null;
+                this.selectedTile    = tile;
+                this.$nextTick(() => this.redrawGrid());
+            } else {
+                alert(res.error);
+            }
+        },
+
+        async doInvestAp(building) {
+            const res = await this.post(this.routes.investBuilding, {
+                building_id: building.building_id,
+            });
+            if (res.ok) {
+                this.updateBuilding(res.building);
+                // Refresh selectedTile reference so bars re-render
+                if (this.selectedTile) {
+                    this.selectedTile = { ...this.selectedTile };
+                }
+            } else {
+                alert(res.error);
+            }
+        },
+
+        // ── State helpers ─────────────────────────────────────────────────────
+
+        updateTile(tile) {
+            const idx = this.tiles.findIndex(t => t.q === tile.q && t.r === tile.r);
+            if (idx !== -1) this.tiles[idx] = tile;
+        },
+
+        updateBuilding(building) {
+            const idx = this.buildings.findIndex(b => b.building_id === building.building_id);
+            if (idx !== -1) this.buildings[idx] = building;
+            else this.buildings.push(building);
         },
 
         tileHeading(tile) {
@@ -133,6 +250,26 @@ function colonyHexView(config) {
             const total    = this.tiles.length;
             const explored = this.tiles.filter(t => t.is_explored).length;
             return `${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
+        },
+
+        // ── HTTP helpers ──────────────────────────────────────────────────────
+
+        get(url) {
+            return fetch(url, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            }).then(r => r.json());
+        },
+
+        post(url, data) {
+            return fetch(url, {
+                method:  'POST',
+                headers: {
+                    'Content-Type':     'application/json',
+                    'X-CSRF-TOKEN':     document.querySelector('meta[name=csrf-token]')?.content ?? '',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                body: JSON.stringify(data),
+            }).then(r => r.json());
         },
     };
 }
@@ -185,7 +322,7 @@ function initHexGrid(container, tiles, opts = {}) {
         const cx       = px + offX;
         const cy       = py + offY;
         const building = buildingsByTile.get(`${tile.q},${tile.r}`) ?? null;
-        const g        = createHexTile(cx, cy, SIZE - 2, tile, building, opts);
+        const g        = createHexTile(cx, cy, SIZE - 2, tile, building, opts, buildingsByTile);
         svg.appendChild(g);
     }
 
@@ -193,21 +330,30 @@ function initHexGrid(container, tiles, opts = {}) {
     container.appendChild(svg);
 }
 
-function createHexTile(cx, cy, size, tile, building, opts) {
+function createHexTile(cx, cy, size, tile, building, opts, buildingsByTile) {
     const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
 
-    const isCC          = tile.q === 0 && tile.r === 0;
-    const isImpassable  = tile.tile_type === 'terrain_impassable' && tile.is_explored;
+    const isCC         = tile.q === 0 && tile.r === 0;
+    const isImpassable = tile.tile_type === 'terrain_impassable' && tile.is_explored;
+
+    // Build-mode: valid placement tile (explored terrain, not occupied)
+    const isBuildTarget = opts.buildMode && opts.pendingBuilding
+        && tile.is_explored
+        && tile.tile_type.startsWith('terrain_')
+        && tile.tile_type !== 'terrain_impassable'
+        && !buildingsByTile?.has(`${tile.q},${tile.r}`);
 
     const points  = hexCorners(cx, cy, size);
     const polygon = document.createElementNS('http://www.w3.org/2000/svg', 'polygon');
     polygon.setAttribute('points', points.join(' '));
-    polygon.setAttribute('fill', getTileColor(tile));
+
+    let fillColor = getTileColor(tile);
+    if (isBuildTarget) fillColor = '#b8e8b8';  // light-green build-target highlight
+    polygon.setAttribute('fill', fillColor);
 
     const [stroke, strokeW] = getTileStroke(tile, isCC);
     polygon.setAttribute('stroke',       stroke);
     polygon.setAttribute('stroke-width', isImpassable ? '0' : strokeW);
-    // Store defaults for deselect restore
     polygon._defaultStroke  = stroke;
     polygon._defaultStrokeW = isImpassable ? '0' : strokeW;
 
@@ -223,7 +369,6 @@ function createHexTile(cx, cy, size, tile, building, opts) {
     }
 
     if (isImpassable) {
-        // Render as a smaller, borderless shape — communicates "obstacle, not a placeable tile"
         return g;
     }
 
@@ -232,26 +377,19 @@ function createHexTile(cx, cy, size, tile, building, opts) {
         g.appendChild(svgText(cx, cy, 'CC', 10, '#2e7d32', 700));
     }
 
-    // Small resource indicator dot (top-right)
+    // Resource indicator dot (top-right, blue)
     if (tile.is_explored && tile.resource_max > 0) {
-        const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-        dot.setAttribute('cx', cx + size * 0.38);
-        dot.setAttribute('cy', cy - size * 0.38);
-        dot.setAttribute('r',  '4');
-        dot.setAttribute('fill', '#2196f3');
-        dot.setAttribute('stroke', '#fff');
-        dot.setAttribute('stroke-width', '1');
-        dot.setAttribute('pointer-events', 'none');
+        const dot = svgCircle(cx + size * 0.38, cy - size * 0.38, 4, '#2196f3', '#fff');
         g.appendChild(dot);
     }
 
-    // Building indicator badge (center-bottom, skip CC — already labeled)
+    // Building badge (center-bottom, skip CC — already labeled)
     if (building && !isCC && tile.is_explored) {
-        const abbr  = BUILDING_ABBR[building.building_key] ?? '?';
+        const abbr   = BUILDING_ABBR[building.building_key] ?? '?';
         const badgeW = 22;
         const badgeH = 12;
-        const bx = cx - badgeW / 2;
-        const by = cy + size * 0.28;
+        const bx     = cx - badgeW / 2;
+        const by     = cy + size * 0.28;
 
         const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
         rect.setAttribute('x',      bx);
@@ -259,24 +397,31 @@ function createHexTile(cx, cy, size, tile, building, opts) {
         rect.setAttribute('width',  badgeW);
         rect.setAttribute('height', badgeH);
         rect.setAttribute('rx',     '3');
-        rect.setAttribute('fill',   'rgba(30,30,30,0.72)');
+        // Under-construction (level 0) gets a lighter badge
+        rect.setAttribute('fill', building.level === 0 ? 'rgba(80,80,80,0.55)' : 'rgba(30,30,30,0.72)');
         rect.setAttribute('pointer-events', 'none');
         g.appendChild(rect);
 
         g.appendChild(svgText(cx, by + badgeH / 2 + 0.5, abbr, 8, '#fff', 700));
     }
 
-    // Event indicator dot (top-left, only when deep-scanned)
+    // Event indicator dot (top-left, orange — only when deep-scanned)
     if (tile.is_deep_scanned && tile.event_type) {
-        const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-        dot.setAttribute('cx', cx - size * 0.38);
-        dot.setAttribute('cy', cy - size * 0.38);
-        dot.setAttribute('r',  '4');
-        dot.setAttribute('fill', '#e67e22');
-        dot.setAttribute('stroke', '#fff');
-        dot.setAttribute('stroke-width', '1');
-        dot.setAttribute('pointer-events', 'none');
-        g.appendChild(dot);
+        g.appendChild(svgCircle(cx - size * 0.38, cy - size * 0.38, 4, '#e67e22', '#fff'));
+    }
+
+    // Signal indicator (center-top, pulsing yellow — explored tile with hidden event)
+    if (tile.has_signal) {
+        const pulse = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        pulse.setAttribute('cx',           cx);
+        pulse.setAttribute('cy',           cy - size * 0.15);
+        pulse.setAttribute('r',            '5');
+        pulse.setAttribute('fill',         '#f0d060');
+        pulse.setAttribute('stroke',       '#c0a820');
+        pulse.setAttribute('stroke-width', '1');
+        pulse.setAttribute('class',        'signal-pulse');
+        pulse.setAttribute('pointer-events', 'none');
+        g.appendChild(pulse);
     }
 
     return g;
@@ -310,13 +455,25 @@ function getTileStroke(tile, isCC) {
 
 function svgText(x, y, text, size, fill, weight) {
     const el = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-    el.setAttribute('x', x);
-    el.setAttribute('y', y + size / 3);
-    el.setAttribute('text-anchor', 'middle');
-    el.setAttribute('font-size',   size);
-    el.setAttribute('font-weight', weight ?? 'normal');
-    el.setAttribute('fill',        fill ?? '#333');
+    el.setAttribute('x',            x);
+    el.setAttribute('y',            y + size / 3);
+    el.setAttribute('text-anchor',  'middle');
+    el.setAttribute('font-size',    size);
+    el.setAttribute('font-weight',  weight ?? 'normal');
+    el.setAttribute('fill',         fill ?? '#333');
     el.setAttribute('pointer-events', 'none');
     el.textContent = text;
+    return el;
+}
+
+function svgCircle(cx, cy, r, fill, stroke) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    el.setAttribute('cx',           cx);
+    el.setAttribute('cy',           cy);
+    el.setAttribute('r',            r);
+    el.setAttribute('fill',         fill);
+    el.setAttribute('stroke',       stroke);
+    el.setAttribute('stroke-width', '1');
+    el.setAttribute('pointer-events', 'none');
     return el;
 }

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -8,8 +8,28 @@ window.__colonyViewData = {
     colony:    @json(['id' => $colony->id, 'name' => $colony->name]),
     ccLevel:   {{ (int)$ccLevel }},
     buildings: @json($buildings),
+    routes: {
+        explore:            '{{ route('colony.tile.explore') }}',
+        deepScan:           '{{ route('colony.tile.deep-scan') }}',
+        buildingsAvailable: '{{ route('colony.buildings.available') }}',
+        placeBuilding:      '{{ route('colony.building.place') }}',
+        investBuilding:     '{{ route('colony.building.invest') }}',
+    },
+    i18n: {
+        explore:           '{{ __('colony.explore') }}',
+        deepScan:          '{{ __('colony.deep_scan') }}',
+        investAp:          '{{ __('colony.invest_ap') }}',
+        build:             '{{ __('colony.build') }}',
+        cancel:            '{{ __('colony.cancel') }}',
+        selectTileHint:    '{{ __('colony.select_tile_hint') }}',
+        buildModeTitle:    '{{ __('colony.build_mode_title') }}',
+        buildModeHint:     '{{ __('colony.build_mode_hint') }}',
+        noBuildings:       '{{ __('colony.no_buildings') }}',
+        constructionSite:  '{{ __('colony.construction_site') }}',
+    },
 };
 </script>
+
 <div class="hex-page" x-data="colonyHexView(window.__colonyViewData)">
     <div class="hex-layout">
 
@@ -18,26 +38,68 @@ window.__colonyViewData = {
             <div class="hex-canvas-header">
                 <h2>{{ $colony->name }}</h2>
                 <small x-text="statusLine()"></small>
+                <button class="build-btn"
+                        :class="{ 'build-btn--active': buildMode }"
+                        @click="toggleBuildMode()">
+                    <span x-text="buildMode ? '{{ __('colony.cancel') }}' : '{{ __('colony.build') }}'"></span>
+                </button>
             </div>
             <div x-ref="hexgrid" class="hex-canvas"></div>
         </div>
 
-        {{-- Tile info sidebar --}}
+        {{-- Tile info / build mode sidebar --}}
         <aside class="tile-panel">
             <div class="tile-panel-header">
-                <h3>Tile-Info</h3>
+                <h3 x-text="buildMode ? '{{ __('colony.build_mode_title') }}' : '{{ __('colony.tile_info') }}'"></h3>
             </div>
 
             <div class="tile-panel-body">
-                <template x-if="selectedTile">
+
+                {{-- Build mode: building list --}}
+                <template x-if="buildMode">
+                    <div>
+                        <p class="build-mode-hint">{{ __('colony.build_mode_hint') }}</p>
+
+                        <template x-if="pendingBuilding">
+                            <p class="build-mode-selected">
+                                <strong x-text="pendingBuilding.label"></strong>
+                                &nbsp;&mdash; {{ __('colony.select_tile_hint') }}
+                            </p>
+                        </template>
+
+                        <template x-if="availableBuildings.length === 0">
+                            <p class="build-mode-empty">{{ __('colony.no_buildings') }}</p>
+                        </template>
+
+                        <ul class="building-list">
+                            <template x-for="b in availableBuildings" :key="b.building_id">
+                                <li class="building-list-item"
+                                    :class="{ 'building-list-item--selected': pendingBuilding?.building_id === b.building_id }"
+                                    @click="selectPendingBuilding(b)">
+                                    <span class="building-list-name" x-text="b.label"></span>
+                                    <span class="building-list-ap" x-text="`${b.ap_for_levelup} AP`"></span>
+                                </li>
+                            </template>
+                        </ul>
+                    </div>
+                </template>
+
+                {{-- Normal mode: selected tile info --}}
+                <template x-if="!buildMode && selectedTile">
                     <div>
                         <h3 class="tile-heading" x-text="tileHeading(selectedTile)"></h3>
 
                         <div class="tile-status-chips">
-                            <span x-show="!selectedTile.is_ring_unlocked" class="chip chip--locked">Gesperrt</span>
-                            <span x-show="selectedTile.is_ring_unlocked && !selectedTile.is_explored" class="chip chip--fog">Unerforscht</span>
-                            <span x-show="selectedTile.is_explored && !selectedTile.is_deep_scanned" class="chip chip--explored">Erkundet</span>
-                            <span x-show="selectedTile.is_deep_scanned" class="chip chip--scanned">Tiefgescannt</span>
+                            <span x-show="!selectedTile.is_ring_unlocked"
+                                  class="chip chip--locked">{{ __('colony.chip_locked') }}</span>
+                            <span x-show="selectedTile.is_ring_unlocked && !selectedTile.is_explored"
+                                  class="chip chip--fog">{{ __('colony.chip_unexplored') }}</span>
+                            <span x-show="selectedTile.is_explored && !selectedTile.is_deep_scanned && !selectedTile.has_signal"
+                                  class="chip chip--explored">{{ __('colony.chip_explored') }}</span>
+                            <span x-show="selectedTile.is_explored && selectedTile.has_signal"
+                                  class="chip chip--signal">{{ __('colony.chip_signal') }}</span>
+                            <span x-show="selectedTile.is_deep_scanned"
+                                  class="chip chip--scanned">{{ __('colony.chip_scanned') }}</span>
                         </div>
 
                         <dl class="tile-dl">
@@ -63,7 +125,7 @@ window.__colonyViewData = {
                             <div class="sidebar-resource">
                                 <div class="sidebar-bar-group">
                                     <div class="sidebar-bar-label">
-                                        <span>Regolith</span>
+                                        <span>{{ __('colony.resource_regolith') }}</span>
                                         <span x-text="`${selectedTile.resource_amount} / ${selectedTile.resource_max}`"></span>
                                     </div>
                                     <div class="sidebar-bar-wrap">
@@ -76,20 +138,24 @@ window.__colonyViewData = {
 
                         <template x-if="buildingForTile(selectedTile)">
                             <div class="sidebar-building">
-                                <div class="sidebar-section-title">Gebäude</div>
+                                <div class="sidebar-section-title">{{ __('colony.building_section') }}</div>
                                 <div class="sidebar-building-name">
-                                    <strong x-text="buildingForTile(selectedTile).label"></strong>
-                                    <span class="sidebar-level-badge" x-text="`Lv. ${buildingForTile(selectedTile).level}`"></span>
+                                    <strong x-text="buildingForTile(selectedTile).level === 0
+                                        ? '{{ __('colony.construction_site') }}: ' + buildingForTile(selectedTile).label
+                                        : buildingForTile(selectedTile).label"></strong>
+                                    <span class="sidebar-level-badge"
+                                          x-show="buildingForTile(selectedTile).level > 0"
+                                          x-text="`Lv. ${buildingForTile(selectedTile).level}`"></span>
                                 </div>
 
                                 <dl class="tile-dl" style="margin-top:.5rem">
-                                    <dt>Max. Stufe</dt>
+                                    <dt>{{ __('colony.max_level') }}</dt>
                                     <dd x-text="buildingForTile(selectedTile).max_level ?? '∞'"></dd>
                                 </dl>
 
                                 <div class="sidebar-bar-group">
                                     <div class="sidebar-bar-label">
-                                        <span>Zustand</span>
+                                        <span>{{ __('colony.condition') }}</span>
                                         <span x-text="`${buildingForTile(selectedTile).status_points} / ${buildingForTile(selectedTile).max_status_points ?? 20}`"></span>
                                     </div>
                                     <div class="sidebar-bar-wrap">
@@ -100,7 +166,7 @@ window.__colonyViewData = {
 
                                 <div class="sidebar-bar-group">
                                     <div class="sidebar-bar-label">
-                                        <span>AP investiert</span>
+                                        <span>{{ __('colony.ap_invested') }}</span>
                                         <span x-text="`${buildingForTile(selectedTile).ap_spend} / ${buildingForTile(selectedTile).ap_for_levelup}`"></span>
                                     </div>
                                     <div class="sidebar-bar-wrap">
@@ -111,20 +177,36 @@ window.__colonyViewData = {
                             </div>
                         </template>
 
-                        <template x-if="selectedTile.is_ring_unlocked">
-                            <div class="sidebar-actions">
-                                <button class="sidebar-action-btn" disabled>Ausbauen</button>
-                                <button class="sidebar-action-btn" disabled>Erkunden</button>
-                            </div>
-                        </template>
+                        {{-- Context action buttons --}}
+                        <div class="sidebar-actions">
+                            <template x-if="selectedTile.is_ring_unlocked && !selectedTile.is_explored">
+                                <button class="sidebar-action-btn" @click="doExploreTile(selectedTile)">
+                                    {{ __('colony.explore') }}
+                                </button>
+                            </template>
+
+                            <template x-if="selectedTile.has_signal && !selectedTile.is_deep_scanned">
+                                <button class="sidebar-action-btn" @click="doDeepScan(selectedTile)">
+                                    {{ __('colony.deep_scan') }}
+                                </button>
+                            </template>
+
+                            <template x-if="buildingForTile(selectedTile)">
+                                <button class="sidebar-action-btn" @click="doInvestAp(buildingForTile(selectedTile))">
+                                    {{ __('colony.invest_ap') }}
+                                </button>
+                            </template>
+                        </div>
                     </div>
                 </template>
 
-                <template x-if="!selectedTile">
+                {{-- Normal mode: nothing selected --}}
+                <template x-if="!buildMode && !selectedTile">
                     <div class="tile-panel-empty">
-                        <p>Hex-Tile anklicken<br>um Details anzuzeigen.</p>
+                        <p>{{ __('colony.click_tile_hint') }}</p>
                     </div>
                 </template>
+
             </div>
         </aside>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,15 @@ Route::middleware('auth')->prefix('colony')->name('colony.')->group(function () 
     Route::get('/',       [ColonyController::class, 'index'])->name('index');
     Route::get('/view',   [ColonyController::class, 'hexview'])->name('view');
     Route::patch('/name', [ColonyController::class, 'rename'])->name('rename');
+
+    // Tile actions (AJAX)
+    Route::post('/tile/explore',    [ColonyController::class, 'exploreTile'])->name('tile.explore');
+    Route::post('/tile/deep-scan',  [ColonyController::class, 'deepScanTile'])->name('tile.deep-scan');
+
+    // Building actions (AJAX)
+    Route::get('/buildings/available', [ColonyController::class, 'availableBuildings'])->name('buildings.available');
+    Route::post('/building/place',     [ColonyController::class, 'placeBuilding'])->name('building.place');
+    Route::post('/building/invest',    [ColonyController::class, 'investBuilding'])->name('building.invest');
 });
 
 // ── Resources (Schritt 5) ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Erkunden** (Explore): Tile-Typ aufdecken, kostet 1 Nav-AP. Button erscheint in Sidebar für unlocked + unexplored Tiles.
- **Sondieren** (Deep Scan): Event auf Signal-Tiles aufdecken, kostet 2 Nav-AP. Nur Tiles mit verborgenem Event senden ein Signal (pulsierender SVG-Indikator). Neue Chip-Variante `chip--signal`.
- **Bauen** (Build Mode): Globaler Button im Canvas-Header öffnet Gebäude-Liste. Gebäude wählen → gültige Terrain-Tiles grün highlighted → Tile anklicken platziert Baustelle (1 Construction-AP). AP investieren hebt Level-Stand.
- **Lokalisierung**: `lang/de/colony.php` + `lang/en/colony.php` für alle UI-Strings und Fehlermeldungen.
- `has_signal` in Tile-Daten: `event_type` wird im API-Output versteckt solange `!is_deep_scanned`.
- Code-Sprache: Englisch (Methoden: `exploreTile`, `deepScanTile`, `placeBuilding`, `investBuilding`).

## Test plan

- [ ] `php artisan test tests/Feature` → 391 Tests grün
- [ ] `php artisan colony:seed-demo` → 61 Tiles, Ring 3 hat Events
- [ ] Browser `/colony/view`:
  - Ring-3-Tile (Nebel) anklicken → "Erkunden"-Button → Tile-Typ erscheint
  - Tile mit Signal → pulsierender Indikator + "Sondieren"-Button → Event + orange Dot erscheint
  - "Bauen" im Header → Gebäude-Liste in Sidebar
  - Gebäude wählen → gültige Terrain-Tiles grün
  - Terrain-Tile klicken → Baustelle (Lv 0) auf Tile + in Sidebar
  - "AP investieren" → Fortschrittsbalken steigt