### PR TITLE
feat: Phase 3d — Colony Zone Expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-04-30
+
+- **Phase 3d — Colony Zone Expansion**: `is_ring_unlocked` → `is_colony_zone` umbenannt (DB-Migration, PRAGMA-Fix für stale `v_trade_researches`-View). Koloniezone schaltet nun individuelle Terrain-Tiles frei statt ganzer Ringe — CC Lv1–5 entspricht kumulativ 4/2/3/3/3 = max. 15 Tiles (config: `game.colony_zone_expansion`). `assignColonyZone()` in `ColonyTileService` berechnet die Zone deterministisch in Ringfolge, überspringt Regolith/impassable, setzt colony-zone-Tiles automatisch auf explored. Karte auf 3 Ringe (37 Tiles) als Default reduziert. Mehrfach-Instanzen für `is_instanced=true`-Gebäude (Wohnhabitat max 6, Hangar) in `availableBuildings()` und `placeBuilding()` implementiert. CC Level-Up gibt aktualisierte Tile-Liste zurück → Frontend (Alpine) aktualisiert Grid sofort. Demo-Seed auf CC Lv5 + 3 Ringe aktualisiert. 393 Tests grün.
+
 ## 2026-04-28
 
 - **GDD §4 Bauregeln** (`docs/GDD.md`): Harvester/Regolith-Trennungsregel formal dokumentiert. Neue Tabelle und Bullet-Regeln: Harvester darf ausschließlich auf `regolith_*`-Tiles stehen, reguläre Gebäude nur auf Terrain-Tiles. Querverweis in §4a (Kolonieoberfläche) ergänzt.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -386,18 +386,19 @@ Alle drei Design-Themen wurden entschieden und im GDD dokumentiert (PRs #78, #79
 - [x] **Startzustand** — CC Lv1 + Harvester Lv1 vorgebaut; 3.000 Credits, 200 Regolith, 0 Werkstoffe/Organika (PR #82)
 - [x] **Berater-Einstellungskosten kalibriert** — 50 Cr → 300–600 Cr je Typ; echter Day-1-Tradeoff (PR #82)
 - [ ] **Bar-Event-System** — 0–2 NPC-Gäste pro Tick, befristete Angebote (1–2 Ticks), Credits + Tausch
-- [ ] **DB-Cleanup: überzählige Gebäude entfernen** — 25 → 12 aktive Gebäude in DB (13 deprecated rows löschen)
+- [x] **DB-Cleanup: überzählige Gebäude entfernt** — 25 → 11 aktive Gebäude; `building_*`-Keys eingeführt; Migration + Seed bereinigt (PR #92)
 - [ ] **Berater Rang 2/3 Beförderungskosten** — ~150/~400 Cr je Rang; noch nicht implementiert
 
 ---
 
-### Phase 3b: UI-Überarbeitung + Almanach
+### Phase 3b: Colony-View + Buildings-Cleanup — Abgeschlossen (April 2026, PR #92)
 
-**Frontend-Stack (entschieden April 2026):** Alpine.js + PicoCSS + SVG für neue Screens. Kein jQuery, kein Bootstrap in neuen Screens. Bestehende Screens (fleets, techtree, trade, innn) schrittweise migrieren — galaxy.js + nouron.js zuerst (trivial), dann rest. Ziel: jQuery-CDN + Bootstrap-CDN komplett entfernen.
+**Frontend-Stack:** Alpine.js + PicoCSS + SVG für neue Screens. Bestehende Screens (fleets, techtree, trade, innn) werden schrittweise migriert.
 
-- [ ] **Alpine.js + PicoCSS einbinden** — CDN-Links in neuem Colony-Layout, bestehende `app.blade.php` vorerst unangetastet
-- [ ] **DB-Migrationen** — `colony_tiles`, `planet_size/type` auf `glx_system_objects`, `instance_id` auf `colony_buildings`, `grid_x/grid_y` auf `fleets` + `glx_system_objects`, `spot`-Feld entfernen
-- [ ] **Colony-View (Hex-Grid)** — SVG + plain JS, Axial-Koordinaten, Fog-of-War, Tile-Interaktion
+- [x] **Alpine.js + PicoCSS eingebunden** — Colony-Layout `layouts/colony.blade.php`; bestehende `app.blade.php` vorerst unangetastet
+- [x] **DB-Migrationen** — `colony_tiles` (Hex-Grid, Rings, Fog-of-War), `instance_id` + `tile_x/y` auf `colony_buildings`, `planet_size/type` auf `glx_system_objects`
+- [x] **Colony-View (Hex-Grid)** — SVG + Alpine.js, Axial-Koordinaten, Fog-of-War, Tile-Sidebar, Building-Badges, Signal-Indikator (PR #92)
+- [x] **Demo-Seed** — `php artisan colony:seed-demo` befüllt Kolonie mit ~80%-Demo-State
 - [ ] **System-View (12×12-Grid)** — SVG + plain JS, Objekte und Flotten, Flottenbefehl-Overlay
 - [ ] **Vertrauensanzeige im UI** — Mechanik vorhanden, UI fehlt noch
 - [ ] **Händler-Modal** — Alpine-gesteuert, nativer `<dialog>`, 3–4 Items, Credits-Kauf
@@ -406,10 +407,29 @@ Alle drei Design-Themen wurden entschieden und im GDD dokumentiert (PRs #78, #79
 
 ---
 
-### Phase 3c: Onboarding & Tutorial
+### Phase 3c: Kolonieaktionen — Abgeschlossen (April 2026, PR #93)
+
+- [x] **Erkunden** — unbekannte Exploration-Zone-Tiles aufdecken (1 Nav-AP); kontextsensitiver Button in Sidebar
+- [x] **Sondieren (Deep Scan)** — Signal-Tiles mit Event untersuchen (2 Nav-AP); pulsierender SVG-Indikator
+- [x] **Bauen** — globaler Button im Canvas-Header; Gebäude-Auswahlliste; Terrain-Tile wählen (1 Construction-AP); AP investieren bis Level-Up
+- [x] **AP-Chips** — Nav-AP und Bau-AP werden nach jeder Aktion live aktualisiert
+
+---
+
+### Phase 3d: Colony Zone Expansion — Abgeschlossen (April 2026, PR #94)
+
+- [x] **Tile-Count Unlock** — CC Lv1–5 schaltet 4/2/3/3/3 = max. 15 individuelle Terrain-Tiles frei (statt ganzer Ringe); konfigurierbar via `config/game.php → colony_zone_expansion`
+- [x] **`is_ring_unlocked` → `is_colony_zone`** — DB-Umbenennung; Semantik: Terrain-Tile in Koloniezone (bebaubar)
+- [x] **3-Ring-Karte als Default** — 37 Tiles statt 61; Kartengröße run-konfigurierbar (vorbereitet)
+- [x] **CC Level-Up live** — Grid aktualisiert sich sofort wenn CC aufsteigt
+- [x] **Mehrfach-Instanzen** — Wohnhabitat (max 6×) und Hangar mehrfach platzierbar
+
+---
+
+### Phase 3e: Onboarding & Tutorial (ausstehend)
 
 - [ ] **Geführte Einführung für neue Spieler** — Form noch offen: interaktive Tour oder Tooltip-gestützte Einführung
-- [ ] **Cold-Start-Problem lösen** — neuer Spieler sieht 25 leere Techtree-Kacheln ohne Orientierung; erster Schritt muss klar sein
+- [ ] **Cold-Start-Problem lösen** — neuer Spieler sieht leere Techtree-Kacheln ohne Orientierung; erster Schritt muss klar sein
 - [ ] **Visuelle Hervorhebung des "nächsten sinnvollen Schritts"** — für Anfänger ohne Spielerfahrung; kein Bevormunden für erfahrene Spieler
 
 ---

--- a/app/Console/Commands/ColonySeedDemo.php
+++ b/app/Console/Commands/ColonySeedDemo.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Services\ColonyTileService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
@@ -14,7 +15,6 @@ use Illuminate\Support\Facades\DB;
  *   Ring 0:   Kommandozentrale (terrain_empty)
  *   Ring 1-2: Kolonie-Zone — terrain tiles only (terrain_empty / hazard), buildings placed
  *   Ring 3:   Exploration-Zone — regolith + events, mostly scouted; Harvester placed here
- *   Ring 4:   Exploration-Zone (frontier) — regolith + impassable, partially unlocked
  *
  * Game-Design rule: Regolith-Tiles are NOT buildable except for the Harvester.
  *                   Regular buildings stand only on terrain tiles.
@@ -23,6 +23,12 @@ class ColonySeedDemo extends Command
 {
     protected $signature   = 'colony:seed-demo {colony_id=1 : Colony ID to seed}';
     protected $description = 'Seed a colony with a rich ~80% built-out demo state for testing';
+
+    public function __construct(
+        private readonly ColonyTileService $tileService,
+    ) {
+        parent::__construct();
+    }
 
     // Harvester placed on a regolith tile in ring 3
     private const HARVESTER_TILE = [3, 0];
@@ -34,24 +40,19 @@ class ColonySeedDemo extends Command
         31 => [-1,  0],  // sciencelab     (ring 1, terrain)
         41 => [0,  -1],  // bioFacility    (ring 1, terrain)
         44 => [2,   0],  // hangar         (ring 2, terrain)
-        46 => [1,   1],  // hospital       (ring 2, terrain)
-        32 => [2,  -1],  // temple         (ring 2, terrain)
         52 => [-2,  0],  // bar            (ring 2, terrain)
-        50 => [-1, -1],  // denkmal        (ring 2, terrain)
         27 => [3,   0],  // harvester      (ring 3, regolith — exploration zone)
+        // hospital (46), temple (32), denkmal (50) intentionally unplaced — available in Build Mode
     ];
 
     private const BUILDING_LEVELS = [
-        25 => 3,
+        25 => 5,  // CC level 5 for demo (all 15 colony zone tiles unlocked)
         27 => 1,
         28 => 2,
         30 => 3,
         31 => 2,
-        32 => 1,
         41 => 1,
         44 => 1,
-        46 => 1,
-        50 => 1,
         52 => 1,
     ];
 
@@ -69,10 +70,16 @@ class ColonySeedDemo extends Command
         DB::table('colony_tiles')->where('colony_id', $colonyId)->delete();
 
         $this->generateTiles($colonyId);
-        $this->info('  ✓ Tiles generated (rings 0–4, 61 tiles)');
+        $this->info('  ✓ Tiles generated (rings 0–3, 37 tiles)');
+
+        $this->tileService->assignColonyZone($colonyId, 5);  // CC Lv5: all 15 colony zone tiles
+        $this->info('  ✓ Colony zone assigned (CC Lv5, 15 terrain tiles)');
 
         $this->assignBuildingTiles($colonyId);
-        $this->info('  ✓ Building positions assigned');
+        $this->info('  ✓ Building positions assigned (hospital/temple/denkmal left unplaced)');
+
+        $this->ensurePilotAdvisor($colonyId);
+        $this->info('  ✓ Pilot advisor ensured (navigation AP)');
 
         $this->line('Done.');
         return self::SUCCESS;
@@ -91,25 +98,16 @@ class ColonySeedDemo extends Command
             '2,-3'  => 'event_wreck',
         ];
 
-        for ($ring = 0; $ring <= 4; $ring++) {
+        for ($ring = 0; $ring <= 3; $ring++) {
             foreach ($this->ringCoords($ring) as [$q, $r]) {
                 $seed = abs($q * 7 + $r * 13 + $colonyId * 3);
                 $key  = "{$q},{$r}";
 
-                // Unlock/explore/scan state per ring
-                $isRingUnlocked = match (true) {
-                    $ring <= 2  => true,
-                    $ring === 3 => true,                   // all ring-3 unlocked (active scouting)
-                    default     => ($seed % 24) < 10,      // ring 4: ~42% unlocked
-                };
-                $isExplored = match (true) {
-                    $ring <= 2  => true,
-                    $ring === 3 => $isRingUnlocked,        // all unlocked ring-3 explored
-                    default     => $isRingUnlocked && ($seed % 6) < 3,
-                };
+                // Explore/scan state per ring
+                $isExplored = $ring <= 3;  // all rings fully explored in demo
                 $isDeepScanned = match (true) {
                     $ring <= 2  => true,
-                    $ring === 3 => $isExplored && ($seed % 3) < 2,  // ~67% deep-scanned
+                    $ring === 3 => ($seed % 3) < 2,   // ~67% deep-scanned
                     default     => false,
                 };
 
@@ -133,7 +131,7 @@ class ColonySeedDemo extends Command
                     'ring'             => $ring,
                     'tile_type'        => $tileType,
                     'event_type'       => $eventType,
-                    'is_ring_unlocked' => $isRingUnlocked,
+                    'is_colony_zone'   => false,
                     'is_explored'      => $isExplored,
                     'is_deep_scanned'  => $isDeepScanned,
                     'resource_amount'  => $resourceAmount,
@@ -151,7 +149,7 @@ class ColonySeedDemo extends Command
 
     /**
      * Rings 0–2 are the colony zone: terrain tiles only (no regolith).
-     * Rings 3–4 are the exploration zone: regolith + hazards + impassable.
+     * Ring 3 is the exploration zone: regolith + hazards + impassable.
      * The harvester tile at (3,0) is always regolith_rich.
      */
     private function tileTypeFor(int $q, int $r, int $ring, int $seed): array
@@ -171,7 +169,7 @@ class ColonySeedDemo extends Command
             return [$types[$seed % count($types)], 0];
         }
 
-        // Exploration zone (rings 3–4)
+        // Exploration zone (ring 3)
         $types = match ($ring) {
             3 => ['regolith_normal', 'regolith_rich', 'regolith_poor', 'terrain_empty',
                   'terrain_hazard', 'regolith_normal', 'terrain_impassable', 'regolith_poor'],
@@ -216,6 +214,14 @@ class ColonySeedDemo extends Command
 
     private function assignBuildingTiles(int $colonyId): void
     {
+        // Clear tile assignment for buildings NOT in BUILDING_PLACEMENTS
+        // (so they appear as "available to build" in Build Mode)
+        $placedIds = array_keys(self::BUILDING_PLACEMENTS);
+        DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->whereNotIn('building_id', $placedIds)
+            ->update(['tile_x' => null, 'tile_y' => null, 'level' => 0, 'ap_spend' => 0]);
+
         foreach (self::BUILDING_PLACEMENTS as $buildingId => [$tileX, $tileY]) {
             $level = self::BUILDING_LEVELS[$buildingId] ?? 1;
 
@@ -230,5 +236,20 @@ class ColonySeedDemo extends Command
                     'ap_spend'      => 0,
                 ]);
         }
+    }
+
+    private function ensurePilotAdvisor(int $colonyId): void
+    {
+        $pilotId = (int) config('advisors.pilot.id');
+        $userId  = (int) DB::table('glx_colonies')->where('id', $colonyId)->value('user_id');
+
+        DB::table('advisors')->insertOrIgnore([
+            'user_id'                => $userId,
+            'personell_id'           => $pilotId,
+            'colony_id'              => $colonyId,
+            'rank'                   => 1,
+            'active_ticks'           => 0,
+            'unavailable_until_tick' => null,
+        ]);
     }
 }

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -69,7 +69,10 @@ class ColonyController extends BaseController
                 return $b;
             });
 
-        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings'));
+        $navAp          = $this->personellService->getAvailableActionPoints('navigation', $colony->id);
+        $constructionAp = $this->personellService->getAvailableActionPoints('construction', $colony->id);
+
+        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'navAp', 'constructionAp'));
     }
 
     // ── Tile actions ──────────────────────────────────────────────────────────
@@ -78,20 +81,18 @@ class ColonyController extends BaseController
     {
         $data   = $request->validate(['q' => 'required|integer', 'r' => 'required|integer']);
         $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $result = $this->tileService->exploreTile($colony->id, (int) $data['q'], (int) $data['r']);
 
-        return response()->json(
-            $this->tileService->exploreTile($colony->id, (int) $data['q'], (int) $data['r'])
-        );
+        return response()->json([...$result, ...($result['ok'] ? $this->currentAp($colony->id) : [])]);
     }
 
     public function deepScanTile(Request $request): JsonResponse
     {
         $data   = $request->validate(['q' => 'required|integer', 'r' => 'required|integer']);
         $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $result = $this->tileService->deepScanTile($colony->id, (int) $data['q'], (int) $data['r']);
 
-        return response()->json(
-            $this->tileService->deepScanTile($colony->id, (int) $data['q'], (int) $data['r'])
-        );
+        return response()->json([...$result, ...($result['ok'] ? $this->currentAp($colony->id) : [])]);
     }
 
     // ── Building actions ──────────────────────────────────────────────────────
@@ -102,22 +103,27 @@ class ColonyController extends BaseController
         $ccLevel = (int) DB::table('colony_buildings')
             ->where('colony_id', $colony->id)->where('building_id', 25)->value('level') ?? 0;
 
-        // Building IDs already placed on a tile
-        $placed = DB::table('colony_buildings')
+        $placedCounts = DB::table('colony_buildings')
             ->where('colony_id', $colony->id)
             ->whereNotNull('tile_x')
-            ->pluck('building_id')
+            ->selectRaw('building_id, COUNT(*) as cnt')
+            ->groupBy('building_id')
+            ->pluck('cnt', 'building_id')
             ->toArray();
 
         $buildings = DB::table('buildings')
             ->select('id', 'name', 'ap_for_levelup', 'max_status_points', 'max_level',
-                     'required_building_id', 'required_building_level')
+                     'required_building_id', 'required_building_level', 'is_instanced')
             ->get()
-            ->filter(function ($b) use ($ccLevel, $placed) {
+            ->filter(function ($b) use ($ccLevel, $placedCounts) {
                 if ($b->id === 25) return false;  // CC — already exists
-                if ($b->id === 27) return false;  // Harvester — special regolith placement
-                if (in_array($b->id, $placed)) return false;
-                // Prerequisite: if requires CC, check CC level
+                if ($b->id === 27) return false;  // Harvester — regolith placement only
+                $count = $placedCounts[$b->id] ?? 0;
+                if ($b->is_instanced) {
+                    if ($count >= ($b->max_level ?? PHP_INT_MAX)) return false;
+                } else {
+                    if ($count > 0) return false;
+                }
                 if ($b->required_building_id === 25 && $ccLevel < (int) ($b->required_building_level ?? 1)) {
                     return false;
                 }
@@ -130,6 +136,7 @@ class ColonyController extends BaseController
                 'ap_for_levelup'    => $b->ap_for_levelup,
                 'max_level'         => $b->max_level,
                 'max_status_points' => $b->max_status_points,
+                'is_instanced'      => (bool) $b->is_instanced,
             ])
             ->values();
 
@@ -156,6 +163,8 @@ class ColonyController extends BaseController
             return response()->json(['ok' => false, 'error' => __('colony.error_tile_not_found')]);
         if (!$tile->is_explored)
             return response()->json(['ok' => false, 'error' => __('colony.error_not_explored')]);
+        if (!$tile->is_colony_zone)
+            return response()->json(['ok' => false, 'error' => __('colony.error_tile_outside_colony')]);
         if (!str_starts_with($tile->tile_type, 'terrain_') || $tile->tile_type === 'terrain_impassable')
             return response()->json(['ok' => false, 'error' => __('colony.error_tile_not_buildable')]);
 
@@ -174,58 +183,84 @@ class ColonyController extends BaseController
         if (!$building)
             return response()->json(['ok' => false, 'error' => __('colony.error_building_not_found')]);
 
-        $existing = DB::table('colony_buildings')
-            ->where('colony_id', $colony->id)
-            ->where('building_id', $data['building_id'])
-            ->first();
-
-        if ($existing) {
-            DB::table('colony_buildings')
+        if ($building->is_instanced) {
+            $nextInstanceId = (int) DB::table('colony_buildings')
                 ->where('colony_id', $colony->id)
                 ->where('building_id', $data['building_id'])
-                ->update(['tile_x' => $data['q'], 'tile_y' => $data['r'], 'ap_spend' => 1]);
-        } else {
+                ->max('instance_id') + 1;
             DB::table('colony_buildings')->insert([
                 'colony_id'     => $colony->id,
                 'building_id'   => $data['building_id'],
-                'instance_id'   => 1,
+                'instance_id'   => $nextInstanceId,
                 'level'         => 0,
                 'status_points' => $building->max_status_points ?? 20,
                 'ap_spend'      => 1,
                 'tile_x'        => $data['q'],
                 'tile_y'        => $data['r'],
             ]);
+        } else {
+            $nextInstanceId = 1;
+            $existing = DB::table('colony_buildings')
+                ->where('colony_id', $colony->id)
+                ->where('building_id', $data['building_id'])
+                ->first();
+
+            if ($existing) {
+                DB::table('colony_buildings')
+                    ->where('colony_id', $colony->id)
+                    ->where('building_id', $data['building_id'])
+                    ->update(['tile_x' => $data['q'], 'tile_y' => $data['r'], 'ap_spend' => 1]);
+                $nextInstanceId = (int) $existing->instance_id;
+            } else {
+                DB::table('colony_buildings')->insert([
+                    'colony_id'     => $colony->id,
+                    'building_id'   => $data['building_id'],
+                    'instance_id'   => 1,
+                    'level'         => 0,
+                    'status_points' => $building->max_status_points ?? 20,
+                    'ap_spend'      => 1,
+                    'tile_x'        => $data['q'],
+                    'tile_y'        => $data['r'],
+                ]);
+            }
         }
 
         $this->personellService->lockActionPoints('construction', $colony->id, 1);
 
-        $row = $this->fetchBuildingRow($colony->id, $data['building_id']);
+        $row = $this->fetchBuildingRow($colony->id, $data['building_id'], $nextInstanceId);
 
-        return response()->json(['ok' => true, 'building' => $row]);
+        return response()->json(['ok' => true, 'building' => $row, ...$this->currentAp($colony->id)]);
     }
 
     public function investBuilding(Request $request): JsonResponse
     {
-        $data   = $request->validate(['building_id' => 'required|integer']);
-        $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $data = $request->validate([
+            'building_id' => 'required|integer',
+            'instance_id' => 'sometimes|integer',
+        ]);
+        $colony     = $this->colonyService->getPrimeColony(Auth::id());
+        $buildingId = (int) $data['building_id'];
+        $instanceId = (int) ($data['instance_id'] ?? 1);
 
         if ($this->personellService->getConstructionPoints($colony->id) < 1)
             return response()->json(['ok' => false, 'error' => __('colony.error_no_construction_ap')]);
 
         $row = DB::table('colony_buildings')
             ->where('colony_id', $colony->id)
-            ->where('building_id', $data['building_id'])
+            ->where('building_id', $buildingId)
+            ->where('instance_id', $instanceId)
             ->first();
 
         if (!$row)
             return response()->json(['ok' => false, 'error' => __('colony.error_building_not_found')]);
 
-        $building   = DB::table('buildings')->where('id', $data['building_id'])->first();
+        $building   = DB::table('buildings')->where('id', $buildingId)->first();
         $newApSpend = min($row->ap_spend + 1, $building->ap_for_levelup);
 
         DB::table('colony_buildings')
             ->where('colony_id', $colony->id)
-            ->where('building_id', $data['building_id'])
+            ->where('building_id', $buildingId)
+            ->where('instance_id', $instanceId)
             ->update(['ap_spend' => $newApSpend]);
 
         $this->personellService->lockActionPoints('construction', $colony->id, 1);
@@ -234,15 +269,30 @@ class ColonyController extends BaseController
         if ($newApSpend >= $building->ap_for_levelup) {
             DB::table('colony_buildings')
                 ->where('colony_id', $colony->id)
-                ->where('building_id', $data['building_id'])
+                ->where('building_id', $buildingId)
+                ->where('instance_id', $instanceId)
                 ->update(['level' => $row->level + 1, 'ap_spend' => 0]);
             $leveledUp = true;
         }
 
+        // CC level-up: recalculate colony zone and include updated tiles in response
+        if ($leveledUp && $buildingId === 25) {
+            $this->tileService->assignColonyZone($colony->id, $row->level + 1);
+            $tiles = $this->tileService->getTilesForColony($colony->id)->values()->toArray();
+            return response()->json([
+                'ok'         => true,
+                'building'   => $this->fetchBuildingRow($colony->id, $buildingId, $instanceId),
+                'leveled_up' => true,
+                'tiles'      => $tiles,
+                ...$this->currentAp($colony->id),
+            ]);
+        }
+
         return response()->json([
-            'ok'        => true,
-            'building'  => $this->fetchBuildingRow($colony->id, $data['building_id']),
+            'ok'         => true,
+            'building'   => $this->fetchBuildingRow($colony->id, $buildingId, $instanceId),
             'leveled_up' => $leveledUp,
+            ...$this->currentAp($colony->id),
         ]);
     }
 
@@ -264,12 +314,21 @@ class ColonyController extends BaseController
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private function fetchBuildingRow(int $colonyId, int $buildingId): object
+    private function currentAp(int $colonyId): array
+    {
+        return [
+            'apNav'          => $this->personellService->getAvailableActionPoints('navigation', $colonyId),
+            'apConstruction' => $this->personellService->getAvailableActionPoints('construction', $colonyId),
+        ];
+    }
+
+    private function fetchBuildingRow(int $colonyId, int $buildingId, int $instanceId = 1): object
     {
         $row = DB::table('colony_buildings')
             ->join('buildings', 'colony_buildings.building_id', '=', 'buildings.id')
             ->where('colony_buildings.colony_id', $colonyId)
             ->where('colony_buildings.building_id', $buildingId)
+            ->where('colony_buildings.instance_id', $instanceId)
             ->select(
                 'colony_buildings.building_id',
                 'colony_buildings.instance_id',

--- a/app/Services/ColonyTileService.php
+++ b/app/Services/ColonyTileService.php
@@ -28,9 +28,8 @@ class ColonyTileService
     {
         $tile = ColonyTile::where('colony_id', $colonyId)->where('q', $q)->where('r', $r)->first();
 
-        if (!$tile)                   return ['ok' => false, 'error' => __('colony.error_tile_not_found')];
-        if (!$tile->is_ring_unlocked) return ['ok' => false, 'error' => __('colony.error_ring_locked')];
-        if ($tile->is_explored)       return ['ok' => false, 'error' => __('colony.error_already_explored')];
+        if (!$tile)             return ['ok' => false, 'error' => __('colony.error_tile_not_found')];
+        if ($tile->is_explored) return ['ok' => false, 'error' => __('colony.error_already_explored')];
 
         if ($this->personellService->getAvailableActionPoints('navigation', $colonyId) < 1) {
             return ['ok' => false, 'error' => __('colony.error_no_nav_ap')];
@@ -63,13 +62,54 @@ class ColonyTileService
         return ['ok' => true, 'tile' => $this->transformTile($tile)];
     }
 
-    private function transformTile(ColonyTile $tile): array
+    /**
+     * Recalculate which terrain tiles belong to the colony zone for a given CC level.
+     * Colony zone tiles are also auto-explored (they are part of the settled area).
+     * Ring 0 (CC tile) is always colony zone regardless of CC level.
+     */
+    public function assignColonyZone(int $colonyId, int $ccLevel): void
     {
-        $arr = $tile->toArray();
-        $arr['has_signal'] = $tile->event_type !== null && (bool) $tile->is_explored && !(bool) $tile->is_deep_scanned;
-        // Hide the actual event until the tile is deep-scanned (sondiert)
-        $arr['event_type'] = $tile->is_deep_scanned ? $tile->event_type : null;
-        return $arr;
+        $expansion = config('game.colony_zone_expansion', [4, 2, 3, 3, 3]);
+        $target    = (int) array_sum(array_slice($expansion, 0, max(0, $ccLevel)));
+
+        $maxRing = (int) DB::table('colony_tiles')->where('colony_id', $colonyId)->max('ring');
+
+        // Load all tile types for lookup
+        $tileTypes = DB::table('colony_tiles')
+            ->where('colony_id', $colonyId)
+            ->get(['q', 'r', 'tile_type'])
+            ->keyBy(fn($t) => "{$t->q},{$t->r}")
+            ->map(fn($t) => $t->tile_type)
+            ->toArray();
+
+        // Ring 0 (CC) always colony zone
+        $colonyZone = [[0, 0]];
+        $counted    = 0;
+
+        for ($ring = 1; $ring <= $maxRing && $counted < $target; $ring++) {
+            foreach ($this->ringCoords($ring) as [$q, $r]) {
+                if ($counted >= $target) break;
+                $type = $tileTypes["{$q},{$r}"] ?? null;
+                if ($type === null
+                    || $type === 'terrain_impassable'
+                    || str_starts_with($type, 'regolith_')) {
+                    continue;
+                }
+                $colonyZone[] = [$q, $r];
+                $counted++;
+            }
+        }
+
+        // Reset all tiles
+        DB::table('colony_tiles')->where('colony_id', $colonyId)->update(['is_colony_zone' => 0]);
+
+        // Mark colony zone tiles (also auto-explore them)
+        foreach ($colonyZone as [$q, $r]) {
+            DB::table('colony_tiles')
+                ->where('colony_id', $colonyId)
+                ->where('q', $q)->where('r', $r)
+                ->update(['is_colony_zone' => 1, 'is_explored' => 1]);
+        }
     }
 
     /**
@@ -92,20 +132,14 @@ class ColonyTileService
             for ($r = $rMin; $r <= $rMax; $r++) {
                 $ring = max(abs($q), abs($r), abs($q + $r));
 
-                $isCC            = ($q === 0 && $r === 0);
-                $isRingUnlocked  = $ring <= max(1, $ccLevel);
-                $isExplored      = $ring <= 1;
-
-                if ($isCC) {
-                    $tileType = 'terrain_empty';
-                } else {
-                    $tileType = $this->pickTileType($q, $r, $colonyId);
-                }
+                $isCC       = ($q === 0 && $r === 0);
+                $isExplored = $isCC || $ring <= 1;
+                $tileType   = $isCC ? 'terrain_empty' : $this->pickTileType($q, $r, $colonyId);
 
                 $resourceAmount = null;
                 $resourceMax    = null;
                 if (str_starts_with($tileType, 'regolith_')) {
-                    $resourceMax    = match ($tileType) {
+                    $resourceMax = match ($tileType) {
                         'regolith_rich'   => 800,
                         'regolith_normal' => 500,
                         default           => 250,
@@ -114,24 +148,34 @@ class ColonyTileService
                 }
 
                 $rows[] = [
-                    'colony_id'       => $colonyId,
-                    'q'               => $q,
-                    'r'               => $r,
-                    'ring'            => $ring,
-                    'tile_type'       => $tileType,
-                    'event_type'      => null,
-                    'is_ring_unlocked' => $isRingUnlocked ? 1 : 0,
-                    'is_explored'     => $isExplored ? 1 : 0,
+                    'colony_id'      => $colonyId,
+                    'q'              => $q,
+                    'r'              => $r,
+                    'ring'           => $ring,
+                    'tile_type'      => $tileType,
+                    'event_type'     => null,
+                    'is_colony_zone' => 0,
+                    'is_explored'    => $isExplored ? 1 : 0,
                     'is_deep_scanned' => 0,
                     'resource_amount' => $resourceAmount,
                     'resource_max'    => $resourceMax,
-                    'created_at'      => now(),
-                    'updated_at'      => now(),
+                    'created_at'     => now(),
+                    'updated_at'     => now(),
                 ];
             }
         }
 
         DB::table('colony_tiles')->insertOrIgnore($rows);
+        $this->assignColonyZone($colonyId, $ccLevel);
+    }
+
+    private function transformTile(ColonyTile $tile): array
+    {
+        $arr = $tile->toArray();
+        $arr['has_signal'] = $tile->event_type !== null && (bool) $tile->is_explored && !(bool) $tile->is_deep_scanned;
+        // Hide the actual event until the tile is deep-scanned (sondiert)
+        $arr['event_type'] = $tile->is_deep_scanned ? $tile->event_type : null;
+        return $arr;
     }
 
     private function pickTileType(int $q, int $r, int $colonyId): string
@@ -144,5 +188,26 @@ class ColonyTileService
         if ($hash < 55) return 'regolith_normal';
         if ($hash < 65) return 'regolith_rich';
         return 'terrain_empty';
+    }
+
+    private function ringCoords(int $ring): array
+    {
+        if ($ring === 0) return [[0, 0]];
+
+        $coords = [];
+        $dirs   = [[1, 0], [0, 1], [-1, 1], [-1, 0], [0, -1], [1, -1]];
+        $q = $ring;
+        $r = 0;
+
+        for ($side = 0; $side < 6; $side++) {
+            for ($step = 0; $step < $ring; $step++) {
+                $coords[] = [$q, $r];
+                [$dq, $dr] = $dirs[($side + 2) % 6];
+                $q += $dq;
+                $r += $dr;
+            }
+        }
+
+        return $coords;
     }
 }

--- a/config/game.php
+++ b/config/game.php
@@ -25,6 +25,11 @@ return [
     // Will be removed in a future release.
     'dev_mode' => (bool) env('GAME_DEV_MODE', false),
 
+    // Tiles unlocked by CC expansion per level (index 0 = CC Lv1, ..., index 4 = CC Lv5).
+    // Walk order: ring 1 → ring 2 → ring 3; skip regolith_* and terrain_impassable.
+    // Max colony zone = sum = 15 terrain tiles (+ CC tile = 16 total).
+    'colony_zone_expansion' => [4, 2, 3, 3, 3],
+
     'tick' => [
         // How many hours is one tick (currently 1 tick = 1 day)
         'length' => 24,

--- a/database/migrations/2026_04_30_000001_rename_colony_tiles_is_ring_unlocked.php
+++ b/database/migrations/2026_04_30_000001_rename_colony_tiles_is_ring_unlocked.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // v_trade_researches references the already-dropped trade_researches table.
+        // SQLite validates all views during RENAME COLUMN, so drop the broken view first.
+        DB::statement('DROP VIEW IF EXISTS v_trade_researches');
+
+        DB::statement('PRAGMA legacy_alter_table = ON');
+        DB::statement('ALTER TABLE colony_tiles RENAME COLUMN is_ring_unlocked TO is_colony_zone');
+        DB::statement('PRAGMA legacy_alter_table = OFF');
+    }
+
+    public function down(): void
+    {
+        DB::statement('PRAGMA legacy_alter_table = ON');
+        DB::statement('ALTER TABLE colony_tiles RENAME COLUMN is_colony_zone TO is_ring_unlocked');
+        DB::statement('PRAGMA legacy_alter_table = OFF');
+    }
+};

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -320,27 +320,37 @@ Das UI-Verb ist immer identisch: **"Tile ausbauen"** — ob Leveled oder Instanc
 
 ### Darstellung: Hex-Grid
 
-Die Kolonieoberfläche wird als 2D top-down Hex-Grid dargestellt. Die Planetengröße bestimmt die Anzahl verfügbarer Ringe und skaliert mit dem Schwierigkeitsgrad des Runs.
+Die Kolonieoberfläche wird als 2D top-down Hex-Grid dargestellt. Die Karte hat immer **3 Ringe** (rings 0–3, gesamt 37 Tiles). Planetentyp und Run-Schwierigkeit beeinflussen die Tile-Qualität (Häufigkeit reicher Vorkommen, Hazard-Dichte), nicht die Kartengröße.
 
 ### Zwei Zonen
 
-**Kolonie-Zone** — die inneren Ringe um das CC. Hier werden Gebäude gebaut (ausschließlich auf Terrain-Tiles). Neue Ringe werden durch CC-Level freigeschaltet.
+**Kolonie-Zone** — ein Set von Terrain-Tiles rund um das CC. Hier werden Gebäude gebaut (ausschließlich auf `terrain_empty`/`terrain_hazard`-Tiles). CC-Level-Upgrades fügen der Kolonie-Zone weitere Terrain-Tiles hinzu.
 
-**Exploration Zone** — die äußeren Tiles jenseits der Kolonie-Zone. Hier liegen Ressourcenquellen (Regolith-Tiles), Gefahren und Event-Spots. Der Harvester steht hier auf einem Regolith-Tile. Jedes Tile muss einzeln per Navigation-AP erkundet werden (Korvette oder Sonde).
+**Exploration Zone** — alle Tiles, die nicht zur Kolonie-Zone gehören. Hier liegen Ressourcenquellen (Regolith-Tiles), Gefahren und Event-Spots. Der Harvester steht hier auf einem Regolith-Tile. Jedes Tile muss einzeln per Navigation-AP erkundet werden (Korvette oder Sonde).
 
 > Zone-Trennung: Reguläre Gebäude nur auf Terrain-Tiles, Harvester nur auf Regolith-Tiles. Siehe §4 "Bauregeln: Zone-Trennung".
 
 ### CC-Level und Koloniewachstum
 
-Die Kommandozentrale schaltet durch Level-Upgrades neue Hex-Ringe in der Kolonie-Zone frei. Tiles innerhalb eines freigeschalteten Rings werden einzeln durch Erkundungs-AP enthüllt — nicht alle auf einmal.
+Die Kommandozentrale schaltet durch Level-Upgrades zusätzliche **Terrain-Tiles** in der Kolonie-Zone frei — keine ganzen Ringe, sondern eine feste Anzahl individueller Tiles.
 
-| Planetengröße | Kolonie-Ringe gesamt | Neuer Ring bei CC-Level |
+**Freischalt-Logik:** Tiles werden in Ringfolge (Ring 1 zuerst, dann Ring 2, dann Ring 3) und innerhalb eines Rings in fester Reihenfolge (Tile-ID-Reihenfolge) freigeschaltet. Regolith-Tiles (`regolith_*`) und unpassierbare Tiles (`terrain_impassable`) werden dabei übersprungen und zählen nicht — sie bleiben dauerhaft Exploration Zone.
+
+| CC-Level | Neu freigeschaltete Terrain-Tiles | Kolonie-Zone gesamt (kumulativ, ohne CC-Tile) |
 |---|---|---|
-| Klein | 2 | 1 / 3 |
-| Mittel | 3 | 1 / 2 / 4 |
-| Groß | 4 | 1 / 2 / 3 / 5 |
+| 1 | 4 | 4 |
+| 2 | 2 | 6 |
+| 3 | 3 | 9 |
+| 4 | 3 | 12 |
+| 5 | 3 | 15 |
 
-Ring 1 (6 Tiles direkt um das CC) ist immer sofort verfügbar. Der erste Ressourcen-Tile ist garantiert in Ring 1 (fixes Starttemplate, Typ variiert pro Run).
+**Maximum: 15 Terrain-Tiles** in der Kolonie-Zone (+ CC-Tile = 16 belegte Tiles). Bei vollständigem Ausbau (alle 10 anderen Gebäude) bleiben 5 Slots für Wohnhabitat — aber das Maximum liegt bei 6 Instanzen. Um das 6. Wohnhabitat zu bauen, muss ein anderes Gebäude weichen. Das erzeugt eine bewusste Knappheits-Entscheidung.
+
+> Die konkreten Zahlen (4/2/3/3/3) sind ein Startwert und liegen in `config/game.php → colony_zone_expansion`. Balancing-Anpassungen ohne Code-Änderungen möglich.
+
+**Kein Spieler-Wahlrecht bei der Freischaltung.** Die Expansion ist deterministisch. Die Spielerentscheidung liegt darin, *welches Gebäude* auf *welchen* der freigeschalteten Tiles gesetzt wird — nicht welche Tiles freigeschaltet werden. Das hält die Interaktion auf Mobile einfach (kein tile-selection-Popup beim CC-Levelup).
+
+Ring 1 (6 Tiles direkt um das CC) liefert die ersten 4–6 Colony-Zone-Tiles (sofern nicht alle regolith oder impassable). Der erste Ressourcen-Tile ist garantiert in Ring 1 (fixes Starttemplate, Typ variiert pro Run).
 
 ### Startposition
 
@@ -350,6 +360,10 @@ Die CC-Startposition ist pro Run zufällig. Das erzeugt unterschiedliche Ausgang
 
 - **Kolonie-Zone:** alle Tiles sofort sichtbar
 - **Exploration Zone:** Fog of War — Tiles werden einzeln per Navigation-AP aufgedeckt
+
+### Visuelle Zone-Abgrenzung
+
+Die Kolonie-Zone-Grenze ist auf kleinen Karten nicht mehr ein sauberer Ring, sondern ergibt sich aus dem `is_colony_zone`-Flag pro Tile. Das Frontend rendert Colony-Zone-Tiles mit einem warmen Basis-Tint (Farbschema: Weiß/Anthrazit/Rot-Palette), Exploration-Zone-Tiles mit einem kühleren, dunkleren Tint. Der Spieler erkennt die Grenze durch Farbe, nicht durch Position. Regolith-Tiles und impassable Tiles innerhalb der inneren Ringe sind immer Exploration Zone — sie wirken als visuelle "Lücken" in der Colony Zone, was die unterschiedliche Funktion deutlich kommuniziert.
 
 ### Tile-Typen und Schwierigkeit
 
@@ -448,10 +462,10 @@ Jedes Tile der Kolonieoberfläche wird als Zeile in `colony_tiles` gespeichert:
 | `colony_id` | FK → glx_colonies | |
 | `q` | integer | Axial-Koordinate |
 | `r` | integer | Axial-Koordinate |
-| `ring` | integer | 0 = CC-Tile, 1–4 = Ring-Nummer |
+| `ring` | integer | 0 = CC-Tile, 1–3 = Ring-Nummer (Karte hat max. 3 Ringe) |
 | `tile_type` | string | Primärer Typ, z.B. `regolith_rich` — sichtbar nach normalem Scan |
 | `event_type` | string nullable | Event-Overlay, NULL = kein Event — sichtbar erst nach Tiefenscan |
-| `is_ring_unlocked` | boolean | CC-Level hat diesen Ring freigeschaltet |
+| `is_colony_zone` | boolean | Tile gehört zur Kolonie-Zone (CC-Level-Expansion hat es freigeschaltet). Regolith- und impassable-Tiles sind immer false. |
 | `is_explored` | boolean | Normaler Scan (Nav-AP) abgeschlossen |
 | `is_deep_scanned` | boolean | Tiefenscan abgeschlossen — enthüllt `event_type` |
 | `resource_amount` | integer nullable | Verbleibende Ressourcenmenge |
@@ -519,6 +533,8 @@ Eine neue Einheit kann nur gebaut / angestellt werden wenn `freies_supply >= Kos
 
 **Startsituation:** CC Lv1 = 10, 0 Wohnhabitate → Supply-Cap = **10**. Erster Tutorial-Schritt: Wohnhabitat bauen → Cap springt auf 18.
 **Hard-Cap:** 200 Supply.
+
+> **Tile-Budget:** 10 Nicht-CC-Gebäude + 5 Wohnhabitat = 15 Tiles (voll). Wer das 6. Wohnhabitat will, muss ein anderes Gebäude opfern — bewusste Designentscheidung für Knappheit.
 
 > **Designabsicht:** CC-Ausbau und Wohnhabitate sind die primären Cap-Quellen. Kenntnisse liefern einen zusätzlichen Bonus, der den Cap in Richtung 200 schiebt — aber nie alleine reicht. Wer militärisch eskalieren will, muss zuerst zivile Infrastruktur investieren.
 

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -50,6 +50,7 @@ return [
     'error_no_nav_ap'           => 'Nicht genug Navigations-AP.',
     'error_no_nav_ap_2'         => 'Nicht genug Navigations-AP (2 benötigt).',
     'error_tile_not_buildable'  => 'Nur bebaubare Terrain-Tiles erlaubt.',
+    'error_tile_outside_colony' => 'Dieses Tile liegt außerhalb der Koloniezone.',
     'error_tile_occupied'       => 'Tile bereits belegt.',
     'error_no_construction_ap'  => 'Nicht genug Bau-AP.',
     'error_building_not_found'  => 'Gebäude nicht gefunden.',

--- a/lang/en/colony.php
+++ b/lang/en/colony.php
@@ -50,6 +50,7 @@ return [
     'error_no_nav_ap'           => 'Not enough navigation AP.',
     'error_no_nav_ap_2'         => 'Not enough navigation AP (2 required).',
     'error_tile_not_buildable'  => 'Only buildable terrain tiles allowed.',
+    'error_tile_outside_colony' => 'This tile is outside the colony zone.',
     'error_tile_occupied'       => 'Tile already occupied.',
     'error_no_construction_ap'  => 'Not enough construction AP.',
     'error_building_not_found'  => 'Building not found.',

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -203,9 +203,33 @@ body {
     border-bottom: 1px solid var(--color-border);
     background: #fff;
     display: flex;
-    align-items: baseline;
-    gap: 1rem;
+    align-items: center;
+    gap: 0.75rem;
     flex-shrink: 0;
+}
+
+.ap-chips {
+    display: flex;
+    gap: 0.4rem;
+    margin-left: auto;
+}
+
+.ap-chip {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+
+.ap-chip--nav {
+    background: #dbeafe;
+    color: #1e40af;
+}
+
+.ap-chip--build {
+    background: #dcfce7;
+    color: #166534;
 }
 
 .hex-canvas-header h2 {

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -80,6 +80,8 @@ function colonyHexView(config) {
         buildings:         config.buildings ?? [],
         routes:            config.routes ?? {},
         i18n:              config.i18n ?? {},
+        apNav:             config.apNav ?? 0,
+        apConstruction:    config.apConstruction ?? 0,
         selectedTile:      null,
         buildMode:         false,
         pendingBuilding:   null,
@@ -106,11 +108,8 @@ function colonyHexView(config) {
 
         onTileClick(tile) {
             if (this.buildMode && this.pendingBuilding) {
-                const isValid = tile.is_explored
-                    && tile.tile_type.startsWith('terrain_')
-                    && tile.tile_type !== 'terrain_impassable'
-                    && !this.buildingForTile(tile);
-                if (isValid) this.doPlaceBuilding(tile);
+                if (isBuildableTile(tile) && !this.buildingForTile(tile))
+                    this.doPlaceBuilding(tile);
                 return;
             }
             this.selectTile(tile);
@@ -149,7 +148,9 @@ function colonyHexView(config) {
         },
 
         selectPendingBuilding(building) {
-            this.pendingBuilding = building;
+            this.pendingBuilding = (this.pendingBuilding?.building_id === building.building_id)
+                ? null
+                : building;
             this.$nextTick(() => this.redrawGrid());
         },
 
@@ -160,6 +161,7 @@ function colonyHexView(config) {
             if (res.ok) {
                 this.updateTile(res.tile);
                 this.selectedTile = res.tile;
+                this.updateAp(res);
                 this.$nextTick(() => this.redrawGrid());
             } else {
                 alert(res.error);
@@ -171,6 +173,7 @@ function colonyHexView(config) {
             if (res.ok) {
                 this.updateTile(res.tile);
                 this.selectedTile = res.tile;
+                this.updateAp(res);
                 this.$nextTick(() => this.redrawGrid());
             } else {
                 alert(res.error);
@@ -190,6 +193,7 @@ function colonyHexView(config) {
                 this.buildMode       = false;
                 this.pendingBuilding = null;
                 this.selectedTile    = tile;
+                this.updateAp(res);
                 this.$nextTick(() => this.redrawGrid());
             } else {
                 alert(res.error);
@@ -199,11 +203,19 @@ function colonyHexView(config) {
         async doInvestAp(building) {
             const res = await this.post(this.routes.investBuilding, {
                 building_id: building.building_id,
+                instance_id: building.instance_id ?? 1,
             });
             if (res.ok) {
                 this.updateBuilding(res.building);
-                // Refresh selectedTile reference so bars re-render
-                if (this.selectedTile) {
+                this.updateAp(res);
+                if (res.tiles) {
+                    this.tiles = res.tiles;
+                    if (this.selectedTile) {
+                        const updated = res.tiles.find(t => t.q === this.selectedTile.q && t.r === this.selectedTile.r);
+                        if (updated) this.selectedTile = updated;
+                    }
+                    this.$nextTick(() => this.redrawGrid());
+                } else if (this.selectedTile) {
                     this.selectedTile = { ...this.selectedTile };
                 }
             } else {
@@ -213,13 +225,20 @@ function colonyHexView(config) {
 
         // ── State helpers ─────────────────────────────────────────────────────
 
+        updateAp(res) {
+            if (res.apNav          !== undefined) this.apNav          = res.apNav;
+            if (res.apConstruction !== undefined) this.apConstruction = res.apConstruction;
+        },
+
         updateTile(tile) {
             const idx = this.tiles.findIndex(t => t.q === tile.q && t.r === tile.r);
             if (idx !== -1) this.tiles[idx] = tile;
         },
 
         updateBuilding(building) {
-            const idx = this.buildings.findIndex(b => b.building_id === building.building_id);
+            const idx = this.buildings.findIndex(
+                b => b.building_id === building.building_id && b.instance_id === building.instance_id
+            );
             if (idx !== -1) this.buildings[idx] = building;
             else this.buildings.push(building);
         },
@@ -272,6 +291,15 @@ function colonyHexView(config) {
             }).then(r => r.json());
         },
     };
+}
+
+// ── Tile helpers ──────────────────────────────────────────────────────────────
+
+function isBuildableTile(tile) {
+    return tile.is_colony_zone
+        && tile.is_explored
+        && tile.tile_type.startsWith('terrain_')
+        && tile.tile_type !== 'terrain_impassable';
 }
 
 // ── SVG hex grid renderer ─────────────────────────────────────────────────────
@@ -336,11 +364,9 @@ function createHexTile(cx, cy, size, tile, building, opts, buildingsByTile) {
     const isCC         = tile.q === 0 && tile.r === 0;
     const isImpassable = tile.tile_type === 'terrain_impassable' && tile.is_explored;
 
-    // Build-mode: valid placement tile (explored terrain, not occupied)
+    // Build-mode: valid placement tile (colony zone, explored terrain, not occupied)
     const isBuildTarget = opts.buildMode && opts.pendingBuilding
-        && tile.is_explored
-        && tile.tile_type.startsWith('terrain_')
-        && tile.tile_type !== 'terrain_impassable'
+        && isBuildableTile(tile)
         && !buildingsByTile?.has(`${tile.q},${tile.r}`);
 
     const points  = hexCorners(cx, cy, size);
@@ -357,7 +383,7 @@ function createHexTile(cx, cy, size, tile, building, opts, buildingsByTile) {
     polygon._defaultStroke  = stroke;
     polygon._defaultStrokeW = isImpassable ? '0' : strokeW;
 
-    if (tile.is_ring_unlocked && !isImpassable) {
+    if (!isImpassable) {
         g.classList.add('tile--unlocked');
         g.addEventListener('click', () => opts.onSelect && opts.onSelect(tile));
     }
@@ -437,16 +463,16 @@ function hexCorners(cx, cy, size) {
 }
 
 function getTileColor(tile) {
-    if (!tile.is_ring_unlocked)                   return LOCKED_COLOR;
-    if (!tile.is_explored)                        return FOG_COLOR;
-    if (tile.q === 0 && tile.r === 0)             return CC_COLOR;
-    if (tile.is_deep_scanned && tile.event_type)  return EVENT_COLOR;
+    if (!tile.is_explored && !tile.is_colony_zone) return LOCKED_COLOR;   // unexplored exploration zone
+    if (!tile.is_explored)                         return FOG_COLOR;        // unexplored colony zone (shouldn't normally appear)
+    if (tile.q === 0 && tile.r === 0)              return CC_COLOR;
+    if (tile.is_deep_scanned && tile.event_type)   return EVENT_COLOR;
     return TILE_COLORS[tile.tile_type] ?? '#c8cdd6';
 }
 
 function getTileStroke(tile, isCC) {
     if (isCC)                                         return [CC_STROKE,     '2.5'];
-    if (!tile.is_ring_unlocked)                       return [LOCKED_STROKE, '1'];
+    if (!tile.is_explored && !tile.is_colony_zone)    return [LOCKED_STROKE, '1'];
     if (!tile.is_explored)                            return [FOG_STROKE,    '1'];
     if (tile.is_deep_scanned && tile.event_type)      return [EVENT_STROKE,  '1.5'];
     if (tile.tile_type === 'terrain_impassable')      return ['#555',        '0'];

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -8,6 +8,8 @@ window.__colonyViewData = {
     colony:    @json(['id' => $colony->id, 'name' => $colony->name]),
     ccLevel:   {{ (int)$ccLevel }},
     buildings: @json($buildings),
+    apNav:          {{ (int)$navAp }},
+    apConstruction: {{ (int)$constructionAp }},
     routes: {
         explore:            '{{ route('colony.tile.explore') }}',
         deepScan:           '{{ route('colony.tile.deep-scan') }}',
@@ -38,6 +40,10 @@ window.__colonyViewData = {
             <div class="hex-canvas-header">
                 <h2>{{ $colony->name }}</h2>
                 <small x-text="statusLine()"></small>
+                <div class="ap-chips">
+                    <span class="ap-chip ap-chip--nav" x-text="`Nav ${apNav} AP`"></span>
+                    <span class="ap-chip ap-chip--build" x-text="`Bau ${apConstruction} AP`"></span>
+                </div>
                 <button class="build-btn"
                         :class="{ 'build-btn--active': buildMode }"
                         @click="toggleBuildMode()">
@@ -90,9 +96,9 @@ window.__colonyViewData = {
                         <h3 class="tile-heading" x-text="tileHeading(selectedTile)"></h3>
 
                         <div class="tile-status-chips">
-                            <span x-show="!selectedTile.is_ring_unlocked"
+                            <span x-show="!selectedTile.is_explored && !selectedTile.is_colony_zone"
                                   class="chip chip--locked">{{ __('colony.chip_locked') }}</span>
-                            <span x-show="selectedTile.is_ring_unlocked && !selectedTile.is_explored"
+                            <span x-show="!selectedTile.is_explored && selectedTile.is_colony_zone"
                                   class="chip chip--fog">{{ __('colony.chip_unexplored') }}</span>
                             <span x-show="selectedTile.is_explored && !selectedTile.is_deep_scanned && !selectedTile.has_signal"
                                   class="chip chip--explored">{{ __('colony.chip_explored') }}</span>
@@ -179,7 +185,7 @@ window.__colonyViewData = {
 
                         {{-- Context action buttons --}}
                         <div class="sidebar-actions">
-                            <template x-if="selectedTile.is_ring_unlocked && !selectedTile.is_explored">
+                            <template x-if="!selectedTile.is_explored">
                                 <button class="sidebar-action-btn" @click="doExploreTile(selectedTile)">
                                     {{ __('colony.explore') }}
                                 </button>


### PR DESCRIPTION
## Summary

- **`is_ring_unlocked` → `is_colony_zone`**: DB-Migration umbenennt die Spalte; PRAGMA-Fix für den stale `v_trade_researches`-View in der Dev-DB
- **Tile-Count Unlock**: CC Lv1–5 schaltet 4/2/3/3/3 = max. 15 individuelle Terrain-Tiles frei (statt ganzer Ringe); Konfiguration in `config/game.php → colony_zone_expansion`; neuer `ColonyTileService::assignColonyZone()` berechnet deterministisch in Ringfolge, überspringt Regolith/impassable
- **3-Ring-Karte**: Default auf 37 Tiles reduziert (war 61); Demo-Seed auf CC Lv5 + Rings 0–3 aktualisiert
- **Mehrfach-Instanzen**: Wohnhabitat (max 6×) und Hangar können mehrfach platziert werden; `availableBuildings()` zählt Instanzen vs. `max_level`; `placeBuilding()` inseriert immer eine neue Zeile für `is_instanced=true`-Gebäude
- **CC Level-Up live**: `investBuilding()` triggert `assignColonyZone()` bei CC-Level-Up und gibt aktualisierte Tile-Liste zurück → Frontend zeichnet Grid sofort neu
- **Frontend**: `isBuildableTile()` nutzt `tile.is_colony_zone` statt `ring <= ccLevel`; alle nicht-impassable Tiles sind klickbar
- **GDD §4a**: 3-Ring-Karte, Tile-Count-Unlock-Tabelle, `is_colony_zone` Schema-Eintrag

## Test plan

- [ ] `php artisan migrate` → kein Fehler
- [ ] `php artisan test` → 393 Tests grün
- [ ] `php artisan colony:seed-demo` → 37 Tiles, CC Lv5, 15 colony zone tiles
- [ ] Browser `/colony/view` → Build-Mode zeigt nur colony zone tiles grün
- [ ] Ring-3-Tiles sind klickbar (exploration zone) aber kein Build-Highlight
- [ ] Wohnhabitat mehrfach platzierbar (zweite Instanz erscheint in Sidebar)
- [ ] CC AP investieren bis Level-Up → Grid erweitert colony zone sofort ohne Seiten-Reload