### PR TITLE
feat: Phase 3f — Berater-Screen als Alpine.js + PicoCSS Karussell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-05-06
+
+- **Berater-Screen Redesign (Phase 3f)**: Berater-Screen komplett auf Alpine.js + PicoCSS migriert (war Bootstrap/jQuery). Neue Karussell-Ansicht mit 5 Portrait-Karten: Mobile zeigt eine Karte mit Swipe-Navigation, Desktop zeigt alle fünf nebeneinander. Jede Karte zeigt Rang, AP/Tick, Ticks, Aufstieg-Fortschrittsbalken und Status-Chip. Leere Slots haben Hire-Knopf, gesperrte Slots (CC-Level zu niedrig) sind ausgegraut. Hire/Fire laufen jetzt per AJAX ohne Seitenreload, mit nativen `<dialog>`-Bestätigungen. `AdvisorController` um `buildSlots()` und JSON-Branching erweitert (22 neue Feature-Tests).
+
 ## 2026-05-05
 
 - **Koloniekarte UX-Überarbeitung (Browser-Test-Fixes)**: Ring 1 generiert jetzt ausschließlich `terrain_empty`-Tiles (kein Regolith, keine Blocker), Ring 2 hat nur seltene Hazards/Blocker. Colony-Zone-Expansion auf `[6,3,3,2,1]` geändert — Ring 1 komplett ab CC Lv1 freigeschaltet, logische Progression ohne Teilringe. CC hard cap bei Lv5: `investBuilding()` prüft `max_level`, "AP investieren"-Button wird bei Max-Level ausgeblendet.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -480,6 +480,19 @@ GDD-Referenz: § 15 (Designprinzipien, §15.1–§15.7)
 
 ---
 
+### Phase 3f: Berater-Screen Redesign — Abgeschlossen (Mai 2026, Branch feat/phase3f-advisor-carousel)
+
+Der Berater-Screen war der logische nächste Schritt nach dem Onboarding (Phase 3e), da der Onboarding-Hinweis Rang 2 direkt auf das Einstellen eines Beraters verweist. Der Screen wurde von Bootstrap/jQuery auf Alpine.js + PicoCSS migriert und als Karussell neugestaltet.
+
+- [x] [backend-coder] `AdvisorController::buildSlots()` — 5-Slot-Array mit Zustands-Logik (active/unavailable/empty/locked), CC-Level-Gating, Rang-Fortschritt in Prozent
+- [x] [backend-coder] JSON-Branching in `hire()` und `fire()` — AJAX-Clients erhalten strukturiertes JSON (`{ok, slots, slotInfo}`), HTML-Clients erhalten weiterhin Redirect
+- [x] [ui-specialist] `public/css/advisors.css` — Portrait-Karten (2:3-Verhältnis), Rang-Badges, Fortschrittsbalken, Status-Chips, Karussell-Track mit CSS-Transition, Arrows + Dots (Mobile only)
+- [x] [ui-specialist] `public/js/advisors.js` — Alpine-Komponente: Swipe-Gesten (Touch-Events), Karussell-Navigation, AJAX hire/fire, native `<dialog>`-Steuerung
+- [x] [ui-specialist] `resources/views/advisors/index.blade.php` — Komplett auf `layouts.colony` (PicoCSS + Alpine) umgestellt; `x-for` für Karten, `x-if` für Zustände, `@push`-Stacks für CSS/JS
+- [x] [qa-tester] 22 Feature-Tests in `AdvisorControllerTest.php` — Index, Hire/Fire (Redirect + JSON), 404-Sicherheit, Auth-Guard; alle grün
+
+---
+
 ### Bewusste Designentscheidungen (nicht umsetzen in Phase 3)
 
 | Thema | Entscheidung | Begründung |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -521,7 +521,7 @@ Der Berater-Screen war der logische nächste Schritt nach dem Onboarding (Phase 
 - [ ] **Gruppen/Gilden** — Datenmodell für Gruppen (kein Schema vorhanden); Grundlage für `restriction = 1` im Handelssystem; bewusst einfach gehalten: gründen, beitreten, verlassen
 - [ ] **Rassen-System überarbeiten** — `race_id` ist im Schema, wird nicht ausgewertet; rassenspezifische Effekte definieren; Designfrage erst nach Phase-3-Playtest beantwortbar
 - [ ] **Steuersystem** — `steuerfaktor` in Moral-Formel als Platzhalter (= 0); GDD-Design steht; Implementierung setzt stabile Moral-Balance aus Phase 3 voraus
-- [ ] **Benannte Chef-Berater** — individuelle Charaktere mit Fähigkeiten und Namen; aktuelles Berater-Modell ist als Fundament ausgelegt (GDD §12)
+- [ ] **Berater-Vertiefung (Design-Sprint nötig)** — Beim Einstellen eine Auswahl aus mehreren Kandidaten (zufällig generiert pro Run); Berater haben positive und negative Traits (z.B. "Pragmatiker: +1 Bau-AP / −5% Moral", "Intrigant: +2 Strategie-AP / Vertrauensmalus"); individuelle Namen und Portrait-Grafiken; aktuelles Berater-Modell ist als Fundament ausgelegt (GDD §12)
 - [ ] **Moral-Erweiterung** — Bevölkerungszufriedenheit als eigener Wert, Revolutionsrisiko, fraktionsspezifische Moralmodifikatoren (GDD §13)
 - [ ] **Handelsbeschränkungen vollständig durchsetzen** — `restriction`-Feld Werte 1/2/3 korrekt auswerten (aktuell ignoriert)
 

--- a/app/Http/Controllers/Techtree/AdvisorController.php
+++ b/app/Http/Controllers/Techtree/AdvisorController.php
@@ -100,6 +100,7 @@ class AdvisorController extends BaseController
                     $progressPct = min(100, (int) round($advisor->active_ticks / $nextThreshold * 100));
                 }
 
+                $upkeepMap   = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
                 $advisorData = [
                     'id'                     => $advisor->id,
                     'rank'                   => $advisor->rank,
@@ -116,6 +117,7 @@ class AdvisorController extends BaseController
                     'is_max_rank'            => $isMaxRank,
                     'is_unavailable'         => $isUnavailable,
                     'unavailable_until_tick' => $advisor->unavailable_until_tick,
+                    'upkeep'                 => $upkeepMap[$advisor->rank] ?? 10,
                 ];
             }
 
@@ -144,14 +146,16 @@ class AdvisorController extends BaseController
         $slotInfo = $this->personellService->getAdvisorSlotInfo($colonyId);
         $slots    = $this->buildSlots($advisors, $slotInfo, $currentTick);
 
-        $pageData = [
-            'slots'    => $slots,
-            'slotInfo' => $slotInfo,
-            'routes'   => [
+        $upkeepMap = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
+        $pageData  = [
+            'slots'         => $slots,
+            'slotInfo'      => $slotInfo,
+            'routes'        => [
                 'hire' => route('advisors.hire'),
                 'fire' => route('advisors.fire', ['id' => '__ID__']),
             ],
-            'colonyId' => $colonyId,
+            'colonyId'      => $colonyId,
+            'junior_upkeep' => $upkeepMap[1] ?? 10,
         ];
 
         return view('advisors.index', compact('pageData'));

--- a/app/Http/Controllers/Techtree/AdvisorController.php
+++ b/app/Http/Controllers/Techtree/AdvisorController.php
@@ -9,11 +9,21 @@ use App\Services\ColonyService;
 use App\Services\ResourcesService;
 use App\Services\Techtree\PersonellService;
 use App\Services\TickService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session;
+use Illuminate\View\View;
 
 class AdvisorController extends BaseController
 {
+    /**
+     * Canonical advisor slot order. Position index (0-based) + 1 = position number (1–5)
+     * and equals the CC level required to unlock that slot.
+     */
+    private const SLOT_ORDER = ['engineer', 'scientist', 'pilot', 'trader', 'stratege'];
+
     public function __construct(
         TickService                       $tick,
         private readonly PersonellService $personellService,
@@ -35,36 +45,119 @@ class AdvisorController extends BaseController
         return $id;
     }
 
-    public function index()
+    /**
+     * Build the canonical 5-slot array for the advisor carousel UI.
+     *
+     * Each slot corresponds to one advisor type in SLOT_ORDER. Position (1–5)
+     * doubles as the CC level required to unlock that slot.
+     *
+     * @param  Collection $advisors   Active advisors on the colony (Advisor models).
+     * @param  array      $slotInfo   Output of PersonellService::getAdvisorSlotInfo().
+     * @param  int        $currentTick Current game tick for unavailability checks.
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildSlots(Collection $advisors, array $slotInfo, int $currentTick): array
     {
-        $userId   = $this->getCurrentUserId();
-        $colonyId = $this->resolveColonyId();
+        $rankThresholds = config('game.advisor.rank_thresholds', [1 => 10, 2 => 20]);
+        $ccLevel        = $slotInfo['cc_level'];
 
-        $advisors = $this->personellService->getColonyAdvisors($colonyId)->load('personell');
-        $slotInfo = $this->personellService->getAdvisorSlotInfo($colonyId);
+        // Index active advisors by personell_id for O(1) lookup.
+        $advisorsByPersonellId = $advisors->keyBy('personell_id');
 
-        // Credits cost per type, keyed by personell_id
-        $creditsByPersonellId = collect(config('advisors'))
-            ->mapWithKeys(fn($cfg) => [$cfg['id'] => $cfg['credits']]);
+        $slots = [];
 
-        // Hireable types (all colony-scoped)
-        $personellTypes = Personell::whereIn('id', PersonellService::allIds())
-            ->get()->keyBy('id');
+        foreach (self::SLOT_ORDER as $index => $key) {
+            $position    = $index + 1; // 1–5
+            $advisorCfg  = config("advisors.{$key}");
+            $personellId = $advisorCfg['id'];
+            $hireCost    = $advisorCfg['credits'];
+            $apType      = $advisorCfg['ap_type'];
 
-        $apInfo = [
-            'construction' => $this->personellService->getTotalActionPoints('construction', $colonyId),
-            'research'     => $this->personellService->getTotalActionPoints('research', $colonyId),
-            'economy'      => $this->personellService->getTotalActionPoints('economy', $colonyId),
-            'strategy'     => $this->personellService->getTotalActionPoints('strategy', $colonyId),
-            'navigation'   => $this->personellService->getTotalActionPoints('navigation', $colonyId),
-        ];
+            /** @var Advisor|null $advisor */
+            $advisor     = $advisorsByPersonellId->get($personellId);
+            $isLocked    = $ccLevel < $position;
 
-        return view('advisors.index', compact(
-            'advisors', 'slotInfo', 'creditsByPersonellId', 'personellTypes', 'apInfo', 'colonyId'
-        ));
+            if ($isLocked) {
+                $state = 'locked';
+            } elseif ($advisor !== null) {
+                $isUnavailable = $advisor->unavailable_until_tick !== null
+                    && $advisor->unavailable_until_tick >= $currentTick;
+                $state = $isUnavailable ? 'unavailable' : 'active';
+            } else {
+                $state = 'empty';
+            }
+
+            $advisorData = null;
+            if ($advisor !== null) {
+                $isMaxRank      = $advisor->rank >= 3;
+                $nextThreshold  = $isMaxRank ? null : ($rankThresholds[$advisor->rank] ?? null);
+                $isUnavailable  = $advisor->unavailable_until_tick !== null
+                    && $advisor->unavailable_until_tick >= $currentTick;
+
+                if ($isMaxRank || $nextThreshold === null) {
+                    $progressPct = 100;
+                } else {
+                    $progressPct = min(100, (int) round($advisor->active_ticks / $nextThreshold * 100));
+                }
+
+                $advisorData = [
+                    'id'                     => $advisor->id,
+                    'rank'                   => $advisor->rank,
+                    'rank_name'              => match ($advisor->rank) {
+                        1       => 'Junior',
+                        2       => 'Senior',
+                        3       => 'Experte',
+                        default => '?',
+                    },
+                    'ap_per_tick'            => $advisor->getApPerTick(),
+                    'active_ticks'           => $advisor->active_ticks,
+                    'progress_pct'           => $progressPct,
+                    'next_rank_ticks'        => $nextThreshold,
+                    'is_max_rank'            => $isMaxRank,
+                    'is_unavailable'         => $isUnavailable,
+                    'unavailable_until_tick' => $advisor->unavailable_until_tick,
+                ];
+            }
+
+            $slots[] = [
+                'position'     => $position,
+                'key'          => $key,
+                'name'         => trans("advisors.{$key}"),
+                'personell_id' => $personellId,
+                'ap_type'      => $apType,
+                'hire_cost'    => $hireCost,
+                'cc_required'  => $position,
+                'state'        => $state,
+                'advisor'      => $advisorData,
+            ];
+        }
+
+        return $slots;
     }
 
-    public function hire(Request $request)
+    public function index(): View
+    {
+        $colonyId    = $this->resolveColonyId();
+        $currentTick = $this->getTick();
+
+        $advisors = $this->personellService->getColonyAdvisors($colonyId);
+        $slotInfo = $this->personellService->getAdvisorSlotInfo($colonyId);
+        $slots    = $this->buildSlots($advisors, $slotInfo, $currentTick);
+
+        $pageData = [
+            'slots'    => $slots,
+            'slotInfo' => $slotInfo,
+            'routes'   => [
+                'hire' => route('advisors.hire'),
+                'fire' => route('advisors.fire', ['id' => '__ID__']),
+            ],
+            'colonyId' => $colonyId,
+        ];
+
+        return view('advisors.index', compact('pageData'));
+    }
+
+    public function hire(Request $request): View|RedirectResponse|JsonResponse
     {
         $request->validate([
             'personell_id' => ['required', 'integer', \Illuminate\Validation\Rule::in(PersonellService::allIds())],
@@ -78,27 +171,60 @@ class AdvisorController extends BaseController
 
         if (is_string($result)) {
             $errorMessages = [
-                'duplicate'            => 'Für diesen Beratertyp ist bereits ein Berater auf dieser Kolonie aktiv.',
-                'slot_full'            => 'Kein freier Berater-Slot. Erhöhe das CommandCenter-Level.',
-                'insufficient_credits' => 'Nicht genug Credits, um diesen Berater einzustellen.',
+                'duplicate'            => __('advisors.error_duplicate'),
+                'slot_full'            => __('advisors.error_slot_full'),
+                'insufficient_credits' => __('advisors.error_insufficient_credits'),
             ];
-            return back()->with('error', $errorMessages[$result] ?? 'Berater konnte nicht eingestellt werden.');
+            $errorMessage = $errorMessages[$result] ?? __('advisors.error_generic');
+
+            if ($request->expectsJson()) {
+                return response()->json(['ok' => false, 'error' => $errorMessage], 422);
+            }
+            return back()->with('error', $errorMessage);
         }
 
-        return back()->with('success', 'Berater eingestellt.');
+        if ($request->expectsJson()) {
+            $currentTick = $this->getTick();
+            $advisors    = $this->personellService->getColonyAdvisors($colonyId);
+            $slotInfo    = $this->personellService->getAdvisorSlotInfo($colonyId);
+            return response()->json([
+                'ok'       => true,
+                'slots'    => $this->buildSlots($advisors, $slotInfo, $currentTick),
+                'slotInfo' => $slotInfo,
+            ]);
+        }
+
+        return back()->with('success', __('advisors.hired'));
     }
 
-    public function fire(int $advisorId)
+    public function fire(Request $request, int $id): RedirectResponse|JsonResponse
     {
-        $advisor = Advisor::where('id', $advisorId)
+        $advisor = Advisor::where('id', $id)
             ->where('user_id', $this->getCurrentUserId())
             ->first();
 
         if (!$advisor) {
+            if ($request->expectsJson()) {
+                return response()->json(['ok' => false, 'error' => 'Not found.'], 404);
+            }
             abort(404);
         }
 
-        $this->personellService->fire($advisorId);
-        return back()->with('success', 'Berater entlassen.');
+        $colonyId = (int) $advisor->colony_id;
+
+        $this->personellService->fire($id);
+
+        if ($request->expectsJson()) {
+            $currentTick = $this->getTick();
+            $advisors    = $this->personellService->getColonyAdvisors($colonyId);
+            $slotInfo    = $this->personellService->getAdvisorSlotInfo($colonyId);
+            return response()->json([
+                'ok'       => true,
+                'slots'    => $this->buildSlots($advisors, $slotInfo, $currentTick),
+                'slotInfo' => $slotInfo,
+            ]);
+        }
+
+        return back()->with('success', __('advisors.fired'));
     }
 }

--- a/lang/de/advisors.php
+++ b/lang/de/advisors.php
@@ -29,4 +29,12 @@ return [
     'ap_strategy'     => 'Strategie-AP',
     'ap_navigation'   => 'Navigations-AP',
 
+    // Flash / JSON response messages
+    'hired'                       => 'Berater eingestellt.',
+    'fired'                       => 'Berater entlassen.',
+    'error_duplicate'             => 'Für diesen Beratertyp ist bereits ein Berater auf dieser Kolonie aktiv.',
+    'error_slot_full'             => 'Kein freier Berater-Slot. Erhöhe das CommandCenter-Level.',
+    'error_insufficient_credits'  => 'Nicht genug Credits, um diesen Berater einzustellen.',
+    'error_generic'               => 'Berater konnte nicht eingestellt werden.',
+
 ];

--- a/public/css/advisors.css
+++ b/public/css/advisors.css
@@ -1,0 +1,394 @@
+/* Advisors carousel — Alpine.js + PicoCSS screen (Phase 3f) */
+
+/* ── Page wrapper ─────────────────────────────────────────────────────────── */
+
+.advisors-page {
+    padding: 1.5rem 1rem 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+/* ── Header bar ───────────────────────────────────────────────────────────── */
+
+.advisors-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.advisors-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--color-anthracite);
+}
+
+.slot-badge {
+    font-size: 0.78rem;
+    color: #888;
+    margin-left: auto;
+}
+
+/* ── AP type chips ────────────────────────────────────────────────────────── */
+
+/* .ap-chip is already defined in colony.css; this block adds the header variant
+   so they sit inline without the canvas-header background. */
+.advisors-header .ap-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
+    padding: 2px 8px;
+    border-radius: 20px;
+    background: #f0f0f0;
+    color: #555;
+}
+
+.advisors-header .ap-chip strong {
+    color: var(--color-anthracite);
+}
+
+/* ── Carousel layout ──────────────────────────────────────────────────────── */
+
+.carousel-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.carousel-viewport {
+    overflow: hidden;
+    flex: 1;
+}
+
+.carousel-track {
+    display: flex;
+    gap: 1rem;
+    transition: transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+/* Desktop: wrap cards into a centred row instead of sliding */
+@media (min-width: 900px) {
+    .carousel-track {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+}
+
+/* ── Nav arrows ───────────────────────────────────────────────────────────── */
+
+.carousel-arrow {
+    background: #fff;
+    border: 1px solid var(--color-border);
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    min-width: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+    color: var(--color-anthracite);
+    transition: background 0.15s;
+    flex-shrink: 0;
+}
+
+.carousel-arrow:hover:not(:disabled) {
+    background: #f0f0f0;
+}
+
+.carousel-arrow:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
+/* Arrows are only useful on mobile — hide on desktop */
+@media (min-width: 900px) {
+    .carousel-arrow {
+        display: none;
+    }
+}
+
+/* ── Dots (mobile pager) ──────────────────────────────────────────────────── */
+
+.carousel-dots {
+    display: flex;
+    gap: 6px;
+    justify-content: center;
+    margin-top: 0.5rem;
+}
+
+.carousel-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #ccc;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.carousel-dot--active {
+    background: var(--color-accent);
+}
+
+@media (min-width: 900px) {
+    .carousel-dots {
+        display: none;
+    }
+}
+
+/* ── Advisor card ─────────────────────────────────────────────────────────── */
+
+.advisor-card {
+    width: 200px;
+    aspect-ratio: 2 / 3;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    flex-shrink: 0;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (max-width: 900px) {
+    .advisor-card {
+        width: calc(100vw - 3rem);
+        max-width: 320px;
+    }
+}
+
+/* Highlighted card in the carousel (active index) */
+.advisor-card--current {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    transform: translateY(-2px);
+}
+
+/* Locked card: greyed out, non-interactive */
+.advisor-card--locked {
+    opacity: 0.45;
+    filter: grayscale(1);
+    pointer-events: none;
+}
+
+/* ── Portrait section (top 60%) ───────────────────────────────────────────── */
+
+.advisor-portrait {
+    flex: 0 0 60%;
+    background: linear-gradient(160deg, #e8eaf0 0%, #d0d4de 100%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+
+/* Large watermark initials rendered via CSS attr() */
+.advisor-portrait::before {
+    content: attr(data-initials);
+    font-size: 3.5rem;
+    font-weight: 900;
+    color: rgba(80, 80, 100, 0.2);
+    letter-spacing: -0.05em;
+    position: absolute;
+}
+
+/* Advisor type name centred on portrait, above the watermark */
+.advisor-type-label {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--color-anthracite);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-align: center;
+    padding: 0 0.5rem;
+    position: relative;
+    z-index: 1;
+}
+
+/* AP type chip anchored to the bottom of the portrait */
+.advisor-ap-chip {
+    position: absolute;
+    bottom: 0.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.72rem;
+    padding: 2px 8px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.75);
+    color: #555;
+    z-index: 1;
+}
+
+.advisor-ap-chip strong {
+    color: var(--color-anthracite);
+    font-weight: 700;
+}
+
+/* ── Stats section (bottom 40%) ───────────────────────────────────────────── */
+
+.advisor-stats {
+    flex: 1;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-size: 0.8rem;
+    border-top: 1px solid var(--color-border);
+}
+
+/* ── Stat rows ────────────────────────────────────────────────────────────── */
+
+.stat-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.stat-label {
+    color: #888;
+    font-size: 0.72rem;
+}
+
+.stat-value {
+    font-weight: 600;
+}
+
+/* ── Rank badge ───────────────────────────────────────────────────────────── */
+
+.rank-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 20px;
+    font-size: 0.68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.rank-badge--1 { background: #f0f0f0; color: #666; }
+.rank-badge--2 { background: #dbeafe; color: #1d4ed8; }
+.rank-badge--3 { background: #fef3c7; color: #92400e; }
+
+/* ── Progress bar (rank advancement) ─────────────────────────────────────── */
+
+.advisor-progress {
+    height: 5px;
+    background: #eee;
+    border-radius: 3px;
+    overflow: hidden;
+    margin-top: 2px;
+}
+
+.advisor-progress-fill {
+    height: 100%;
+    background: var(--color-accent);
+    border-radius: 3px;
+    transition: width 0.4s ease;
+}
+
+/* ── Status chip ──────────────────────────────────────────────────────────── */
+
+.advisor-status {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 7px;
+    border-radius: 20px;
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.advisor-status--active      { background: #e8f4e8; color: #2e7d32; border: 1px solid #a5d6a7; }
+.advisor-status--unavailable { background: #fef3c7; color: #78350f; border: 1px solid #fcd34d; }
+.advisor-status--empty       { background: #f0f4ff; color: #3b5ac6; border: 1px solid #b0c0e8; }
+.advisor-status--locked      { background: #f0f0f0; color: #999;    border: 1px solid #ddd; }
+
+/* ── Hire / fire action buttons inside cards ──────────────────────────────── */
+
+.advisor-card .btn-hire,
+.advisor-card .btn-fire {
+    width: 100%;
+    padding: 0.4rem;
+    font-size: 0.78rem;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+    margin-top: auto;
+}
+
+.btn-hire             { background: #e8f4e8; color: #2e7d32; }
+.btn-hire:hover       { background: #c8e6c9; }
+.btn-fire             { background: #fdecea; color: #c0392b; }
+.btn-fire:hover       { background: #f8d7da; }
+
+/* ── Hire / fire confirmation dialogs ─────────────────────────────────────── */
+
+dialog.advisor-dialog {
+    max-width: 360px;
+    width: 90%;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+    padding: 1.5rem;
+}
+
+dialog.advisor-dialog h3 {
+    margin: 0 0 1rem;
+    font-size: 1rem;
+}
+
+.dialog-cost {
+    font-size: 0.85rem;
+    color: #555;
+    margin-bottom: 1rem;
+}
+
+.dialog-cost strong {
+    color: var(--color-anthracite);
+}
+
+.dialog-actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-top: 1rem;
+}
+
+.dialog-actions button {
+    padding: 0.4rem 1rem;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.btn-confirm-hire       { background: #2e7d32; color: #fff; }
+.btn-confirm-hire:hover { background: #1b5e20; }
+.btn-confirm-fire       { background: #c0392b; color: #fff; }
+.btn-confirm-fire:hover { background: #96241a; }
+.btn-cancel             { background: #f0f0f0; color: #555; }
+.btn-cancel:hover       { background: #e0e0e0; }
+
+.dialog-error {
+    color: #c0392b;
+    font-size: 0.8rem;
+    margin-top: 0.5rem;
+    min-height: 1em;
+}

--- a/public/css/advisors.css
+++ b/public/css/advisors.css
@@ -3,9 +3,8 @@
 /* ── Page wrapper ─────────────────────────────────────────────────────────── */
 
 .advisors-page {
-    padding: 1.5rem 1rem 2rem;
-    max-width: 1100px;
-    margin: 0 auto;
+    padding: 1.5rem 2rem 2rem;
+    max-width: none;
 }
 
 /* ── Header bar ───────────────────────────────────────────────────────────── */
@@ -72,11 +71,17 @@
     transition: transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
-/* Desktop: wrap cards into a centred row instead of sliding */
+/* Desktop: all 5 cards in a single row, no wrapping */
 @media (min-width: 900px) {
     .carousel-track {
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         justify-content: center;
+    }
+    .advisor-card {
+        flex: 1 1 0;
+        width: auto;
+        min-width: 0;
+        max-width: 380px;
     }
 }
 
@@ -150,7 +155,7 @@
 
 .advisor-card {
     width: 200px;
-    aspect-ratio: 2 / 3;
+    min-height: 440px;
     border-radius: 10px;
     border: 1px solid var(--color-border);
     background: #fff;
@@ -164,7 +169,8 @@
 @media (max-width: 900px) {
     .advisor-card {
         width: calc(100vw - 3rem);
-        max-width: 320px;
+        max-width: 340px;
+        min-height: 420px;
     }
 }
 
@@ -184,7 +190,7 @@
 /* ── Portrait section (top 60%) ───────────────────────────────────────────── */
 
 .advisor-portrait {
-    flex: 0 0 60%;
+    flex: 0 0 220px;
     background: linear-gradient(160deg, #e8eaf0 0%, #d0d4de 100%);
     display: flex;
     flex-direction: column;

--- a/public/js/advisors.js
+++ b/public/js/advisors.js
@@ -1,0 +1,172 @@
+/**
+ * advisors.js — Alpine.js component for the advisor carousel screen.
+ *
+ * Manages a 5-slot advisor carousel with hire/fire dialogs.
+ * Data is injected server-side via window.__advisorData (set in the Blade view).
+ *
+ * @param {object} config - Matches the $pageData structure from AdvisorController.
+ */
+function advisorCarousel(config) {
+    return {
+        slots:       config.slots,
+        slotInfo:    config.slotInfo,
+        routes:      config.routes,
+        activeIndex: 0,
+        isMobile:    false,
+        touchStartX: 0,
+        touchStartY: 0,
+        dialogSlot:  null,
+        errorMsg:    null,
+
+        init() {
+            this.checkBreakpoint();
+            window.addEventListener('resize', () => this.checkBreakpoint());
+        },
+
+        checkBreakpoint() {
+            this.isMobile = window.innerWidth < 900;
+        },
+
+        prev() {
+            if (this.activeIndex > 0) this.activeIndex--;
+        },
+
+        next() {
+            if (this.activeIndex < this.slots.length - 1) this.activeIndex++;
+        },
+
+        goTo(i) {
+            this.activeIndex = i;
+        },
+
+        /**
+         * Returns the inline style string for the carousel track.
+         * On desktop the track wraps naturally; on mobile it slides by card width + gap.
+         */
+        trackStyle() {
+            if (!this.isMobile) return '';
+            const cardWidth = Math.min(window.innerWidth - 48, 320);
+            const gap = 16; // 1rem in px
+            const offset = this.activeIndex * (cardWidth + gap);
+            return `transform: translateX(-${offset}px)`;
+        },
+
+        onTouchStart(e) {
+            this.touchStartX = e.touches[0].clientX;
+            this.touchStartY = e.touches[0].clientY;
+        },
+
+        onTouchEnd(e) {
+            const dx = e.changedTouches[0].clientX - this.touchStartX;
+            const dy = e.changedTouches[0].clientY - this.touchStartY;
+            if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 40) {
+                if (dx < 0) this.next();
+                else this.prev();
+            }
+        },
+
+        openHireDialog(slot) {
+            this.dialogSlot = slot;
+            this.errorMsg = null;
+            this.$nextTick(() => this.$refs.hireDialog.showModal());
+        },
+
+        openFireDialog(slot) {
+            this.dialogSlot = slot;
+            this.errorMsg = null;
+            this.$nextTick(() => this.$refs.fireDialog.showModal());
+        },
+
+        closeDialogs() {
+            this.$refs.hireDialog?.close();
+            this.$refs.fireDialog?.close();
+            this.dialogSlot = null;
+            this.errorMsg = null;
+        },
+
+        async doHire() {
+            const res = await this.post(this.routes.hire, {
+                personell_id: this.dialogSlot.personell_id,
+            });
+            if (res.ok) {
+                this.slots    = res.slots;
+                this.slotInfo = res.slotInfo;
+                this.closeDialogs();
+            } else {
+                this.errorMsg = res.error ?? 'Fehler beim Einstellen.';
+            }
+        },
+
+        async doFire() {
+            const url = this.routes.fire.replace('__ID__', this.dialogSlot.advisor.id);
+            const res = await this.delete(url);
+            if (res.ok) {
+                this.slots    = res.slots;
+                this.slotInfo = res.slotInfo;
+                this.closeDialogs();
+            } else {
+                this.errorMsg = res.error ?? 'Fehler beim Entlassen.';
+            }
+        },
+
+        /**
+         * Returns the human-readable AP type label for a given ap_type key.
+         * @param {string} type
+         * @returns {string}
+         */
+        apTypeLabel(type) {
+            const labels = {
+                construction: 'Bau-AP',
+                research:     'Forschungs-AP',
+                navigation:   'Navigations-AP',
+                economy:      'Wirtschafts-AP',
+                strategy:     'Strategie-AP',
+            };
+            return labels[type] ?? type;
+        },
+
+        /**
+         * Returns the two-letter initials displayed as a watermark in the portrait area.
+         * @param {string} key - Advisor type key (engineer, scientist, pilot, trader, stratege)
+         * @returns {string}
+         */
+        portraitInitials(key) {
+            const map = {
+                engineer:  'Ba',
+                scientist: 'An',
+                pilot:     'Rf',
+                trader:    'Ko',
+                stratege:  'St',
+            };
+            return map[key] ?? key.substring(0, 2).toUpperCase();
+        },
+
+        _csrf() {
+            return document.querySelector('meta[name="csrf-token"]')?.content ?? '';
+        },
+
+        post(url, data) {
+            return fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type':     'application/json',
+                    'X-CSRF-TOKEN':     this._csrf(),
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'Accept':           'application/json',
+                },
+                body: JSON.stringify(data),
+            }).then(r => r.json());
+        },
+
+        delete(url) {
+            return fetch(url, {
+                method: 'DELETE',
+                headers: {
+                    'X-CSRF-TOKEN':     this._csrf(),
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'Accept':           'application/json',
+                },
+            }).then(r => r.json());
+        },
+    };
+}

--- a/public/js/advisors.js
+++ b/public/js/advisors.js
@@ -8,9 +8,10 @@
  */
 function advisorCarousel(config) {
     return {
-        slots:       config.slots,
-        slotInfo:    config.slotInfo,
-        routes:      config.routes,
+        slots:        config.slots,
+        slotInfo:     config.slotInfo,
+        routes:       config.routes,
+        juniorUpkeep: config.junior_upkeep ?? 10,
         activeIndex: 0,
         isMobile:    false,
         touchStartX: 0,

--- a/resources/views/advisors/index.blade.php
+++ b/resources/views/advisors/index.blade.php
@@ -1,288 +1,215 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 @section('title', 'Berater — Nouron')
 
+@push('styles')
+    <link rel="stylesheet" href="{{ asset('css/advisors.css') }}">
+@endpush
+
+@push('scripts')
+    <script src="{{ asset('js/advisors.js') }}"></script>
+@endpush
+
 @section('content')
-<div id="advisors">
+<script>window.__advisorData = @json($pageData)</script>
 
-{{-- Flash messages --}}
-@if(session('success'))
-<div class="alert alert-success alert-dismissible fade show" role="alert">
-    {{ session('success') }}
-    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-</div>
-@endif
-@if(session('error'))
-<div class="alert alert-danger alert-dismissible fade show" role="alert">
-    {{ session('error') }}
-    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-</div>
-@endif
+<div class="advisors-page" x-data="advisorCarousel(window.__advisorData)" x-cloak>
 
-{{-- Compact status line --}}
-<div class="d-flex flex-wrap gap-3 align-items-center text-muted small mb-4">
-    <span><i class="bi bi-hammer"></i> <strong>{{ $apInfo['construction'] }}</strong> Bau-AP</span>
-    <span class="text-muted opacity-50">·</span>
-    <span><i class="bi bi-microscope"></i> <strong>{{ $apInfo['research'] }}</strong> Forschungs-AP</span>
-    <span class="text-muted opacity-50">·</span>
-    <span><i class="bi bi-cart3"></i> <strong>{{ $apInfo['economy'] }}</strong> Wirtschafts-AP</span>
-    <span class="text-muted opacity-50">·</span>
-    <span><i class="bi bi-diagram-3"></i> <strong>{{ $apInfo['strategy'] }}</strong> Strategie-AP</span>
-    <span class="text-muted opacity-50">·</span>
-    <span><i class="bi bi-rocket"></i> <strong>{{ $apInfo['navigation'] }}</strong> Navigations-AP</span>
-    <span class="ms-auto">
-        <i class="bi bi-person-badge"></i>
-        Slots: <strong>{{ $slotInfo['used'] }}/{{ $slotInfo['max'] }}</strong>
-        <span class="text-muted">(CC Lv{{ $slotInfo['cc_level'] }})</span>
-    </span>
-</div>
+    {{-- ── Header bar ──────────────────────────────────────────────────────── --}}
+    <div class="advisors-header">
+        <h2>Berater</h2>
 
-{{-- Group definitions --}}
-@php
-    $rankNames  = [1 => 'Junior', 2 => 'Senior', 3 => 'Experte'];
-    $rankThresh = config('game.advisor.rank_thresholds', [1 => 10, 2 => 20]);
-
-    $colonySections = [
-        [
-            'personell_id' => config('advisors.engineer.id'),
-            'key'          => 'engineer',
-            'icon'         => 'bi-hammer',
-            'border'       => 'border-primary',
-            'bg'           => 'bg-primary bg-opacity-10',
-            'ap_type'      => config('advisors.engineer.ap_type'),
-        ],
-        [
-            'personell_id' => config('advisors.scientist.id'),
-            'key'          => 'scientist',
-            'icon'         => 'bi-microscope',
-            'border'       => 'border-success',
-            'bg'           => 'bg-success bg-opacity-10',
-            'ap_type'      => config('advisors.scientist.ap_type'),
-        ],
-        [
-            'personell_id' => config('advisors.trader.id'),
-            'key'          => 'trader',
-            'icon'         => 'bi-cart3',
-            'border'       => 'border-warning',
-            'bg'           => 'bg-warning bg-opacity-10',
-            'ap_type'      => config('advisors.trader.ap_type'),
-        ],
-        [
-            'personell_id' => config('advisors.stratege.id'),
-            'key'          => 'stratege',
-            'icon'         => 'bi-diagram-3',
-            'border'       => 'border-danger',
-            'bg'           => 'bg-danger bg-opacity-10',
-            'ap_type'      => config('advisors.stratege.ap_type'),
-        ],
-        [
-            'personell_id' => config('advisors.pilot.id'),
-            'key'          => 'pilot',
-            'icon'         => 'bi-rocket',
-            'border'       => 'border-info',
-            'bg'           => 'bg-info bg-opacity-10',
-            'ap_type'      => config('advisors.pilot.ap_type'),
-        ],
-    ];
-
-    $grouped = $advisors->groupBy('personell_id');
-@endphp
-
-{{-- Section header with hire button --}}
-<div class="d-flex justify-content-between align-items-center mb-3">
-    <h4 class="mb-0">Aktive Berater</h4>
-    @if($slotInfo['free'] > 0)
-    <button type="button" class="btn btn-sm btn-success"
-            data-bs-toggle="modal" data-bs-target="#modal-hire-advisor">
-        <i class="bi bi-person-plus"></i> Berater einstellen
-    </button>
-    @else
-    <span class="text-muted small">
-        <i class="bi bi-exclamation-triangle"></i>
-        Keine freien Slots — CC Level {{ $slotInfo['cc_level'] }} erlaubt max. {{ $slotInfo['max'] }} Berater
-    </span>
-    @endif
-</div>
-
-{{-- Colony advisor cards (2-per-row on desktop) --}}
-<div class="row row-cols-1 row-cols-md-2 g-4 mb-4">
-
-@foreach($colonySections as $section)
-@php
-    $sectionAdvisors = $grouped->get($section['personell_id'], collect());
-    $totalAp         = $sectionAdvisors->sum(fn($a) => $a->getApPerTick());
-    $creditsCost     = $creditsByPersonellId->get($section['personell_id'], 0);
-    $hasAdvisor      = $sectionAdvisors->isNotEmpty();
-@endphp
-<div class="col">
-    <div class="card h-100">
-        <div class="card-header d-flex justify-content-between align-items-center py-2">
-            <span class="fw-semibold">
-                <i class="bi {{ $section['icon'] }}"></i> {{ __('advisors.' . $section['key'] . '_plural') }}
-            </span>
-            <span class="d-flex align-items-center gap-2">
-                <small class="text-muted">{{ __('advisors.ap_' . $section['ap_type']) }}:</small>
-                <span class="fw-bold">{{ $totalAp }} AP/Tick</span>
-            </span>
+        {{-- AP type chips — one per slot showing ap_type label --}}
+        <div style="display:flex;gap:0.5rem;flex-wrap:wrap">
+            <template x-for="slot in slots" :key="'chip-' + slot.key">
+                <span class="ap-chip" x-show="slot.state === 'active'">
+                    <strong x-text="apTypeLabel(slot.ap_type)"></strong>
+                    <span x-text="slot.advisor ? slot.advisor.ap_per_tick + ' AP' : ''"></span>
+                </span>
+            </template>
         </div>
-        <div class="card-body p-0">
-            @if(!$hasAdvisor)
-            <p class="text-muted small p-3 mb-0">
-                Keine {{ __('advisors.' . $section['key'] . '_plural') }} aktiv.
-                @if($slotInfo['free'] > 0)
-                <a href="#" data-bs-toggle="modal" data-bs-target="#modal-hire-advisor"
-                   data-personell-id="{{ $section['personell_id'] }}">Jetzt einstellen</a>
-                @endif
-            </p>
-            @else
-            <table class="table table-sm table-hover align-middle mb-0">
-                <thead class="table-light">
-                    <tr>
-                        <th>Rang</th>
-                        <th class="text-center">AP/Tick</th>
-                        <th class="text-center">Ticks</th>
-                        <th class="text-center">Aufstieg</th>
-                        <th class="text-center">Status</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                @foreach($sectionAdvisors as $advisor)
-                @php
-                    $nextRankTicks = $rankThresh[$advisor->rank] ?? null;
-                    $progress      = $nextRankTicks
-                        ? min(100, (int) round($advisor->active_ticks / $nextRankTicks * 100))
-                        : 100;
-                    $rankBadge = match($advisor->rank) {
-                        1       => ['Junior',  'bg-secondary'],
-                        2       => ['Senior',  'bg-info text-dark'],
-                        3       => ['Experte', 'bg-warning text-dark'],
-                        default => [$rankNames[$advisor->rank] ?? '?', 'bg-secondary'],
-                    };
-                @endphp
-                <tr>
-                    <td><span class="badge {{ $rankBadge[1] }}">{{ $rankBadge[0] }}</span></td>
-                    <td class="text-center fw-semibold">{{ $advisor->getApPerTick() }}</td>
-                    <td class="text-center text-muted small">{{ $advisor->active_ticks }}</td>
-                    <td class="text-center" style="min-width:100px">
-                        @if($advisor->rank < 3 && $nextRankTicks)
-                        <div class="progress" style="height:6px"
-                             title="{{ $advisor->active_ticks }}/{{ $nextRankTicks }} Ticks">
-                            <div class="progress-bar" style="width:{{ $progress }}%"></div>
+
+        <span class="slot-badge">
+            Slots: <strong x-text="slotInfo.used + '/' + slotInfo.max"></strong>
+            <span x-text="'(CC Lv' + slotInfo.cc_level + ')'"></span>
+        </span>
+    </div>
+
+    {{-- ── Carousel ─────────────────────────────────────────────────────────── --}}
+    <div class="carousel-wrapper">
+
+        <button class="carousel-arrow"
+                @click="prev()"
+                :disabled="activeIndex === 0"
+                aria-label="Vorheriger Berater">&#8249;</button>
+
+        <div class="carousel-viewport"
+             @touchstart.passive="onTouchStart($event)"
+             @touchend.passive="onTouchEnd($event)">
+
+            <div class="carousel-track" :style="trackStyle()">
+
+                <template x-for="(slot, i) in slots" :key="slot.key">
+                    <div class="advisor-card"
+                         :class="{
+                             'advisor-card--locked':  slot.state === 'locked',
+                             'advisor-card--current': i === activeIndex
+                         }">
+
+                        {{-- Portrait area --}}
+                        <div class="advisor-portrait" :data-initials="portraitInitials(slot.key)">
+                            <div class="advisor-type-label" x-text="slot.name"></div>
+                            <div class="advisor-ap-chip">
+                                <strong x-text="apTypeLabel(slot.ap_type)"></strong>
+                            </div>
                         </div>
-                        <span class="text-muted" style="font-size:0.7rem">
-                            {{ $advisor->active_ticks }}/{{ $nextRankTicks }}
-                        </span>
-                        @else
-                        <span class="badge bg-warning text-dark" style="font-size:0.65rem">Max</span>
-                        @endif
-                    </td>
-                    <td class="text-center">
-                        @if($advisor->unavailable_until_tick)
-                            <span class="badge bg-warning text-dark" style="font-size:0.65rem">
-                                Inaktiv bis T{{ $advisor->unavailable_until_tick }}
-                            </span>
-                        @else
-                            <span class="badge bg-success" style="font-size:0.65rem">Aktiv</span>
-                        @endif
-                    </td>
-                    <td class="text-end">
-                        <form method="POST" action="{{ route('advisors.fire', $advisor->id) }}"
-                              onsubmit="return confirm('Berater wirklich entlassen?')">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"
-                                    title="Entlassen">
-                                <i class="bi bi-person-dash"></i>
-                            </button>
-                        </form>
-                    </td>
-                </tr>
-                @endforeach
-                </tbody>
-            </table>
-            @endif
-        </div>
-        @if($hasAdvisor)
-        <div class="card-footer py-1 d-flex justify-content-end align-items-center">
-            <small class="text-muted">
-                <strong>{{ $totalAp }} AP/Tick</strong>
-            </small>
-        </div>
-        @endif
+
+                        {{-- Stats / state section --}}
+                        <div class="advisor-stats">
+
+                            {{-- ACTIVE or UNAVAILABLE: advisor object is present --}}
+                            <template x-if="slot.advisor !== null">
+                                <div style="display:flex;flex-direction:column;gap:0.4rem;height:100%">
+
+                                    <div class="stat-row">
+                                        <span class="stat-label">Rang</span>
+                                        <span class="rank-badge"
+                                              :class="'rank-badge--' + slot.advisor.rank"
+                                              x-text="slot.advisor.rank_name"></span>
+                                    </div>
+
+                                    <div class="stat-row">
+                                        <span class="stat-label">AP/Tick</span>
+                                        <span class="stat-value" x-text="slot.advisor.ap_per_tick"></span>
+                                    </div>
+
+                                    <div class="stat-row">
+                                        <span class="stat-label">Ticks</span>
+                                        <span class="stat-value" x-text="slot.advisor.active_ticks"></span>
+                                    </div>
+
+                                    {{-- Rank advancement progress --}}
+                                    <div>
+                                        <div class="stat-row" style="margin-bottom:2px">
+                                            <span class="stat-label">Aufstieg</span>
+                                            <span class="stat-label"
+                                                  x-text="slot.advisor.is_max_rank
+                                                      ? 'Max'
+                                                      : (slot.advisor.active_ticks + '/' + slot.advisor.next_rank_ticks)">
+                                            </span>
+                                        </div>
+                                        <div class="advisor-progress">
+                                            <div class="advisor-progress-fill"
+                                                 :style="{ width: slot.advisor.progress_pct + '%' }"></div>
+                                        </div>
+                                    </div>
+
+                                    {{-- Status chip + fire button --}}
+                                    <div class="stat-row" style="margin-top:auto">
+                                        <span class="advisor-status"
+                                              :class="slot.advisor.is_unavailable
+                                                  ? 'advisor-status--unavailable'
+                                                  : 'advisor-status--active'"
+                                              x-text="slot.advisor.is_unavailable
+                                                  ? ('Inaktiv bis T' + slot.advisor.unavailable_until_tick)
+                                                  : 'Aktiv'">
+                                        </span>
+                                        <button class="btn-fire" @click="openFireDialog(slot)">Entlassen</button>
+                                    </div>
+
+                                </div>
+                            </template>
+
+                            {{-- EMPTY: slot is available, no advisor hired yet --}}
+                            <template x-if="slot.advisor === null && slot.state === 'empty'">
+                                <div style="display:flex;flex-direction:column;gap:0.5rem;height:100%">
+
+                                    <span class="advisor-status advisor-status--empty">Vakant</span>
+
+                                    <div class="stat-row">
+                                        <span class="stat-label">Einstellungskosten</span>
+                                        <span class="stat-value" x-text="slot.hire_cost + ' Cr'"></span>
+                                    </div>
+
+                                    <div class="stat-label" style="font-size:0.7rem;color:#aaa">
+                                        Junior &middot; 4 AP/Tick
+                                    </div>
+
+                                    <button class="btn-hire"
+                                            style="margin-top:auto"
+                                            @click="openHireDialog(slot)">Einstellen</button>
+
+                                </div>
+                            </template>
+
+                            {{-- LOCKED: CC level too low to unlock this slot --}}
+                            <template x-if="slot.state === 'locked'">
+                                <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:0.4rem;color:#aaa;text-align:center">
+                                    <span style="font-size:1.5rem">&#128274;</span>
+                                    <span class="advisor-status advisor-status--locked">Gesperrt</span>
+                                    <span style="font-size:0.72rem">
+                                        CC Level <strong x-text="slot.cc_required"></strong> erforderlich
+                                    </span>
+                                </div>
+                            </template>
+
+                        </div>{{-- /.advisor-stats --}}
+                    </div>{{-- /.advisor-card --}}
+                </template>
+
+            </div>{{-- /.carousel-track --}}
+        </div>{{-- /.carousel-viewport --}}
+
+        <button class="carousel-arrow"
+                @click="next()"
+                :disabled="activeIndex >= slots.length - 1"
+                aria-label="Nächster Berater">&#8250;</button>
+
+    </div>{{-- /.carousel-wrapper --}}
+
+    {{-- Pagination dots (mobile only, hidden on desktop via CSS) --}}
+    <div class="carousel-dots">
+        <template x-for="(slot, i) in slots" :key="'dot-' + i">
+            <button class="carousel-dot"
+                    :class="{ 'carousel-dot--active': i === activeIndex }"
+                    @click="goTo(i)"
+                    :aria-label="slot.name"></button>
+        </template>
     </div>
-</div>
-@endforeach
 
-</div>{{-- /.row --}}
-
-</div>{{-- #advisors --}}
-
-{{-- Hire modal --}}
-<div class="modal fade" id="modal-hire-advisor" tabindex="-1">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Berater einstellen</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+    {{-- ── Hire confirmation dialog ─────────────────────────────────────────── --}}
+    <dialog class="advisor-dialog" x-ref="hireDialog" @close="closeDialogs()">
+        <h3>Berater einstellen</h3>
+        <template x-if="dialogSlot">
+            <div>
+                <p class="dialog-cost">
+                    <strong x-text="dialogSlot.name"></strong> &middot; Junior &middot; 4 AP/Tick<br>
+                    Kosten: <strong x-text="dialogSlot.hire_cost + ' Cr'"></strong>
+                </p>
+                <div class="dialog-error" x-text="errorMsg"></div>
+                <div class="dialog-actions">
+                    <button class="btn-cancel" @click="closeDialogs()">Abbrechen</button>
+                    <button class="btn-confirm-hire" @click="doHire()">Einstellen</button>
+                </div>
             </div>
-            <form method="POST" action="{{ route('advisors.hire') }}">
-                @csrf
-                <div class="modal-body">
-                    <p class="text-muted small">
-                        Neue Berater starten als Junior ({{ config('game.advisor.ap_per_rank.1', 4) }} AP/Tick).
-                        Slots belegt: <strong>{{ $slotInfo['used'] }}/{{ $slotInfo['max'] }}</strong>
-                        (CC Lv{{ $slotInfo['cc_level'] }}).
-                    </p>
-                    <div class="mb-3">
-                        <label for="personell_id" class="form-label">Typ</label>
-                        <select name="personell_id" id="personell_id" class="form-select" required>
-                            @foreach($personellTypes as $pId => $pType)
-                            @php
-                                $apLabel = match($pType->name) {
-                                    'techs_engineer'  => 'Bau-AP',
-                                    'techs_scientist' => 'Forschungs-AP',
-                                    'techs_trader'    => 'Wirtschafts-AP',
-                                    'techs_stratege'  => 'Strategie-AP',
-                                    'techs_pilot'     => 'Navigations-AP',
-                                    default           => '',
-                                };
-                                $label = __('techtree.' . $pType->name) . ($apLabel ? ' (' . $apLabel . ')' : '');
-                                $cost = $creditsByPersonellId->get($pId, 0);
-                                $alreadyHired = $advisors->contains('personell_id', $pId);
-                            @endphp
-                            <option value="{{ $pId }}" @if($alreadyHired) disabled @endif>
-                                {{ $label }}
-                                — @include('partials.res_chip', ['abbreviation' => 'Cr', 'amount' => number_format($cost, 0, ',', '.')])
-                                @if($alreadyHired) (bereits eingestellt) @endif
-                            </option>
-                            @endforeach
-                        </select>
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
-                    <button type="submit" class="btn btn-success">
-                        <i class="bi bi-person-plus"></i> Einstellen
-                    </button>
-                </div>
-            </form>
-        </div>
-    </div>
-</div>
+        </template>
+    </dialog>
 
-<script>
-// Pre-select the type in the hire modal when clicking "Jetzt einstellen" links
-document.addEventListener('DOMContentLoaded', function () {
-    document.querySelectorAll('[data-personell-id]').forEach(function (el) {
-        el.addEventListener('click', function () {
-            var pId = this.getAttribute('data-personell-id');
-            var sel = document.getElementById('personell_id');
-            if (sel && pId) {
-                sel.value = pId;
-            }
-        });
-    });
-});
-</script>
+    {{-- ── Fire confirmation dialog ─────────────────────────────────────────── --}}
+    <dialog class="advisor-dialog" x-ref="fireDialog" @close="closeDialogs()">
+        <h3>Berater entlassen</h3>
+        <template x-if="dialogSlot">
+            <div>
+                <p class="dialog-cost">
+                    <strong x-text="dialogSlot.name"></strong> wirklich entlassen?
+                </p>
+                <div class="dialog-error" x-text="errorMsg"></div>
+                <div class="dialog-actions">
+                    <button class="btn-cancel" @click="closeDialogs()">Abbrechen</button>
+                    <button class="btn-confirm-fire" @click="doFire()">Entlassen</button>
+                </div>
+            </div>
+        </template>
+    </dialog>
 
+</div>{{-- /.advisors-page --}}
 @endsection

--- a/resources/views/advisors/index.blade.php
+++ b/resources/views/advisors/index.blade.php
@@ -87,6 +87,11 @@
                                         <span class="stat-value" x-text="slot.advisor.active_ticks"></span>
                                     </div>
 
+                                    <div class="stat-row">
+                                        <span class="stat-label">Unterhalt</span>
+                                        <span class="stat-value" x-text="slot.advisor.upkeep + ' Cr/Tick'"></span>
+                                    </div>
+
                                     {{-- Rank advancement progress --}}
                                     <div>
                                         <div class="stat-row" style="margin-bottom:2px">
@@ -130,8 +135,14 @@
                                         <span class="stat-value" x-text="slot.hire_cost + ' Cr'"></span>
                                     </div>
 
-                                    <div class="stat-label" style="font-size:0.7rem;color:#aaa">
-                                        Junior &middot; 4 AP/Tick
+                                    <div class="stat-row">
+                                        <span class="stat-label">AP/Tick (Junior)</span>
+                                        <span class="stat-value">4</span>
+                                    </div>
+
+                                    <div class="stat-row">
+                                        <span class="stat-label">Unterhalt</span>
+                                        <span class="stat-value" x-text="juniorUpkeep + ' Cr/Tick'"></span>
                                     </div>
 
                                     <button class="btn-hire"

--- a/tests/Feature/Techtree/AdvisorControllerTest.php
+++ b/tests/Feature/Techtree/AdvisorControllerTest.php
@@ -1,0 +1,483 @@
+<?php
+
+namespace Tests\Feature\Techtree;
+
+/**
+ * AdvisorController feature tests.
+ *
+ * Covered scenarios:
+ *  INDEX
+ *    - test_index_returns_200
+ *    - test_index_passes_page_data_with_five_slots
+ *    - test_index_slots_have_correct_cc_required_values
+ *    - test_locked_slots_when_cc_level_three
+ *
+ *  HIRE — redirect branch
+ *    - test_hire_redirects_on_success
+ *    - test_hire_fails_for_unknown_personell_id
+ *
+ *  HIRE — JSON branch
+ *    - test_hire_returns_json_on_ajax_request
+ *    - test_hire_json_returns_422_on_duplicate
+ *
+ *  FIRE — redirect branch
+ *    - test_fire_redirects_on_success
+ *    - test_fire_returns_404_for_foreign_advisor
+ *
+ *  FIRE — JSON branch
+ *    - test_fire_returns_json_on_ajax_request
+ *    - test_fire_json_returns_404_for_foreign_advisor
+ */
+
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AdvisorControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Fixture constants ─────────────────────────────────────────────────────
+
+    protected int $userIdBart  = 3;   // owns colony 1 (Springfield), CC level 3
+    protected int $userIdHomer = 0;   // owns advisors on colony 2 (Shelbyville)
+    protected int $colonyIdBart  = 1;
+    protected int $colonyIdHomer = 2;
+
+    // personell_id values from config/advisors.php
+    protected int $personellEngineer  = 35;
+    protected int $personellScientist = 36;
+    protected int $personellPilot     = 89;
+    protected int $personellTrader    = 92;
+    protected int $personellStratege  = 93;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Return a request session carrying the active colony for Bart.
+     */
+    private function bartSession(): array
+    {
+        return ['activeIds' => ['colonyId' => $this->colonyIdBart]];
+    }
+
+    /**
+     * Remove all advisors for Bart's colony so hire tests start from zero.
+     */
+    private function clearBartAdvisors(): void
+    {
+        DB::table('advisors')
+            ->where('colony_id', $this->colonyIdBart)
+            ->delete();
+    }
+
+    /**
+     * Hire one advisor for Bart directly via DB (bypasses credit cost) and
+     * return the new advisor id.
+     */
+    private function insertAdvisor(int $userId, int $personellId, int $colonyId, int $rank = 1): int
+    {
+        return DB::table('advisors')->insertGetId([
+            'user_id'               => $userId,
+            'personell_id'          => $personellId,
+            'colony_id'             => $colonyId,
+            'rank'                  => $rank,
+            'active_ticks'          => 0,
+            'unavailable_until_tick' => null,
+        ]);
+    }
+
+    /**
+     * Ensure Bart's user_resources row has enough credits for hiring.
+     */
+    private function ensureCredits(int $userId, int $credits): void
+    {
+        DB::table('user_resources')
+            ->where('user_id', $userId)
+            ->update(['credits' => $credits]);
+    }
+
+    // ── INDEX tests ───────────────────────────────────────────────────────────
+
+    public function test_index_returns_200(): void
+    {
+        $bart = User::find($this->userIdBart);
+
+        $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->getJson(route('advisors.index'))
+            ->assertOk();
+    }
+
+    public function test_index_passes_page_data_with_five_slots(): void
+    {
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->get(route('advisors.index'));
+
+        $response->assertOk();
+        $response->assertViewHas('pageData');
+
+        $pageData = $response->viewData('pageData');
+
+        $this->assertArrayHasKey('slots', $pageData);
+        $this->assertArrayHasKey('slotInfo', $pageData);
+        $this->assertArrayHasKey('routes', $pageData);
+        $this->assertArrayHasKey('colonyId', $pageData);
+
+        $slots = $pageData['slots'];
+        $this->assertCount(5, $slots, 'There must be exactly 5 advisor slots');
+
+        $requiredKeys = ['position', 'key', 'name', 'state', 'personell_id', 'hire_cost', 'cc_required', 'advisor'];
+        foreach ($slots as $i => $slot) {
+            foreach ($requiredKeys as $key) {
+                $this->assertArrayHasKey($key, $slot, "Slot {$i} is missing key '{$key}'");
+            }
+        }
+    }
+
+    public function test_index_slots_have_correct_cc_required_values(): void
+    {
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->get(route('advisors.index'));
+
+        $slots = $response->viewData('pageData')['slots'];
+
+        // cc_required for each slot must equal its position (1–5)
+        foreach ($slots as $slot) {
+            $this->assertEquals(
+                $slot['position'],
+                $slot['cc_required'],
+                "Slot position {$slot['position']} must require CC level {$slot['position']}"
+            );
+        }
+    }
+
+    /**
+     * Bart's colony 1 has CC level 3.
+     * Slots 1–3 should be 'active' or 'empty'; slots 4–5 must be 'locked'.
+     * The test data pre-seeds advisors 35, 36, 92, 93 for Bart on colony 1.
+     * We clear them so all unlocked slots appear as 'empty', which is the
+     * clean baseline state the task description calls "test_locked_slots_when_cc_level_one".
+     * Since the actual CC level in test data is 3, we test with that real value.
+     */
+    public function test_locked_slots_when_cc_level_three(): void
+    {
+        $this->clearBartAdvisors();
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->get(route('advisors.index'));
+
+        $slots = $response->viewData('pageData')['slots'];
+
+        // Slots 1–3 must NOT be locked (CC=3 grants them)
+        foreach (array_slice($slots, 0, 3) as $slot) {
+            $this->assertNotEquals('locked', $slot['state'],
+                "Slot {$slot['position']} should not be locked with CC level 3");
+        }
+
+        // Slots 4–5 must be locked
+        foreach (array_slice($slots, 3, 2) as $slot) {
+            $this->assertEquals('locked', $slot['state'],
+                "Slot {$slot['position']} must be locked with CC level 3");
+        }
+    }
+
+    public function test_index_slot_state_is_empty_when_no_advisor_hired(): void
+    {
+        $this->clearBartAdvisors();
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->get(route('advisors.index'));
+
+        $slots = $response->viewData('pageData')['slots'];
+
+        // First unlocked slot (engineer / position 1) must be 'empty'
+        $this->assertEquals('empty', $slots[0]['state'],
+            'Engineer slot must be empty when no advisor is hired');
+    }
+
+    public function test_index_slot_state_is_active_when_advisor_is_hired(): void
+    {
+        $this->clearBartAdvisors();
+        $this->insertAdvisor($this->userIdBart, $this->personellEngineer, $this->colonyIdBart);
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->get(route('advisors.index'));
+
+        $slots = $response->viewData('pageData')['slots'];
+
+        // engineer is position 1 (index 0)
+        $engineerSlot = $slots[0];
+        $this->assertEquals('active', $engineerSlot['state'],
+            'Engineer slot must be active when an advisor is hired');
+        $this->assertNotNull($engineerSlot['advisor'],
+            'Advisor data must be populated for an active slot');
+    }
+
+    // ── HIRE — redirect branch ────────────────────────────────────────────────
+
+    public function test_hire_redirects_on_success(): void
+    {
+        $this->clearBartAdvisors();
+        $this->ensureCredits($this->userIdBart, 10000);
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+    }
+
+    public function test_hire_creates_advisor_record_in_database(): void
+    {
+        $this->clearBartAdvisors();
+        $this->ensureCredits($this->userIdBart, 10000);
+
+        $bart = User::find($this->userIdBart);
+
+        $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
+
+        $this->assertDatabaseHas('advisors', [
+            'user_id'      => $this->userIdBart,
+            'personell_id' => $this->personellEngineer,
+            'colony_id'    => $this->colonyIdBart,
+            'rank'         => 1,
+        ]);
+    }
+
+    public function test_hire_fails_for_unknown_personell_id(): void
+    {
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->post(route('advisors.hire'), ['personell_id' => 999]);
+
+        // Validation must reject unknown IDs (422 for JSON, redirect-with-errors for HTML)
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors('personell_id');
+    }
+
+    // ── HIRE — JSON branch ────────────────────────────────────────────────────
+
+    public function test_hire_returns_json_on_ajax_request(): void
+    {
+        $this->clearBartAdvisors();
+        $this->ensureCredits($this->userIdBart, 10000);
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
+
+        $response->assertOk()
+            ->assertJson(['ok' => true])
+            ->assertJsonStructure(['ok', 'slots', 'slotInfo']);
+    }
+
+    public function test_hire_json_returns_422_on_duplicate(): void
+    {
+        $this->clearBartAdvisors();
+        $this->ensureCredits($this->userIdBart, 10000);
+
+        $bart = User::find($this->userIdBart);
+
+        // First hire via plain POST (seeds the advisor)
+        $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
+
+        // Second hire via AJAX should return 422 with ok=false
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false])
+            ->assertJsonStructure(['ok', 'error']);
+    }
+
+    public function test_hire_json_returns_422_on_unknown_personell_id(): void
+    {
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post(route('advisors.hire'), ['personell_id' => 999]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_hire_json_returns_422_when_slot_full(): void
+    {
+        // Colony 1 has CC level 3, so max 3 slots.
+        // We fill all 3 slots, then try to hire a 4th.
+        $this->clearBartAdvisors();
+        $this->ensureCredits($this->userIdBart, 10000);
+
+        $this->insertAdvisor($this->userIdBart, $this->personellEngineer,  $this->colonyIdBart);
+        $this->insertAdvisor($this->userIdBart, $this->personellScientist, $this->colonyIdBart);
+        $this->insertAdvisor($this->userIdBart, $this->personellTrader,    $this->colonyIdBart);
+
+        $bart = User::find($this->userIdBart);
+
+        // Pilot is the 4th distinct type — slot is locked (CC=3, position 3 already full)
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post(route('advisors.hire'), ['personell_id' => $this->personellStratege]);
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false]);
+    }
+
+    // ── FIRE — redirect branch ────────────────────────────────────────────────
+
+    public function test_fire_redirects_on_success(): void
+    {
+        $this->clearBartAdvisors();
+
+        $advisorId = $this->insertAdvisor($this->userIdBart, $this->personellEngineer, $this->colonyIdBart);
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->delete(route('advisors.fire', ['id' => $advisorId]));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+    }
+
+    public function test_fire_sets_colony_id_to_null_on_advisor(): void
+    {
+        $this->clearBartAdvisors();
+
+        $advisorId = $this->insertAdvisor($this->userIdBart, $this->personellEngineer, $this->colonyIdBart);
+
+        $bart = User::find($this->userIdBart);
+
+        $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->delete(route('advisors.fire', ['id' => $advisorId]));
+
+        $this->assertDatabaseHas('advisors', [
+            'id'        => $advisorId,
+            'colony_id' => null,
+        ]);
+    }
+
+    public function test_fire_returns_404_for_foreign_advisor(): void
+    {
+        // Advisor id=5 belongs to Homer (user_id=0) on colony 2.
+        // Bart must not be able to fire it.
+        $homerAdvisorId = 5;
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->delete(route('advisors.fire', ['id' => $homerAdvisorId]));
+
+        $response->assertNotFound();
+    }
+
+    public function test_fire_returns_404_for_nonexistent_advisor(): void
+    {
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->delete(route('advisors.fire', ['id' => 99999]));
+
+        $response->assertNotFound();
+    }
+
+    // ── FIRE — JSON branch ────────────────────────────────────────────────────
+
+    public function test_fire_returns_json_on_ajax_request(): void
+    {
+        $this->clearBartAdvisors();
+
+        $advisorId = $this->insertAdvisor($this->userIdBart, $this->personellEngineer, $this->colonyIdBart);
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->delete(route('advisors.fire', ['id' => $advisorId]));
+
+        $response->assertOk()
+            ->assertJson(['ok' => true])
+            ->assertJsonStructure(['ok', 'slots', 'slotInfo']);
+    }
+
+    public function test_fire_json_returns_404_for_foreign_advisor(): void
+    {
+        // Advisor id=5 belongs to Homer — Bart cannot fire it via AJAX either.
+        $homerAdvisorId = 5;
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->delete(route('advisors.fire', ['id' => $homerAdvisorId]));
+
+        $response->assertStatus(404)
+            ->assertJson(['ok' => false]);
+    }
+
+    // ── Auth guard ────────────────────────────────────────────────────────────
+
+    public function test_index_requires_authentication(): void
+    {
+        $response = $this->get(route('advisors.index'));
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_hire_requires_authentication(): void
+    {
+        $response = $this->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_fire_requires_authentication(): void
+    {
+        $response = $this->delete(route('advisors.fire', ['id' => 1]));
+        $response->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
## Summary

- Berater-Screen komplett von Bootstrap/jQuery auf Alpine.js + PicoCSS migriert
- Neue Karussell-Ansicht mit 5 Portrait-Karten: Mobile 1 Karte + Swipe-Navigation, Desktop alle 5 nebeneinander
- Hire/Fire per AJAX ohne Seitenreload, native `<dialog>`-Bestätigungen
- `AdvisorController` um `buildSlots()` und JSON-Branching erweitert
- 22 neue Feature-Tests, alle grün (436 gesamt)

## Was sich ändert

**AdvisorController** (`app/Http/Controllers/Techtree/AdvisorController.php`):
- Neue `buildSlots()` Methode: liefert immer genau 5 Slot-Objekte (engineer→stratege) mit Zustand (`active`/`unavailable`/`empty`/`locked`), Rang-Fortschritt, AP/Tick
- `index()` übergibt einheitliches `$pageData` statt separater Variablen
- `hire()` und `fire()` geben JSON zurück wenn `Accept: application/json` gesetzt (AJAX-Clients), sonst weiterhin Redirect

**Neue Dateien:**
- `public/css/advisors.css` — Portrait-Karten (2:3 Aspect Ratio), Rang-Badges (Junior grau / Senior blau / Experte gold), Status-Chips, CSS-Transition für Karussell-Sliding
- `public/js/advisors.js` — Alpine-Komponente: Swipe-Gesten (Touch-Events), Karussell-Navigation, AJAX hire/fire, native dialog-Steuerung
- `tests/Feature/Techtree/AdvisorControllerTest.php` — 22 Tests

**Geändertes View** (`resources/views/advisors/index.blade.php`):
- `@extends('layouts.app')` → `@extends('layouts.colony')` (PicoCSS + Alpine)
- Bootstrap-Grid + jQuery-Modal → Alpine `x-for`/`x-if` + native `<dialog>`

## Test plan

- [ ] `/advisors` öffnen → 5 Karten erscheinen (Baumeister, Analytiker, Raumfahrer, Konsul, Stratege)
- [ ] Mobile-Viewport (< 900px): eine Karte sichtbar, Swipe links/rechts wechselt Berater, Dots zeigen aktiven
- [ ] Desktop (≥ 900px): alle 5 Karten nebeneinander, Arrows versteckt
- [ ] Leerer Slot → "Einstellen" → Dialog öffnet → Hire → Karte wechselt zu "Aktiv" ohne Reload
- [ ] Aktiver Berater → "Entlassen" → Bestätigungs-Dialog → Fire → Karte wechselt zu "Vakant"
- [ ] Gesperrter Slot (CC Level < Position) → ausgegraut, kein Button
- [ ] `php artisan test tests/Feature/` → 436 Tests grün