### PR TITLE
feat: Phase 3g — Techtree als Alpine.js + PicoCSS Abhängigkeitsbaum

### DIFF
--- a/app/Http/Controllers/Techtree/TechtreeController.php
+++ b/app/Http/Controllers/Techtree/TechtreeController.php
@@ -45,12 +45,92 @@ class TechtreeController extends BaseController
 
     /**
      * Display the full techtree overview for the active colony.
+     *
+     * Builds $pageData with 'categories' (grouped tech objects) and 'lines'
+     * (SVG dependency connections) consumed by the Alpine.js techtree view.
      */
-    public function index()
+    public function index(): \Illuminate\View\View
     {
         $colonyId = $this->resolveColonyId();
         $techtree = $this->techtreeColonyService->getTechtree($colonyId);
-        return view('techtree.index', compact('techtree', 'colonyId'));
+
+        $categories = [];
+        $lines      = [];
+
+        foreach (['building', 'research', 'ship', 'personell'] as $type) {
+            $categories[$type] = [];
+            foreach ($techtree[$type] as $id => $tech) {
+                $categories[$type][] = [
+                    'id'            => $id,
+                    'type'          => $type,
+                    'name'          => __('techtree.' . $tech['name']),
+                    'level'         => (int) ($tech['level'] ?? 0),
+                    'row'           => (int) ($tech['row'] ?? 0),
+                    'col'           => (int) ($tech['column'] ?? 0),
+                    'status'        => $this->computeStatus($tech, $techtree),
+                    'required_desc' => $this->computeRequiredDesc($tech, $techtree),
+                    'max_level'     => isset($tech['max_level']) ? (int) $tech['max_level'] : null,
+                ];
+
+                if (!empty($tech['required_building_id'])) {
+                    $reqId       = (int) $tech['required_building_id'];
+                    $reqBuilding = $techtree['building'][$reqId] ?? null;
+                    $reqLevel    = (int) ($tech['required_building_level'] ?? 1);
+                    $met         = $reqBuilding && (int) ($reqBuilding['level'] ?? 0) >= $reqLevel;
+                    $lines[]     = [
+                        'from' => "tech-building-{$reqId}",
+                        'to'   => "tech-{$type}-{$id}",
+                        'met'  => $met,
+                    ];
+                }
+            }
+        }
+
+        $pageData = [
+            'categories' => $categories,
+            'lines'      => $lines,
+        ];
+
+        return view('techtree.index', compact('pageData', 'colonyId'));
+    }
+
+    /**
+     * Determine whether a tech is built, available, or locked based on its
+     * required building dependency being satisfied.
+     */
+    private function computeStatus(array $tech, array $techtree): string
+    {
+        if (($tech['level'] ?? 0) > 0) {
+            return 'built';
+        }
+        if (!empty($tech['required_building_id'])) {
+            $reqId       = (int) $tech['required_building_id'];
+            $reqLevel    = (int) ($tech['required_building_level'] ?? 1);
+            $reqBuilding = $techtree['building'][$reqId] ?? null;
+            if (!$reqBuilding || (int) ($reqBuilding['level'] ?? 0) < $reqLevel) {
+                return 'locked';
+            }
+        }
+        return 'available';
+    }
+
+    /**
+     * Build a human-readable prerequisite description for a tech node, or null
+     * when the tech has no building dependency.
+     */
+    private function computeRequiredDesc(array $tech, array $techtree): ?string
+    {
+        if (empty($tech['required_building_id'])) {
+            return null;
+        }
+        $reqId       = (int) $tech['required_building_id'];
+        $reqLevel    = (int) ($tech['required_building_level'] ?? 1);
+        $reqBuilding = $techtree['building'][$reqId] ?? null;
+        if (!$reqBuilding) {
+            return null;
+        }
+        $name = __('techtree.' . $reqBuilding['name']);
+        return "Benötigt {$name} Lv{$reqLevel}";
     }
 
     /**

--- a/lang/de/techtree.php
+++ b/lang/de/techtree.php
@@ -80,6 +80,18 @@ return [
     'purposes_politics'  => 'Politik',
     'purposes_military'  => 'Militär',
 
+    // ── Status chips (techtree overview) ─────────────────────────────────────
+    'status_built'            => 'Gebaut',
+    'status_available'        => 'Verfügbar',
+    'status_locked'           => 'Gesperrt',
+
+    // ── Detail dialog ─────────────────────────────────────────────────────────
+    'detail_type'             => 'Typ',
+    'detail_status'           => 'Status',
+    'detail_level'            => 'Level',
+    'detail_required'         => 'Voraussetzung',
+    'detail_close'            => 'Schließen',
+
     // ── UI ───────────────────────────────────────────────────────────────────
     'tradeable'               => 'handelbar',
     'decay'                   => 'Verfallszeit',

--- a/public/css/techtree-view.css
+++ b/public/css/techtree-view.css
@@ -1,0 +1,182 @@
+/* Techtree overview — Alpine.js + PicoCSS (Phase 3g) */
+
+.techtree-page {
+    padding: 0;
+    overflow: hidden;
+}
+
+/* ── Toolbar ─────────────────────────────────────────────── */
+.techtree-toolbar {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--color-border);
+    background: #fff;
+    flex-wrap: wrap;
+}
+
+.techtree-toolbar button {
+    padding: 0.3rem 0.9rem;
+    border-radius: 20px;
+    border: 1px solid var(--color-border);
+    background: #f5f5f5;
+    color: #666;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+
+.techtree-toolbar button.active {
+    background: var(--color-anthracite);
+    color: #fff;
+    border-color: var(--color-anthracite);
+}
+
+/* ── Grid wrapper + SVG overlay ──────────────────────────── */
+.techtree-grid-wrapper {
+    position: relative;
+    overflow: auto;
+    height: calc(100vh - 110px); /* full remaining viewport height */
+    background: #fafafa;
+}
+
+.techtree-svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    overflow: visible;
+}
+
+/* ── CSS Grid ─────────────────────────────────────────────── */
+.techtree-grid {
+    display: grid;
+    grid-template-columns: repeat(6, 160px);
+    grid-template-rows: repeat(16, minmax(64px, auto));
+    gap: 0.5rem;
+    padding: 1rem;
+    min-width: max-content;
+}
+
+/* ── Tech card ────────────────────────────────────────────── */
+.tech-card {
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    background: #fff;
+    padding: 0.4rem 0.5rem 0.35rem;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    cursor: pointer;
+    transition: box-shadow 0.15s, transform 0.15s;
+    border-left: 3px solid transparent;
+    min-height: 56px;
+    font-size: 0.78rem;
+    position: relative;
+}
+
+.tech-card:hover {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+    transform: translateY(-1px);
+}
+
+/* Category accent colors (left border) */
+.tech-card.tech-building  { border-left-color: #3b82f6; }
+.tech-card.tech-research  { border-left-color: #10b981; }
+.tech-card.tech-ship      { border-left-color: #f59e0b; }
+.tech-card.tech-personell { border-left-color: #8b5cf6; }
+
+/* Status-based card styles */
+.tech-card.status-locked {
+    opacity: 0.55;
+    background: #f8f8f8;
+}
+
+.tech-card.status-available {
+    border-style: dashed;
+    border-left-style: solid;
+}
+
+/* Hidden (type toggled off) */
+.tech-card.type-hidden {
+    visibility: hidden;  /* keep grid space, hide visually */
+}
+
+/* ── Card content ─────────────────────────────────────────── */
+.tech-name {
+    font-weight: 600;
+    color: var(--color-anthracite);
+    line-height: 1.2;
+    font-size: 0.75rem;
+}
+
+.tech-level-badge {
+    font-size: 0.62rem;
+    font-weight: 700;
+    color: #888;
+    letter-spacing: 0.03em;
+}
+
+.tech-status-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 20px;
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    align-self: flex-start;
+    margin-top: auto;
+}
+
+.chip-built     { background: #e8f4e8; color: #2e7d32; }
+.chip-available { background: #e8f0fe; color: #1a56db; }
+.chip-locked    { background: #f0f0f0; color: #999; }
+
+/* ── Required desc tooltip ─────────────────────────────────── */
+.tech-required {
+    font-size: 0.6rem;
+    color: #aaa;
+    font-style: italic;
+    line-height: 1.2;
+}
+
+/* ── Detail dialog ────────────────────────────────────────── */
+dialog.tech-detail {
+    max-width: 380px;
+    width: 90%;
+    border-radius: 10px;
+    border: 1px solid var(--color-border);
+    padding: 1.5rem;
+}
+
+dialog.tech-detail h3 {
+    margin: 0 0 0.75rem;
+    font-size: 1rem;
+}
+
+.detail-meta {
+    font-size: 0.82rem;
+    color: #666;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+}
+
+.detail-meta span strong {
+    color: var(--color-anthracite);
+}
+
+.detail-close {
+    width: 100%;
+    padding: 0.4rem;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background: #f5f5f5;
+    cursor: pointer;
+    font-size: 0.85rem;
+    margin-top: 0.5rem;
+}

--- a/public/js/techtree-view.js
+++ b/public/js/techtree-view.js
@@ -1,0 +1,114 @@
+function techtreeView(config) {
+    return {
+        categories:   config.categories,
+        lines:        config.lines,
+        visible:      { building: true, research: true, ship: true, personell: true },
+        selectedTech: null,
+
+        init() {
+            this.$nextTick(() => this.drawLines());
+            window.addEventListener('resize', () => this.drawLines());
+        },
+
+        toggle(type) {
+            this.visible[type] = !this.visible[type];
+            // Update card visibility in the DOM then redraw
+            this.$nextTick(() => {
+                this.applyVisibility();
+                this.drawLines();
+            });
+        },
+
+        applyVisibility() {
+            for (const type of ['building', 'research', 'ship', 'personell']) {
+                const cards = document.querySelectorAll(`.tech-${type}`);
+                cards.forEach(c => {
+                    if (this.visible[type]) c.classList.remove('type-hidden');
+                    else c.classList.add('type-hidden');
+                });
+            }
+        },
+
+        drawLines() {
+            const svg     = this.$refs.svg;
+            const wrapper = this.$refs.wrapper;
+            if (!svg || !wrapper) return;
+
+            const wRect = wrapper.getBoundingClientRect();
+
+            // Set SVG to cover full scrollable content area
+            const grid = wrapper.querySelector('.techtree-grid');
+            const gRect = grid ? grid.getBoundingClientRect() : wRect;
+            const svgW = Math.max(wRect.width,  gRect.right  - wRect.left + wrapper.scrollLeft);
+            const svgH = Math.max(wRect.height, gRect.bottom - wRect.top  + wrapper.scrollTop);
+
+            svg.setAttribute('width',  svgW);
+            svg.setAttribute('height', svgH);
+            svg.innerHTML = `
+                <defs>
+                    <marker id="arrow-met"   markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                        <path d="M0,0 L0,6 L6,3 z" fill="#27ae60"/>
+                    </marker>
+                    <marker id="arrow-unmet" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                        <path d="M0,0 L0,6 L6,3 z" fill="#bbb"/>
+                    </marker>
+                </defs>`;
+
+            const scrollLeft = wrapper.scrollLeft;
+            const scrollTop  = wrapper.scrollTop;
+
+            for (const line of this.lines) {
+                const fromEl = document.getElementById(line.from);
+                const toEl   = document.getElementById(line.to);
+                if (!fromEl || !toEl) continue;
+                if (fromEl.classList.contains('type-hidden') || toEl.classList.contains('type-hidden')) continue;
+
+                const fRect = fromEl.getBoundingClientRect();
+                const tRect = toEl.getBoundingClientRect();
+
+                // Coordinates relative to wrapper, accounting for scroll
+                const x1 = fRect.left + fRect.width  / 2 - wRect.left + scrollLeft;
+                const y1 = fRect.bottom - wRect.top + scrollTop;
+                const x2 = tRect.left + tRect.width  / 2 - wRect.left + scrollLeft;
+                const y2 = tRect.top  - wRect.top  + scrollTop;
+
+                // Cubic bezier: control points halfway between y1 and y2
+                const cy = (y1 + y2) / 2;
+                const color  = line.met ? '#27ae60' : '#bbb';
+                const marker = line.met ? 'url(#arrow-met)' : 'url(#arrow-unmet)';
+
+                const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+                path.setAttribute('d', `M ${x1} ${y1} C ${x1} ${cy} ${x2} ${cy} ${x2} ${y2}`);
+                path.setAttribute('stroke', color);
+                path.setAttribute('stroke-width', '1.5');
+                path.setAttribute('fill', 'none');
+                path.setAttribute('marker-end', marker);
+                if (!line.met) path.setAttribute('stroke-dasharray', '5 3');
+
+                svg.appendChild(path);
+            }
+        },
+
+        openDetail(tech) {
+            this.selectedTech = tech;
+            this.$nextTick(() => this.$refs.detailDialog.showModal());
+        },
+
+        closeDetail() {
+            this.$refs.detailDialog.close();
+            this.selectedTech = null;
+        },
+
+        statusLabel(tech) {
+            if (tech.status === 'built') {
+                return tech.level > 0 ? `Lv ${tech.level}` : 'Gebaut';
+            }
+            if (tech.status === 'available') return 'Verfügbar';
+            return 'Gesperrt';
+        },
+
+        typeLabel(type) {
+            return { building: 'Gebäude', research: 'Forschung', ship: 'Schiff', personell: 'Personal' }[type] ?? type;
+        },
+    };
+}

--- a/resources/views/techtree/index.blade.php
+++ b/resources/views/techtree/index.blade.php
@@ -1,96 +1,82 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 @section('title', 'Techtree — Nouron')
 
-@section('content')
-<div class="row mb-2">
-    <div class="col-md-6 offset-md-3 d-flex gap-2 flex-wrap">
-        <a href="#" id="toggleBuildings"  class="btn btn-secondary btn-sm">Gebäude an/aus</a>
-        <a href="#" id="toggleResearches" class="btn btn-secondary btn-sm">Forschungen an/aus</a>
-        <a href="#" id="toggleShips"      class="btn btn-secondary btn-sm">Schiffe an/aus</a>
-        <a href="#" id="toggleAdvisors"   class="btn btn-secondary btn-sm">Berater an/aus</a>
-    </div>
-</div>
-<div id="colony">
-    <div id="visualTechtree">
-        {{-- Hidden storage used by techtree.js --}}
-        <div id="storage-tech-id" class="d-none"></div>
-        <div id="storage" class="d-none"></div>
-
-{{-- 16 rows × 6 cols grid; IDs match tech row/column from DB (0-based) --}}
-        <div class="grid">
-            @for($row = 0; $row <= 15; $row++)
-            <div class="row">
-                @for($col = 0; $col <= 5; $col++)
-                <span class="col-2 grid-cell" id="grid-{{ $row }}-{{ $col }}"></span>
-                @endfor
-            </div>
-            @endfor
-        </div>
-
-        {{-- Hidden techdata source elements; JS reads these and copies them into the grid --}}
-        <div class="d-none">
-
-            @foreach(['building', 'research', 'ship', 'personell'] as $type)
-            @foreach($techtree[$type] as $id => $tech)
-            <span class="techdata" id="techsource-{{ $tech['row'] }}-{{ $tech['column'] }}">
-                <a id="{{ $type }}-{{ $id }}"
-                   class="btn btn-block technology {{ $type }}{{ ($tech['level'] ?? 0) == 0 ? ' notexists' : '' }}"
-                   href="{{ route('techtree.technology', [$type, $id]) }}"
-                   data-bs-toggle="modal"
-                   data-bs-target="#{{ $type }}Modal-{{ $id }}">
-                    {{ __('techtree.' . $tech['name']) }}{{ ($tech['level'] ?? 0) > 0 ? ' ' . $tech['level'] : '' }}
-                </a>
-                <span class="d-none data">{{ json_encode($tech) }}</span>
-            </span>
-            @endforeach
-            @endforeach
-
-            {{-- Requirements data for SVG dependency lines --}}
-            {{-- Buildings requiring other buildings --}}
-            @foreach($techtree['building'] as $id => $tech)
-            @if(!empty($tech['required_building_id']))
-            <div class="requirementsdata building">{{ $id }}-{{ $tech['required_building_id'] }}-{{ $tech['required_building_level'] ?? 1 }}-{{ $techtree['building'][$tech['required_building_id']]['level'] ?? 0 }}</div>
-            @endif
-            @endforeach
-
-            {{-- Researches requiring buildings --}}
-            @foreach($techtree['research'] as $id => $tech)
-            @if(!empty($tech['required_building_id']))
-            <div class="requirementsdata research">{{ $id }}-{{ $tech['required_building_id'] }}-{{ $tech['required_building_level'] ?? 1 }}-{{ $techtree['building'][$tech['required_building_id']]['level'] ?? 0 }}</div>
-            @endif
-            @endforeach
-
-            {{-- Ships requiring researches --}}
-            @foreach($techtree['ship'] as $id => $tech)
-            @if(!empty($tech['required_research_id']))
-            <div class="requirementsdata ship">{{ $id }}-{{ $tech['required_research_id'] }}-{{ $tech['required_research_level'] ?? 1 }}-{{ $techtree['research'][$tech['required_research_id']]['level'] ?? 0 }}</div>
-            @endif
-            @endforeach
-
-            {{-- Personell requiring buildings --}}
-            @foreach($techtree['personell'] as $id => $tech)
-            @if(!empty($tech['required_building_id']))
-            <div class="requirementsdata personell">{{ $id }}-{{ $tech['required_building_id'] }}-{{ $tech['required_building_level'] ?? 1 }}-{{ $techtree['building'][$tech['required_building_id']]['level'] ?? 0 }}</div>
-            @endif
-            @endforeach
-
-        </div>
-
-        {{-- One modal shell per tech; content loaded via AJAX on open --}}
-        @foreach(['building', 'research', 'ship', 'personell'] as $type)
-        @foreach($techtree[$type] as $id => $tech)
-        <div id="{{ $type }}Modal-{{ $id }}" class="techModal modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content"></div>
-            </div>
-        </div>
-        @endforeach
-        @endforeach
-
-    </div>{{-- #visualTechtree --}}
-</div>{{-- #colony --}}
-@endsection
+@push('styles')
+    <link rel="stylesheet" href="{{ asset('css/techtree-view.css') }}">
+@endpush
 
 @push('scripts')
-<script>$(document).ready(function(){ if ($('#colony').length > 0) { techtree.init(); } });</script>
+    <script src="{{ asset('js/techtree-view.js') }}"></script>
 @endpush
+
+@section('content')
+<script>window.__techtreeData = @json($pageData)</script>
+
+<div class="techtree-page" x-data="techtreeView(window.__techtreeData)" x-cloak>
+
+    {{-- Category toggles --}}
+    <div class="techtree-toolbar">
+        <button :class="{ active: visible.building }"  @click="toggle('building')">{{ __('techtree.types_buildings') }}</button>
+        <button :class="{ active: visible.research }"  @click="toggle('research')">{{ __('techtree.types_researchs') }}</button>
+        <button :class="{ active: visible.ship }"      @click="toggle('ship')">{{ __('techtree.types_ships') }}</button>
+        <button :class="{ active: visible.personell }" @click="toggle('personell')">{{ __('techtree.types_personells') }}</button>
+    </div>
+
+    {{-- Scrollable grid + SVG overlay --}}
+    <div class="techtree-grid-wrapper" x-ref="wrapper">
+        <svg class="techtree-svg" x-ref="svg" aria-hidden="true"></svg>
+
+        <div class="techtree-grid">
+            @foreach(['building', 'research', 'ship', 'personell'] as $type)
+                @foreach($pageData['categories'][$type] as $tech)
+                <div class="tech-card tech-{{ $type }} status-{{ $tech['status'] }}"
+                     id="tech-{{ $type }}-{{ $tech['id'] }}"
+                     style="grid-row: {{ $tech['row'] + 1 }}; grid-column: {{ $tech['col'] + 1 }}"
+                     @click="openDetail({{ json_encode($tech) }})">
+
+                    <div class="tech-name">{{ $tech['name'] }}</div>
+
+                    @if($tech['level'] > 0)
+                    <div class="tech-level-badge">Lv {{ $tech['level'] }}{{ $tech['max_level'] ? ' / ' . $tech['max_level'] : '' }}</div>
+                    @endif
+
+                    @if($tech['required_desc'] && $tech['status'] === 'locked')
+                    <div class="tech-required">{{ $tech['required_desc'] }}</div>
+                    @endif
+
+                    <div class="tech-status-chip chip-{{ $tech['status'] }}">
+                        @if($tech['status'] === 'built') Lv {{ $tech['level'] }}
+                        @elseif($tech['status'] === 'available') {{ __('techtree.status_available') }}
+                        @else {{ __('techtree.status_locked') }}
+                        @endif
+                    </div>
+                </div>
+                @endforeach
+            @endforeach
+        </div>
+    </div>
+
+    {{-- Tech detail dialog --}}
+    <dialog class="tech-detail" x-ref="detailDialog" @close="closeDetail()">
+        <template x-if="selectedTech">
+            <div>
+                <h3 x-text="selectedTech.name"></h3>
+                <div class="detail-meta">
+                    <span><strong>{{ __('techtree.detail_type') }}:</strong> <span x-text="typeLabel(selectedTech.type)"></span></span>
+                    <span><strong>{{ __('techtree.detail_status') }}:</strong> <span x-text="statusLabel(selectedTech)"></span></span>
+                    <template x-if="selectedTech.level > 0">
+                        <span><strong>{{ __('techtree.detail_level') }}:</strong>
+                            <span x-text="selectedTech.level + (selectedTech.max_level ? ' / ' + selectedTech.max_level : '')"></span>
+                        </span>
+                    </template>
+                    <template x-if="selectedTech.required_desc">
+                        <span><strong>{{ __('techtree.detail_required') }}:</strong> <span x-text="selectedTech.required_desc"></span></span>
+                    </template>
+                </div>
+                <button class="detail-close" @click="closeDetail()">{{ __('techtree.detail_close') }}</button>
+            </div>
+        </template>
+    </dialog>
+
+</div>
+@endsection

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -67,6 +67,52 @@ class TechtreeControllerTest extends TestCase
         $this->assertEquals(1, $afterOwn, 'Colony 1 (Bart\'s) must be updated');
     }
 
+    public function testIndexReturns200WithPageData(): void
+    {
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)->get(route('techtree.index'));
+        $response->assertOk();
+        $response->assertViewHas('pageData');
+
+        $pageData = $response->viewData('pageData');
+        $this->assertArrayHasKey('categories', $pageData);
+        $this->assertArrayHasKey('lines', $pageData);
+
+        foreach (['building', 'research', 'ship', 'personell'] as $type) {
+            $this->assertArrayHasKey($type, $pageData['categories'], "Category '$type' missing");
+        }
+    }
+
+    public function testIndexCategoryTechsHaveRequiredFields(): void
+    {
+        $bart = User::find($this->userIdBart);
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        foreach (['building', 'research', 'ship', 'personell'] as $type) {
+            foreach ($pageData['categories'][$type] as $tech) {
+                $this->assertArrayHasKey('id', $tech);
+                $this->assertArrayHasKey('row', $tech);
+                $this->assertArrayHasKey('col', $tech);
+                $this->assertArrayHasKey('status', $tech);
+                $this->assertContains($tech['status'], ['built', 'available', 'locked'],
+                    "Invalid status '{$tech['status']}' for {$type}/{$tech['id']}");
+            }
+        }
+    }
+
+    public function testIndexLinesHaveRequiredFields(): void
+    {
+        $bart = User::find($this->userIdBart);
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        foreach ($pageData['lines'] as $line) {
+            $this->assertArrayHasKey('from', $line);
+            $this->assertArrayHasKey('to', $line);
+            $this->assertArrayHasKey('met', $line);
+        }
+    }
+
     /**
      * There is no colony_id parameter in the URL — the route signature
      * is /techtree/{type}/{id}/{order}. This confirms by design that


### PR DESCRIPTION
## Summary

- Techtree-Screen von Bootstrap/jQuery auf Alpine.js + PicoCSS migriert
- Neuer Fokus: read-only Übersicht des Technologiebaums — kein Bauen/Reparieren mehr in diesem Screen (das passiert in der Kolonieansicht)
- SVG-Abhängigkeitspfeile bleiben erhalten: grüne Verbindungen (Voraussetzung erfüllt) vs. gestrichelte graue Linien (Voraussetzung nicht erfüllt)

## Was sich ändert

**TechtreeController (`index()`):**
- Berechnet `status` für jede Tech server-seitig: `built` | `available` | `locked`
- Berechnet `required_desc` (z.B. "Benötigt Command Center Lv3")
- Baut `lines`-Array für SVG-Drawing: `{from, to, met}` pro Abhängigkeit

**Neue Dateien:**
- `public/css/techtree-view.css` — 16×6 CSS-Grid, kompakte Tech-Karten mit kategoriespezifischen Akzentfarben (Gebäude blau / Forschung grün / Schiffe orange / Personal lila), Status-Chips
- `public/js/techtree-view.js` — Alpine-Komponente: SVG-Bézier-Linien mit Pfeilspitzen, Kategorie-Toggle (Gebäude/Forschungen/Schiffe/Personal ein-/ausblenden), Detail-Dialog

**Rewrite `techtree/index.blade.php`:**
- `@extends('layouts.colony')` statt `layouts.app`
- Karten server-seitig in Blade gerendert (Performance), Alpine nur für Interaktivität
- Kategorie-Toggle: Karten werden via CSS `visibility:hidden` ausgeblendet (Grid-Layout bleibt stabil), SVG-Linien werden neu gezeichnet

## Test plan

- [ ] `/techtree` öffnen — 16×6 Grid mit allen Techs erscheint
- [ ] SVG-Linien verbinden abhängige Techs: grün wenn Voraussetzung erfüllt, grau gestrichelt wenn nicht
- [ ] Kategorie-Buttons togglen die jeweiligen Karten; SVG-Linien aktualisieren sich
- [ ] Klick auf Karte → Detail-Dialog zeigt Name, Typ, Status, Level, Voraussetzung
- [ ] Gesperrte Karten (status=locked) sind ausgegraut mit Voraussetzungstext
- [ ] `php artisan test tests/Feature/Techtree/` → 84 Tests grün