### PR TITLE
feat: Phase 3a Reste — Bar-Event-System + Berater Beförderungskosten

### DIFF
--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -12,6 +12,7 @@ use App\Models\FleetOrder;
 use App\Models\FleetResource;
 use App\Models\FleetShip;
 use App\Models\UserResource;
+use App\Services\BarService;
 use App\Services\EventService;
 use App\Services\MoralService;
 use App\Services\OnboardingTriggerService;
@@ -39,6 +40,7 @@ use Illuminate\Support\Facades\DB;
  *  8c. Passive Credits    — Nexus subsidy (30 Cr) + colony tax per housing level (20 Cr/level) added to user Credits
  *  8d. Advisor upkeep     — deduct Credits per active advisor by rank (10/50/160 Cr); clamped to ≥ 0
  *  9. Advisor ticks       — increment active_ticks, check rank promotions
+ * 10. Bar offers          — expire stale offers, generate new NPC offers per colony with Bar
  */
 class GameTick extends Command
 {
@@ -54,6 +56,7 @@ class GameTick extends Command
         private readonly MoralService              $moralService,
         private readonly ResourcesService          $resourcesService,
         private readonly OnboardingTriggerService  $onboardingTriggerService,
+        private readonly BarService               $barService,
     ) {
         parent::__construct();
     }
@@ -103,6 +106,9 @@ class GameTick extends Command
 
             $n = $this->incrementAdvisorTicks();
             $this->line("  Advisors ticked:          {$n}");
+
+            $n = $this->processBarOffers($tick);
+            $this->line("  Bar offers generated:     {$n}");
         });
 
         $this->info("Tick {$tick} done.");
@@ -851,6 +857,24 @@ class GameTick extends Command
 
     // ── 9. Advisor ticks ─────────────────────────────────────────────────────
 
+    // ── 10. Bar offers ───────────────────────────────────────────────────────
+
+    private function processBarOffers(int $tick): int
+    {
+        $colonyIds = DB::table('colony_buildings')
+            ->where('building_id', (int) config('buildings.bar.id', 52))
+            ->where('level', '>', 0)
+            ->pluck('colony_id');
+
+        foreach ($colonyIds as $colonyId) {
+            $this->barService->generateOffersForColony((int) $colonyId, $tick);
+        }
+
+        return $colonyIds->count();
+    }
+
+    // ── 9. Advisor ticks ─────────────────────────────────────────────────────
+
     private function incrementAdvisorTicks(): int
     {
         $updated = DB::table('advisors')
@@ -858,12 +882,35 @@ class GameTick extends Command
             ->whereNotNull('colony_id')
             ->increment('active_ticks');
 
-        $thresholds = config('game.advisor.rank_thresholds', [1 => 10, 2 => 20]);
+        $thresholds    = config('game.advisor.rank_thresholds', [1 => 10, 2 => 20]);
+        $promotionCosts = config('game.advisor.promotion_costs', [2 => 150, 3 => 400]);
+
         foreach ($thresholds as $fromRank => $ticks) {
-            DB::table('advisors')
-                ->where('rank', $fromRank)
-                ->where('active_ticks', '>=', $ticks)
-                ->update(['rank' => $fromRank + 1]);
+            $toRank = $fromRank + 1;
+            $cost   = (int) ($promotionCosts[$toRank] ?? 0);
+
+            $eligible = DB::table('advisors as a')
+                ->join('glx_colonies as c', 'c.id', '=', 'a.colony_id')
+                ->where('a.rank', $fromRank)
+                ->where('a.active_ticks', '>=', $ticks)
+                ->whereNotNull('a.colony_id')
+                ->select('a.id', 'c.user_id')
+                ->get();
+
+            foreach ($eligible as $advisor) {
+                if ($cost > 0) {
+                    $credits = (int) (DB::table('user_resources')
+                        ->where('user_id', $advisor->user_id)
+                        ->value('credits') ?? 0);
+                    if ($credits < $cost) {
+                        continue; // Deferred — try again next tick
+                    }
+                    DB::table('user_resources')
+                        ->where('user_id', $advisor->user_id)
+                        ->decrement('credits', $cost);
+                }
+                DB::table('advisors')->where('id', $advisor->id)->update(['rank' => $toRank]);
+            }
         }
 
         return $updated;

--- a/app/Http/Controllers/Colony/BarController.php
+++ b/app/Http/Controllers/Colony/BarController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Colony;
+
+use App\Http\Controllers\BaseController;
+use App\Services\BarService;
+use App\Services\ColonyService;
+use App\Services\TickService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\View\View;
+
+class BarController extends BaseController
+{
+    private const BAR_BUILDING_ID = 52;
+
+    public function __construct(
+        TickService $tick,
+        private readonly ColonyService $colonyService,
+        private readonly BarService    $barService,
+    ) {
+        parent::__construct($tick);
+    }
+
+    public function index(): View
+    {
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $tick   = $this->tick->getTickCount();
+
+        $barLevel = (int) DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', self::BAR_BUILDING_ID)
+            ->value('level') ?? 0;
+
+        $offers = $barLevel > 0
+            ? $this->barService->getActiveOffers($colony->id, $tick)
+            : collect();
+
+        return view('colony.bar', compact('colony', 'offers', 'barLevel', 'tick'));
+    }
+
+    public function accept(Request $request, int $offerId): JsonResponse
+    {
+        $userId = Auth::id();
+        $colony = $this->colonyService->getPrimeColony($userId);
+        $tick   = $this->tick->getTickCount();
+        $result = $this->barService->acceptOffer($colony->id, $offerId, $userId, $tick);
+
+        return response()->json($result, $result['ok'] ? 200 : 422);
+    }
+}

--- a/app/Models/BarOffer.php
+++ b/app/Models/BarOffer.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Eloquent model for bar_offers.
+ *
+ * NPC traders leave offers at the Bar/Cantina. Each offer specifies a give/get
+ * resource pair and is valid until expires_tick. The player can accept or decline.
+ */
+class BarOffer extends Model
+{
+    protected $table = 'bar_offers';
+
+    protected $fillable = [
+        'colony_id',
+        'give_resource_id',
+        'give_amount',
+        'get_resource_id',
+        'get_amount',
+        'expires_tick',
+        'is_accepted',
+    ];
+
+    protected $casts = [
+        'is_accepted' => 'boolean',
+    ];
+}

--- a/app/Services/BarService.php
+++ b/app/Services/BarService.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\BarOffer;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class BarService
+{
+    private const BAR_BUILDING_ID   = 52;
+    private const TRADER_ADVISOR_ID = 92; // personell.id for 'trader'
+    private const RES_CREDITS       = 1;
+    private const TRADEABLE         = [3, 4, 5]; // regolith, compounds, organics
+
+    public function __construct(
+        private readonly ResourcesService $resourcesService,
+    ) {}
+
+    public function generateOffersForColony(int $colonyId, int $tick): void
+    {
+        // Bar must exist and be level ≥ 1
+        $barLevel = (int) DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', self::BAR_BUILDING_ID)
+            ->value('level') ?? 0;
+
+        if ($barLevel < 1) {
+            return;
+        }
+
+        // Expire old offers
+        DB::table('bar_offers')
+            ->where('colony_id', $colonyId)
+            ->where('expires_tick', '<=', $tick)
+            ->where('is_accepted', false)
+            ->delete();
+
+        // Trader advisor rank (0 if none assigned)
+        $traderRank = (int) (DB::table('advisors')
+            ->where('colony_id', $colonyId)
+            ->where('personell_id', self::TRADER_ADVISOR_ID)
+            ->whereNull('unavailable_until_tick')
+            ->value('rank') ?? 0);
+
+        [$minGuests, $maxGuests] = config("game.bar.guest_count.{$traderRank}", [0, 1]);
+        $guestCount = $this->pseudoRand($colonyId * 997 + $tick * 31, $minGuests, $maxGuests);
+
+        if ($guestCount < 1) {
+            return;
+        }
+
+        $duration = (int) config('game.bar.offer_duration', 2);
+        $expiresTick = $tick + $duration;
+        $discount    = (float) config("game.bar.trader_discount.{$traderRank}", 0.0);
+        $basePrices  = config('game.bar.base_prices', [3 => 30, 4 => 60, 5 => 50]);
+        $variance    = (float) config('game.bar.price_variance', 0.20);
+
+        for ($i = 0; $i < $guestCount; $i++) {
+            $seed = $colonyId * 1009 + $tick * 127 + $i * 37;
+            [$giveResId, $giveAmount, $getResId, $getAmount] =
+                $this->buildOffer($seed, $basePrices, $variance, $discount);
+
+            BarOffer::create([
+                'colony_id'       => $colonyId,
+                'give_resource_id' => $giveResId,
+                'give_amount'      => $giveAmount,
+                'get_resource_id'  => $getResId,
+                'get_amount'       => $getAmount,
+                'expires_tick'     => $expiresTick,
+                'is_accepted'      => false,
+            ]);
+        }
+    }
+
+    public function getActiveOffers(int $colonyId, int $tick): Collection
+    {
+        return BarOffer::where('colony_id', $colonyId)
+            ->where('expires_tick', '>', $tick)
+            ->where('is_accepted', false)
+            ->orderBy('id')
+            ->get();
+    }
+
+    public function acceptOffer(int $colonyId, int $offerId, int $userId, int $currentTick): array
+    {
+        $offer = BarOffer::where('id', $offerId)
+            ->where('colony_id', $colonyId)
+            ->first();
+
+        if (!$offer) {
+            return ['ok' => false, 'error' => __('colony.bar_offer_not_found')];
+        }
+        if ($offer->is_accepted) {
+            return ['ok' => false, 'error' => __('colony.bar_offer_already_accepted')];
+        }
+
+        if ($offer->expires_tick <= $currentTick) {
+            return ['ok' => false, 'error' => __('colony.bar_offer_expired')];
+        }
+
+        // Check player can afford the give side
+        $giveBalance = $this->getResourceBalance($colonyId, $userId, $offer->give_resource_id);
+        if ($giveBalance < $offer->give_amount) {
+            return ['ok' => false, 'error' => __('colony.bar_offer_insufficient_resources')];
+        }
+
+        // Execute trade
+        $this->resourcesService->decreaseAmount($colonyId, $offer->give_resource_id, $offer->give_amount);
+        $this->resourcesService->increaseAmount($colonyId, $offer->get_resource_id, $offer->get_amount);
+        $offer->is_accepted = true;
+        $offer->save();
+
+        return ['ok' => true];
+    }
+
+    private function getResourceBalance(int $colonyId, int $userId, int $resId): int
+    {
+        if ($resId === self::RES_CREDITS) {
+            return (int) (DB::table('user_resources')
+                ->where('user_id', $userId)
+                ->value('credits') ?? 0);
+        }
+        return (int) (DB::table('colony_resources')
+            ->where('colony_id', $colonyId)
+            ->where('resource_id', $resId)
+            ->value('amount') ?? 0);
+    }
+
+    /**
+     * Build a single offer deterministically from seed.
+     * Returns [give_resource_id, give_amount, get_resource_id, get_amount].
+     * Offer types: resource→credits (buy) or barter (resource↔resource).
+     */
+    private function buildOffer(int $seed, array $basePrices, float $variance, float $discount): array
+    {
+        // 60% resource-for-credits, 40% barter
+        $type = $this->pseudoRand($seed, 0, 9);
+
+        if ($type < 6) {
+            // Player pays Credits, gets a tradeable resource
+            $getResId  = self::TRADEABLE[$this->pseudoRand($seed + 1, 0, count(self::TRADEABLE) - 1)];
+            $getAmount = $this->pseudoRand($seed + 2, 1, 5) * 10; // 10–50 units
+            $basePrice = $basePrices[$getResId] ?? 40;
+            $rawPrice  = $basePrice * (1 + ($this->pseudoRand($seed + 3, -10, 10) / 100) * ($variance / 0.2));
+            $finalPrice = (int) max(1, round($rawPrice * $getAmount * (1 - $discount)));
+            return [self::RES_CREDITS, $finalPrice, $getResId, $getAmount];
+        } else {
+            // Barter: player gives one resource, gets another
+            $shuffled  = self::TRADEABLE;
+            $giveResId = $shuffled[$this->pseudoRand($seed + 4, 0, count($shuffled) - 1)];
+            $getResId  = $shuffled[$this->pseudoRand($seed + 5, 0, count($shuffled) - 1)];
+            if ($getResId === $giveResId) {
+                $getResId = $shuffled[($this->pseudoRand($seed + 5, 0, count($shuffled) - 1) + 1) % count($shuffled)];
+            }
+            $giveAmount = $this->pseudoRand($seed + 6, 2, 6) * 5; // 10–30 units
+            $givePrice  = ($basePrices[$giveResId] ?? 40) * $giveAmount;
+            $getPrice   = ($basePrices[$getResId] ?? 40);
+            $getAmount  = (int) max(1, round($givePrice * (1 + $discount) / $getPrice));
+            return [$giveResId, $giveAmount, $getResId, $getAmount];
+        }
+    }
+
+    private function pseudoRand(int $seed, int $min, int $max): int
+    {
+        if ($min >= $max) {
+            return $min;
+        }
+        $hash = abs(($seed * 1664525 + 1013904223) & 0x7FFFFFFF);
+        return $min + ($hash % ($max - $min + 1));
+    }
+}

--- a/config/game.php
+++ b/config/game.php
@@ -78,15 +78,18 @@ return [
     // Advisor rank-up: cumulative active_ticks required per rank (rank => ticks).
     // Configurable so balancing can be adjusted after first playtest (see GDD §8).
     'advisor' => [
-        'rank_thresholds' => [1 => 10, 2 => 20],
-        'ap_per_rank'     => [1 => 4, 2 => 7, 3 => 12],
+        'rank_thresholds'  => [1 => 10, 2 => 20],
+        'ap_per_rank'      => [1 => 4, 2 => 7, 3 => 12],
+        // One-time Credits cost when advisor is promoted to this rank (keyed by target rank).
+        // If user cannot afford it the promotion is deferred until next tick (ROADMAP Phase 3a).
+        'promotion_costs'  => [2 => 150, 3 => 400],
         // Slot system: CC level = number of advisor slots (max 5).
         // Formula: min(cc_level, max_slots)
-        'max_slots'       => 5,
+        'max_slots'        => 5,
         // Credits deducted from the owning user each tick per active advisor (GDD §12).
         // Processed in GameTick after passive Credits income to prevent false-negative
         // deficits when income and upkeep fire in the same tick.
-        'upkeep'          => [1 => 10, 2 => 50, 3 => 160],
+        'upkeep'           => [1 => 10, 2 => 50, 3 => 160],
     ],
 
     // Passive Credits income per tick (GDD §3).
@@ -96,6 +99,20 @@ return [
         'nexus_subsidy'   => 30,
         // Cr/Tick per housing level (sum of all housingComplex instances in the colony).
         'tax_per_housing' => 20,
+    ],
+
+    // Bar/Cantina NPC offer generation (GDD §14 Kanal 1).
+    // base_prices: Cr per 1 unit of tradeable resource (before variance/discount).
+    // price_variance: ±fraction applied to base price (pseudo-random per offer).
+    // trader_discount: fraction by which prices drop for the player (keyed by trader rank, 0 = no trader).
+    // guest_count: [min, max] guests per tick keyed by trader rank.
+    // offer_duration: ticks an offer stays valid (expires_tick = current_tick + offer_duration).
+    'bar' => [
+        'base_prices'     => [3 => 30, 4 => 60, 5 => 50], // regolith, compounds, organics
+        'price_variance'  => 0.20,
+        'trader_discount' => [0 => 0.00, 1 => 0.00, 2 => 0.10, 3 => 0.25],
+        'guest_count'     => [0 => [0, 1], 1 => [0, 1], 2 => [0, 2], 3 => [1, 2]],
+        'offer_duration'  => 2,
     ],
 
     // Military orders are deliberately more expensive than civilian ones (see GDD §1.1).

--- a/data/sql/testdata.sqlite.sql
+++ b/data/sql/testdata.sqlite.sql
@@ -455,3 +455,10 @@ UPDATE "buildings"  SET phase=4, "row"=1, "column"=2 WHERE id=32; -- temple
 -- Phase 5 (CC Lv5)
 UPDATE "buildings"  SET phase=5, "row"=1, "column"=2 WHERE id=50; -- monument
 INSERT OR REPLACE INTO "user_preferences" VALUES(3,3,1,NULL,NULL,NULL,NULL);
+
+-- Bar offers (migration 2026_05_14_000003)
+-- colony_id=1 (Springfield), expires_tick=9999999 (far future, always valid in tests)
+-- Offer 1: pay 800 Credits, receive 50 Compounds (Werkstoffe)
+INSERT INTO "bar_offers" (colony_id,give_resource_id,give_amount,get_resource_id,get_amount,expires_tick,is_accepted,created_at,updated_at) VALUES(1,1,800,4,50,9999999,0,'2026-05-14 00:00:00','2026-05-14 00:00:00');
+-- Offer 2: pay 20 Regolith, receive 30 Organics (Organika)
+INSERT INTO "bar_offers" (colony_id,give_resource_id,give_amount,get_resource_id,get_amount,expires_tick,is_accepted,created_at,updated_at) VALUES(1,3,20,5,30,9999999,0,'2026-05-14 00:00:00','2026-05-14 00:00:00');

--- a/database/migrations/2026_05_14_000003_create_bar_offers_table.php
+++ b/database/migrations/2026_05_14_000003_create_bar_offers_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the bar_offers table.
+ *
+ * NPC traders leave 0–2 offers per tick at the Bar/Cantina building.
+ * Each offer is valid for 1–2 ticks. The player can accept or decline.
+ *
+ * Columns:
+ *   colony_id        — the colony whose bar holds this offer
+ *   give_resource_id — resource the player pays (1=credits, 3=regolith, 4=compounds, 5=organics)
+ *   give_amount      — amount the player pays
+ *   get_resource_id  — resource the player receives
+ *   get_amount       — amount the player receives
+ *   expires_tick     — tick at which the offer expires (exclusive)
+ *   is_accepted      — whether the player accepted the offer
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('bar_offers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('colony_id');
+            $table->unsignedInteger('give_resource_id');
+            $table->unsignedInteger('give_amount');
+            $table->unsignedInteger('get_resource_id');
+            $table->unsignedInteger('get_amount');
+            $table->unsignedInteger('expires_tick');
+            $table->boolean('is_accepted')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bar_offers');
+    }
+};

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -94,4 +94,19 @@ return [
     'error_building_not_found'  => 'Gebäude nicht gefunden.',
     'error_max_level_reached'   => 'Maximales Level bereits erreicht.',
 
+    // ── Bar/Cantina ───────────────────────────────────────────────────────────
+
+    'bar_title'                        => 'Cantina',
+    'bar_no_building'                  => 'Die Cantina ist noch nicht gebaut.',
+    'bar_no_offers'                    => 'Keine Gäste im Moment. Komm nächsten Tick wieder.',
+    'bar_offer_heading'                => 'Angebote',
+    'bar_offer_accept'                 => 'Annehmen',
+    'bar_offer_give'                   => 'Du gibst',
+    'bar_offer_get'                    => 'Du bekommst',
+    'bar_offer_expires'                => 'Läuft ab nach Tick',
+    'bar_offer_not_found'              => 'Angebot nicht gefunden.',
+    'bar_offer_already_accepted'       => 'Angebot bereits angenommen.',
+    'bar_offer_expired'                => 'Angebot ist abgelaufen.',
+    'bar_offer_insufficient_resources' => 'Nicht genügend Ressourcen.',
+
 ];

--- a/resources/views/colony/bar.blade.php
+++ b/resources/views/colony/bar.blade.php
@@ -1,0 +1,104 @@
+@extends('layouts.colony')
+@section('title', __('colony.bar_title') . ' — Nouron')
+
+@section('content')
+@php
+    $resourceLabels = [
+        1 => __('resources.res_credits'),
+        3 => __('resources.res_regolith'),
+        4 => __('resources.res_werkstoffe'),
+        5 => __('resources.res_organika'),
+    ];
+@endphp
+
+<div x-data="barPage()" x-cloak>
+
+    <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem">
+        <h2 style="margin:0">{{ __('colony.bar_title') }}</h2>
+        <small style="color:var(--pico-muted-color)">Tick {{ $tick }}</small>
+    </div>
+
+    @if ($barLevel < 1)
+        <p>{{ __('colony.bar_no_building') }}</p>
+    @elseif ($offers->isEmpty())
+        <p style="color:var(--pico-muted-color)">{{ __('colony.bar_no_offers') }}</p>
+    @else
+        <p style="font-weight:600;margin-bottom:1rem">{{ __('colony.bar_offer_heading') }}</p>
+
+        <div style="display:flex;flex-direction:column;gap:1rem;max-width:480px">
+            @foreach ($offers as $offer)
+            <article style="margin:0;padding:1.25rem;border-radius:var(--pico-border-radius);border:1px solid var(--pico-muted-border-color)">
+                <div style="display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:0.75rem;margin-bottom:1rem">
+                    <div>
+                        <div style="font-size:0.8rem;color:var(--pico-muted-color);margin-bottom:0.25rem">
+                            {{ __('colony.bar_offer_give') }}
+                        </div>
+                        <strong>{{ $offer->give_amount }}×</strong>
+                        {{ $resourceLabels[$offer->give_resource_id] ?? $offer->give_resource_id }}
+                    </div>
+                    <span style="font-size:1.25rem">→</span>
+                    <div>
+                        <div style="font-size:0.8rem;color:var(--pico-muted-color);margin-bottom:0.25rem">
+                            {{ __('colony.bar_offer_get') }}
+                        </div>
+                        <strong>{{ $offer->get_amount }}×</strong>
+                        {{ $resourceLabels[$offer->get_resource_id] ?? $offer->get_resource_id }}
+                    </div>
+                </div>
+
+                <div style="display:flex;justify-content:space-between;align-items:center">
+                    <small style="color:var(--pico-muted-color)">
+                        {{ __('colony.bar_offer_expires') }} {{ $offer->expires_tick }}
+                    </small>
+                    <button
+                        @click="accept({{ $offer->id }}, $el)"
+                        :disabled="accepted.has({{ $offer->id }}) || loading"
+                        style="margin:0"
+                    >
+                        <span x-show="!accepted.has({{ $offer->id }})">{{ __('colony.bar_offer_accept') }}</span>
+                        <span x-show="accepted.has({{ $offer->id }})">✓</span>
+                    </button>
+                </div>
+                <div x-show="error[{{ $offer->id }}]" x-text="error[{{ $offer->id }}]"
+                     style="color:var(--pico-del-color);font-size:0.85rem;margin-top:0.5rem"></div>
+            </article>
+            @endforeach
+        </div>
+    @endif
+
+</div>
+
+<script>
+function barPage() {
+    return {
+        accepted: new Set(),
+        loading: false,
+        error: {},
+        async accept(offerId, btn) {
+            this.loading = true;
+            this.error[offerId] = null;
+            try {
+                const res = await fetch('{{ route('colony.bar.accept', ['offer' => '__ID__']) }}'.replace('__ID__', offerId), {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                        'Accept': 'application/json',
+                    },
+                });
+                const data = await res.json();
+                if (data.ok) {
+                    this.accepted.add(offerId);
+                } else {
+                    this.error[offerId] = data.error ?? 'Fehler';
+                }
+            } catch {
+                this.error[offerId] = 'Verbindungsfehler';
+            } finally {
+                this.loading = false;
+            }
+        },
+    };
+}
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Colony\BarController;
 use App\Http\Controllers\Colony\ColonyController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Galaxy\GalaxyController;
@@ -62,6 +63,10 @@ Route::middleware('auth')->prefix('colony')->name('colony.')->group(function () 
 
     // Onboarding hint actions (AJAX)
     Route::post('/hint/dismiss', [ColonyController::class, 'dismissHint'])->name('hint.dismiss');
+
+    // Bar/Cantina
+    Route::get('/bar',               [BarController::class, 'index'])->name('bar');
+    Route::post('/bar/accept/{offer}', [BarController::class, 'accept'])->name('bar.accept');
 });
 
 // ── Resources (Schritt 5) ─────────────────────────────────────────────────────

--- a/tests/Feature/Bar/BarControllerTest.php
+++ b/tests/Feature/Bar/BarControllerTest.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Tests\Feature\Bar;
+
+/**
+ * BarController feature tests.
+ *
+ * Covered scenarios:
+ *  AUTH GUARD
+ *    - test_index_requires_auth
+ *    - test_accept_requires_auth
+ *
+ *  INDEX
+ *    - test_index_shows_bar_page
+ *    - test_index_shows_bar_page_when_bar_not_built
+ *
+ *  ACCEPT
+ *    - test_accept_returns_json_ok
+ *    - test_accept_returns_error_for_nonexistent_offer
+ *    - test_accept_returns_error_when_insufficient_resources
+ *    - test_accept_does_not_allow_foreign_colony_offer
+ */
+
+use App\Models\User;
+use App\Services\TickService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class BarControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Fixture constants ─────────────────────────────────────────────────────
+
+    private const USER_ID_BART    = 3;
+    private const COLONY_ID_BART  = 1;
+    private const BAR_BUILDING_ID = 52;
+    private const RES_REGOLITH    = 3;
+    private const RES_COMPOUNDS   = 4;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function bart(): User
+    {
+        return User::find(self::USER_ID_BART);
+    }
+
+    /** Pin the TickService to a fixed tick so offer expiry is deterministic. */
+    private function mockTick(int $tick): void
+    {
+        $this->app->instance(TickService::class, new TickService($tick));
+    }
+
+    private function setBarLevel(int $level): void
+    {
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID_BART)
+            ->where('building_id', self::BAR_BUILDING_ID)
+            ->update(['level' => $level]);
+    }
+
+    private function clearBarOffers(): void
+    {
+        DB::table('bar_offers')->where('colony_id', self::COLONY_ID_BART)->delete();
+    }
+
+    /**
+     * Insert a valid (non-expired, non-accepted) offer for Springfield and return its id.
+     */
+    private function insertValidOffer(int $expiresTick = 9999): int
+    {
+        return DB::table('bar_offers')->insertGetId([
+            'colony_id'        => self::COLONY_ID_BART,
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => 10,
+            'get_resource_id'  => self::RES_COMPOUNDS,
+            'get_amount'       => 5,
+            'expires_tick'     => $expiresTick,
+            'is_accepted'      => false,
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+    }
+
+    private function setColonyResource(int $resourceId, int $amount): void
+    {
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID_BART, 'resource_id' => $resourceId],
+            ['amount' => $amount]
+        );
+    }
+
+    // ── Auth guard ────────────────────────────────────────────────────────────
+
+    public function test_index_requires_auth(): void
+    {
+        $response = $this->get(route('colony.bar'));
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_accept_requires_auth(): void
+    {
+        $response = $this->post(route('colony.bar.accept', ['offer' => 1]));
+        $response->assertRedirect(route('login'));
+    }
+
+    // ── INDEX ─────────────────────────────────────────────────────────────────
+
+    public function test_index_shows_bar_page(): void
+    {
+        $this->mockTick(1);
+        $this->setBarLevel(1);
+
+        $response = $this->actingAs($this->bart())
+            ->get(route('colony.bar'));
+
+        $response->assertOk();
+        $response->assertViewIs('colony.bar');
+        $response->assertViewHasAll(['colony', 'offers', 'barLevel', 'tick']);
+    }
+
+    public function test_index_shows_bar_page_when_bar_not_built(): void
+    {
+        $this->mockTick(1);
+        $this->setBarLevel(0);
+
+        $response = $this->actingAs($this->bart())
+            ->get(route('colony.bar'));
+
+        $response->assertOk();
+        $response->assertViewIs('colony.bar');
+
+        // barLevel must be 0 and offers must be empty
+        $barLevel = $response->viewData('barLevel');
+        $offers   = $response->viewData('offers');
+
+        $this->assertEquals(0, $barLevel);
+        $this->assertCount(0, $offers);
+    }
+
+    public function test_index_passes_active_offers_to_view(): void
+    {
+        $this->mockTick(10);
+        $this->setBarLevel(1);
+        $this->clearBarOffers();
+        $this->insertValidOffer(9999); // expires far in the future
+
+        $response = $this->actingAs($this->bart())
+            ->get(route('colony.bar'));
+
+        $response->assertOk();
+        $offers = $response->viewData('offers');
+        $this->assertCount(1, $offers, 'Index must pass the active offer to the view');
+    }
+
+    // ── ACCEPT ────────────────────────────────────────────────────────────────
+
+    public function test_accept_returns_json_ok(): void
+    {
+        $this->mockTick(10);
+        $this->setBarLevel(1);
+        $this->clearBarOffers();
+
+        // Give the player enough regolith to afford the offer
+        $this->setColonyResource(self::RES_REGOLITH, 100);
+
+        $offerId = $this->insertValidOffer(9999);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.bar.accept', ['offer' => $offerId]));
+
+        $response->assertOk()
+            ->assertJson(['ok' => true]);
+    }
+
+    public function test_accept_returns_error_for_nonexistent_offer(): void
+    {
+        $this->mockTick(10);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.bar.accept', ['offer' => 9999]));
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false])
+            ->assertJsonStructure(['ok', 'error']);
+    }
+
+    public function test_accept_returns_error_when_insufficient_resources(): void
+    {
+        $this->mockTick(10);
+        $this->clearBarOffers();
+
+        // Player has zero regolith but the offer costs 10 regolith
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertValidOffer(9999);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.bar.accept', ['offer' => $offerId]));
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false])
+            ->assertJsonStructure(['ok', 'error']);
+    }
+
+    public function test_accept_does_not_allow_foreign_colony_offer(): void
+    {
+        $this->mockTick(10);
+        $this->clearBarOffers();
+
+        // Insert an offer for Shelbyville (colony_id=2) — Bart's colony is 1
+        $foreignOfferId = DB::table('bar_offers')->insertGetId([
+            'colony_id'        => 2,
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => 10,
+            'get_resource_id'  => self::RES_COMPOUNDS,
+            'get_amount'       => 5,
+            'expires_tick'     => 9999,
+            'is_accepted'      => false,
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.bar.accept', ['offer' => $foreignOfferId]));
+
+        // The BarService looks up offer by id AND colony_id → offer not found for Bart's colony
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false]);
+    }
+
+    public function test_accept_returns_error_for_expired_offer(): void
+    {
+        $this->mockTick(100);
+        $this->clearBarOffers();
+
+        // Insert an offer that expired at tick 100 (service: expires_tick <= tick)
+        $expiredOfferId = $this->insertValidOffer(100);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.bar.accept', ['offer' => $expiredOfferId]));
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false]);
+    }
+
+    public function test_accept_returns_ok_status_code_200(): void
+    {
+        $this->mockTick(10);
+        $this->clearBarOffers();
+        $this->setColonyResource(self::RES_REGOLITH, 500);
+
+        $offerId = $this->insertValidOffer(9999);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.bar.accept', ['offer' => $offerId]));
+
+        // HTTP 200 on success, 422 on failure
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/Bar/BarServiceTest.php
+++ b/tests/Feature/Bar/BarServiceTest.php
@@ -1,0 +1,461 @@
+<?php
+
+namespace Tests\Feature\Bar;
+
+/**
+ * BarService feature tests.
+ *
+ * Covered scenarios:
+ *  GENERATE OFFERS
+ *    - test_generate_does_nothing_when_bar_not_built
+ *    - test_generate_creates_offers_when_bar_built
+ *    - test_generate_expires_old_offers
+ *
+ *  GET ACTIVE OFFERS
+ *    - test_get_active_offers_filters_expired
+ *    - test_get_active_offers_filters_accepted
+ *
+ *  ACCEPT OFFER
+ *    - test_accept_offer_deducts_give_and_adds_get
+ *    - test_accept_returns_error_for_expired_offer
+ *    - test_accept_returns_error_when_insufficient_resources
+ *    - test_accept_returns_error_for_foreign_offer
+ */
+
+use App\Services\BarService;
+use App\Services\TickService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class BarServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Fixture constants ─────────────────────────────────────────────────────
+
+    private const COLONY_ID      = 1;   // Springfield — user_id = 3 (Bart)
+    private const USER_ID        = 3;   // Bart
+    private const BAR_BUILDING_ID = 52;
+    private const RES_CREDITS    = 1;
+    private const RES_REGOLITH   = 3;
+    private const RES_COMPOUNDS  = 4;
+    private const RES_ORGANICS   = 5;
+
+    private BarService $barService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        $this->barService = $this->app->make(BarService::class);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Override the bar level for Springfield. Uses the row that the TestSeeder
+     * already inserts (colony_id=1, building_id=52).
+     */
+    private function setBarLevel(int $level): void
+    {
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::BAR_BUILDING_ID)
+            ->update(['level' => $level]);
+    }
+
+    /**
+     * Remove all bar_offers for Springfield so each test starts clean.
+     * The TestSeeder inserts two seeded offers (expires_tick=99) that would
+     * otherwise interfere with generate/accept tests.
+     */
+    private function clearBarOffers(): void
+    {
+        DB::table('bar_offers')->where('colony_id', self::COLONY_ID)->delete();
+    }
+
+    /**
+     * Insert a bar_offer directly and return its id.
+     */
+    private function insertOffer(array $overrides = []): int
+    {
+        $defaults = [
+            'colony_id'        => self::COLONY_ID,
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => 20,
+            'get_resource_id'  => self::RES_COMPOUNDS,
+            'get_amount'       => 10,
+            'expires_tick'     => 50,
+            'is_accepted'      => false,
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ];
+
+        return DB::table('bar_offers')->insertGetId(array_merge($defaults, $overrides));
+    }
+
+    /** Set the colony-level resource amount for Springfield. */
+    private function setColonyResource(int $resourceId, int $amount): void
+    {
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => $resourceId],
+            ['amount' => $amount]
+        );
+    }
+
+    /** Read the colony-level resource amount for Springfield. */
+    private function getColonyResource(int $resourceId): int
+    {
+        return (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('resource_id', $resourceId)
+            ->value('amount');
+    }
+
+    /** Set credits for Bart. */
+    private function setCredits(int $amount): void
+    {
+        DB::table('user_resources')
+            ->where('user_id', self::USER_ID)
+            ->update(['credits' => $amount]);
+    }
+
+    /** Read credits for Bart. */
+    private function getCredits(): int
+    {
+        return (int) DB::table('user_resources')
+            ->where('user_id', self::USER_ID)
+            ->value('credits');
+    }
+
+    /**
+     * Override the TickService singleton so that acceptOffer() sees a specific
+     * current tick rather than the wall-clock-derived one.
+     */
+    private function mockTick(int $tick): void
+    {
+        $this->app->instance(TickService::class, new TickService($tick));
+    }
+
+    // ── generateOffersForColony ───────────────────────────────────────────────
+
+    public function test_generate_does_nothing_when_bar_not_built(): void
+    {
+        $this->clearBarOffers();
+        $this->setBarLevel(0);
+
+        $this->barService->generateOffersForColony(self::COLONY_ID, 100);
+
+        $count = DB::table('bar_offers')
+            ->where('colony_id', self::COLONY_ID)
+            ->count();
+
+        $this->assertEquals(0, $count, 'No bar_offers should be created when bar level is 0');
+    }
+
+    public function test_generate_creates_offers_when_bar_built(): void
+    {
+        $this->clearBarOffers();
+        $this->setBarLevel(1);
+
+        // Use a seed+tick combination known to yield at least 1 guest at rank 0
+        // guest_count for rank 0 = [0, 1]; try multiple ticks to find one that hits 1.
+        // pseudoRand(colonyId*997 + tick*31, 0, 1) must return 1.
+        // We brute-force a tick value: check small range until one works.
+        $generated = false;
+        for ($tick = 100; $tick <= 200; $tick++) {
+            $this->clearBarOffers();
+            $this->barService->generateOffersForColony(self::COLONY_ID, $tick);
+
+            $count = DB::table('bar_offers')
+                ->where('colony_id', self::COLONY_ID)
+                ->count();
+
+            if ($count > 0) {
+                $generated = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($generated, 'generateOffersForColony should create at least one bar_offer for bar level 1');
+    }
+
+    public function test_generate_expires_old_offers(): void
+    {
+        $this->clearBarOffers();
+        $this->setBarLevel(1);
+
+        // Insert a stale offer that should be deleted (expires_tick=1 < tick=5)
+        $staleId = $this->insertOffer([
+            'expires_tick' => 1,
+            'is_accepted'  => false,
+        ]);
+
+        $this->barService->generateOffersForColony(self::COLONY_ID, 5);
+
+        $exists = DB::table('bar_offers')
+            ->where('id', $staleId)
+            ->exists();
+
+        $this->assertFalse($exists, 'Expired unaccepted offers must be deleted on generate');
+    }
+
+    public function test_generate_does_not_delete_accepted_expired_offers(): void
+    {
+        // Accepted offers are historical records — they should NOT be purged even if expired.
+        $this->clearBarOffers();
+        $this->setBarLevel(1);
+
+        $acceptedId = $this->insertOffer([
+            'expires_tick' => 1,
+            'is_accepted'  => true,
+        ]);
+
+        $this->barService->generateOffersForColony(self::COLONY_ID, 5);
+
+        $exists = DB::table('bar_offers')
+            ->where('id', $acceptedId)
+            ->exists();
+
+        $this->assertTrue($exists, 'Accepted offers must not be deleted even when expired');
+    }
+
+    // ── getActiveOffers ───────────────────────────────────────────────────────
+
+    public function test_get_active_offers_filters_expired(): void
+    {
+        $this->clearBarOffers();
+
+        // expires_tick = 5 means the offer expires AT tick 5 (exclusive: expires_tick > tick)
+        $this->insertOffer(['expires_tick' => 5]);
+
+        // At tick 5 the offer is expired (expires_tick > tick is false for tick=5)
+        $atExpiry = $this->barService->getActiveOffers(self::COLONY_ID, 5);
+        $this->assertCount(0, $atExpiry, 'Offer with expires_tick=5 must not appear at tick=5');
+
+        // At tick 4 the offer is still active (5 > 4)
+        $beforeExpiry = $this->barService->getActiveOffers(self::COLONY_ID, 4);
+        $this->assertCount(1, $beforeExpiry, 'Offer with expires_tick=5 must appear at tick=4');
+    }
+
+    public function test_get_active_offers_filters_accepted(): void
+    {
+        $this->clearBarOffers();
+
+        $this->insertOffer([
+            'expires_tick' => 99,
+            'is_accepted'  => true,
+        ]);
+
+        $offers = $this->barService->getActiveOffers(self::COLONY_ID, 1);
+        $this->assertCount(0, $offers, 'Accepted offers must not be returned as active');
+    }
+
+    public function test_get_active_offers_returns_non_expired_non_accepted_offers(): void
+    {
+        $this->clearBarOffers();
+
+        $this->insertOffer(['expires_tick' => 99, 'is_accepted' => false]);
+        $this->insertOffer(['expires_tick' => 99, 'is_accepted' => false]);
+
+        $offers = $this->barService->getActiveOffers(self::COLONY_ID, 1);
+        $this->assertCount(2, $offers);
+    }
+
+    // ── acceptOffer ───────────────────────────────────────────────────────────
+
+    public function test_accept_offer_deducts_give_and_adds_get(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        $giveAmount = 20;
+        $getAmount  = 30;
+
+        // Give = regolith (colony resource), get = compounds (colony resource)
+        $this->setColonyResource(self::RES_REGOLITH, 100);
+        $this->setColonyResource(self::RES_COMPOUNDS, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => $giveAmount,
+            'get_resource_id'  => self::RES_COMPOUNDS,
+            'get_amount'       => $getAmount,
+            'expires_tick'     => 20, // valid at tick 10
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertTrue($result['ok'], 'acceptOffer should return ok=true on success');
+
+        $regolithAfter  = $this->getColonyResource(self::RES_REGOLITH);
+        $compoundsAfter = $this->getColonyResource(self::RES_COMPOUNDS);
+
+        $this->assertEquals(100 - $giveAmount, $regolithAfter, 'give_amount of regolith must be deducted');
+        $this->assertEquals($getAmount, $compoundsAfter, 'get_amount of compounds must be added');
+    }
+
+    public function test_accept_offer_with_credits_as_give(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        $giveAmount = 500;  // player pays credits
+        $getAmount  = 20;   // player receives regolith
+
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount'      => $giveAmount,
+            'get_resource_id'  => self::RES_REGOLITH,
+            'get_amount'       => $getAmount,
+            'expires_tick'     => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertTrue($result['ok']);
+        // Credits are handled by ResourcesService::decreaseAmount → increaseAmount
+        // which goes through user_resources for res_id=1.
+        $creditsAfter   = $this->getCredits();
+        $regolithAfter  = $this->getColonyResource(self::RES_REGOLITH);
+
+        $this->assertEquals(1000 - $giveAmount, $creditsAfter, 'Credits must be deducted for the give side');
+        $this->assertEquals($getAmount, $regolithAfter, 'Regolith must be added for the get side');
+    }
+
+    public function test_accept_marks_offer_as_accepted(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        $this->setColonyResource(self::RES_REGOLITH, 100);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => 20,
+            'expires_tick'     => 20,
+        ]);
+
+        $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $isAccepted = (bool) DB::table('bar_offers')
+            ->where('id', $offerId)
+            ->value('is_accepted');
+
+        $this->assertTrue($isAccepted, 'Offer must be marked is_accepted=1 after successful accept');
+    }
+
+    public function test_accept_returns_error_for_expired_offer(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10); // current tick = 10
+
+        $offerId = $this->insertOffer([
+            'expires_tick' => 10, // expires AT tick 10 → expired (service checks <= tick)
+            'is_accepted'  => false,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertFalse($result['ok'], 'acceptOffer must fail for an expired offer');
+        $this->assertArrayHasKey('error', $result, 'Error key must be present in failure response');
+    }
+
+    public function test_accept_returns_error_when_insufficient_resources(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        // Player has less regolith than required
+        $this->setColonyResource(self::RES_REGOLITH, 5);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => 20, // needs 20 but only has 5
+            'expires_tick'     => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertFalse($result['ok'], 'acceptOffer must fail when player cannot afford give_amount');
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    public function test_accept_returns_error_when_zero_credits(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        $this->setCredits(0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount'      => 100,
+            'expires_tick'     => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertFalse($result['ok'], 'acceptOffer must fail when player has 0 credits and offer costs credits');
+    }
+
+    public function test_accept_returns_error_for_foreign_offer(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        // Insert offer for colony_id=2 (Shelbyville), not Springfield (1)
+        $foreignOfferId = DB::table('bar_offers')->insertGetId([
+            'colony_id'        => 2,
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => 10,
+            'get_resource_id'  => self::RES_COMPOUNDS,
+            'get_amount'       => 5,
+            'expires_tick'     => 20,
+            'is_accepted'      => false,
+            'created_at'       => now(),
+            'updated_at'       => now(),
+        ]);
+
+        // Bart tries to accept an offer that belongs to colony 2
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $foreignOfferId, self::USER_ID, 10);
+
+        $this->assertFalse($result['ok'], 'Player must not be able to accept offers from a foreign colony');
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    public function test_accept_returns_error_for_nonexistent_offer(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, 99999, self::USER_ID, 10);
+
+        $this->assertFalse($result['ok'], 'acceptOffer must fail for a non-existent offer id');
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    public function test_accept_returns_error_for_already_accepted_offer(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+
+        $this->setColonyResource(self::RES_REGOLITH, 100);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount'      => 20,
+            'expires_tick'     => 20,
+            'is_accepted'      => true, // pre-accepted
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertFalse($result['ok'], 'acceptOffer must fail when offer is already accepted');
+    }
+}

--- a/tests/Feature/GameTick/AdvisorPromotionCostTest.php
+++ b/tests/Feature/GameTick/AdvisorPromotionCostTest.php
@@ -1,0 +1,251 @@
+<?php
+
+namespace Tests\Feature\GameTick;
+
+/**
+ * Advisor rank-promotion cost tests.
+ *
+ * Tests cover the incrementAdvisorTicks() step in GameTick which charges a
+ * one-time Credits cost when an advisor crosses a rank threshold.
+ *
+ * Config:
+ *   game.advisor.rank_thresholds  = [1 => 10, 2 => 20]  (active_ticks needed to promote)
+ *   game.advisor.promotion_costs  = [2 => 150, 3 => 400]  (Credits charged at target rank)
+ *
+ * Test fixture (from TestSeeder):
+ *   Colony 1 (Springfield), user_id = 3 (Bart)
+ *   Advisor id=3: user_id=3, personell_id=92 (trader), colony_id=1, rank=1, active_ticks=0
+ *
+ * Covered scenarios:
+ *   - test_promotion_deducts_credits_from_user
+ *   - test_promotion_deferred_when_insufficient_credits
+ *   - test_promotion_cost_matches_config
+ *   - test_no_cost_deducted_if_no_promotion
+ */
+
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AdvisorPromotionCostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Fixture constants ─────────────────────────────────────────────────────
+
+    private const USER_ID   = 3;    // Bart
+    private const COLONY_ID = 1;    // Springfield
+
+    /**
+     * Trader advisor (personell_id=92) — present in test data for colony 1.
+     * We use its id (3) throughout these tests.
+     */
+    private const ADVISOR_ID          = 3;
+    private const ADVISOR_PERSONELL_ID = 92;
+
+    /**
+     * Threshold from config: advisor at rank 1 needs 10 active_ticks to become rank 2.
+     * Set active_ticks to threshold - 1 so that one tick push crosses the boundary.
+     */
+    private const RANK1_THRESHOLD   = 10; // config('game.advisor.rank_thresholds')[1]
+    private const RANK2_COST        = 150; // config('game.advisor.promotion_costs')[2]
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        // Remove all advisors for Bart except the trader (id=3) so upkeep costs
+        // from other advisors don't contaminate the credits balance under test.
+        DB::table('advisors')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('id', '!=', self::ADVISOR_ID)
+            ->delete();
+
+        // Reset the trader advisor to rank 1 and place it one tick below the threshold.
+        // After one tick increment it will reach active_ticks = threshold and be eligible.
+        DB::table('advisors')
+            ->where('id', self::ADVISOR_ID)
+            ->update([
+                'rank'        => 1,
+                'active_ticks' => self::RANK1_THRESHOLD - 1,
+            ]);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function setCredits(int $amount): void
+    {
+        DB::table('user_resources')
+            ->where('user_id', self::USER_ID)
+            ->update(['credits' => $amount]);
+    }
+
+    private function getCredits(): int
+    {
+        return (int) DB::table('user_resources')
+            ->where('user_id', self::USER_ID)
+            ->value('credits');
+    }
+
+    private function getAdvisorRank(): int
+    {
+        return (int) DB::table('advisors')
+            ->where('id', self::ADVISOR_ID)
+            ->value('rank');
+    }
+
+    private function getAdvisorActiveTicks(): int
+    {
+        return (int) DB::table('advisors')
+            ->where('id', self::ADVISOR_ID)
+            ->value('active_ticks');
+    }
+
+    /**
+     * Run the game:tick command at a high tick number that has no fleet orders
+     * scheduled (to keep the test isolated to the advisor tick step).
+     */
+    private function runTick(int $tick = 9500): void
+    {
+        Artisan::call('game:tick', ['--tick' => $tick]);
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    public function test_promotion_deducts_credits_from_user(): void
+    {
+        // Give the player more than enough credits for the promotion cost
+        $initialCredits = 10_000;
+        $this->setCredits($initialCredits);
+
+        $this->runTick(9500);
+
+        $rank = $this->getAdvisorRank();
+        $this->assertEquals(2, $rank, 'Advisor must reach rank 2 after crossing the threshold');
+
+        $creditsAfter = $this->getCredits();
+        $this->assertLessThan(
+            $initialCredits,
+            $creditsAfter,
+            'Credits must have been deducted for the promotion'
+        );
+    }
+
+    public function test_promotion_deferred_when_insufficient_credits(): void
+    {
+        // Exactly 0 credits — cannot afford the rank-2 promotion cost of 150
+        $this->setCredits(0);
+
+        $this->runTick(9501);
+
+        $rank = $this->getAdvisorRank();
+        $this->assertEquals(1, $rank, 'Advisor rank must stay at 1 when player cannot afford promotion cost');
+
+        // Credits must not go negative. Passive income fires before the promotion check
+        // (nexus subsidy + housing tax), so exact value depends on colony state.
+        $creditsAfter = $this->getCredits();
+        $this->assertGreaterThanOrEqual(0, $creditsAfter, 'Credits must not go below 0');
+    }
+
+    public function test_promotion_cost_matches_config(): void
+    {
+        $configCost = (int) config('game.advisor.promotion_costs.2', 150);
+
+        // Give the player exactly enough for the configured cost plus what upkeep
+        // will consume. Upkeep for rank-1 advisor = 10 Cr. Passive income also fires
+        // (nexus 30 + housing × 20). We set credits high enough to isolate the promotion cost.
+        // Strategy: set credits to a round number, run tick, then check the delta
+        // against the expected cost (accounting for income/upkeep in the same tick).
+
+        // Determine the net credits delta in a control run WITHOUT promotion:
+        // Use a tick number where active_ticks will NOT cross the threshold.
+        DB::table('advisors')
+            ->where('id', self::ADVISOR_ID)
+            ->update(['active_ticks' => 0]); // far from threshold
+
+        $controlCredits = 10_000;
+        $this->setCredits($controlCredits);
+        $this->runTick(9510);
+        $afterControl = $this->getCredits();
+        $netDeltaNoPromotion = $afterControl - $controlCredits;
+
+        // Reset advisor to one tick before promotion threshold
+        DB::table('advisors')
+            ->where('id', self::ADVISOR_ID)
+            ->update([
+                'rank'        => 1,
+                'active_ticks' => self::RANK1_THRESHOLD - 1,
+            ]);
+
+        $this->setCredits($controlCredits);
+        $this->runTick(9511);
+        $afterPromotion = $this->getCredits();
+        $netDeltaWithPromotion = $afterPromotion - $controlCredits;
+
+        // The difference between the two runs must be exactly the promotion cost
+        $promotionCostActual = $netDeltaNoPromotion - $netDeltaWithPromotion;
+
+        $this->assertEquals(
+            $configCost,
+            $promotionCostActual,
+            "Promotion cost must equal config value ({$configCost} Cr)"
+        );
+    }
+
+    public function test_no_cost_deducted_if_no_promotion(): void
+    {
+        // Set active_ticks well below the threshold so no promotion fires
+        DB::table('advisors')
+            ->where('id', self::ADVISOR_ID)
+            ->update(['active_ticks' => 0]);
+
+        $initialCredits = 5_000;
+        $this->setCredits($initialCredits);
+
+        $this->runTick(9520);
+
+        $rank = $this->getAdvisorRank();
+        $this->assertEquals(1, $rank, 'Advisor must remain at rank 1 when threshold is not reached');
+
+        // Credits may change due to passive income/upkeep, but must NOT decrease
+        // by the promotion cost (150 Cr). The maximum possible upkeep for a single
+        // rank-1 advisor is 10 Cr; passive income is >= 30 Cr (nexus subsidy alone).
+        // Net: credits should be >= initial (income > upkeep). Asserting simply that
+        // the promotion cost of 150 was not charged — i.e. credits > initial - 150.
+        $creditsAfter = $this->getCredits();
+        $this->assertGreaterThan(
+            $initialCredits - self::RANK2_COST,
+            $creditsAfter,
+            'Promotion cost must not be deducted when the advisor did not promote'
+        );
+    }
+
+    public function test_promotion_only_fires_once(): void
+    {
+        // After promotion, subsequent ticks must not charge the cost again.
+        $initialCredits = 10_000;
+        $this->setCredits($initialCredits);
+
+        // First tick: crosses threshold → promotes to rank 2
+        $this->runTick(9530);
+        $this->assertEquals(2, $this->getAdvisorRank(), 'Advisor must be rank 2 after first tick');
+        $afterFirstTick = $this->getCredits();
+
+        // Second tick: advisor is now rank 2, already past rank-1 threshold.
+        // The rank-2 threshold (20 ticks) is far away — no second promotion should fire.
+        $this->runTick(9531);
+        $afterSecondTick = $this->getCredits();
+
+        // The only difference between ticks should be the recurring upkeep (50 Cr for rank 2)
+        // and passive income. The promotion cost (150 Cr) must NOT be charged again.
+        $deltaSecondTick = $afterFirstTick - $afterSecondTick;
+        $this->assertLessThan(
+            self::RANK2_COST,
+            $deltaSecondTick,
+            'Promotion cost must not be charged a second time after the advisor already promoted'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Bar-Event-System**: Pro Tick erscheinen 0–2 NPC-Gäste in der Cantina (abhängig von Konsul-Rang). Angebote laufen nach 2 Ticks ab. Zwei Angebotstypen: Ressource gegen Credits oder Tausch (Ressource↔Ressource). `BarService`, `BarController`, Route `/colony/bar`, Blade-View (PicoCSS + Alpine.js).
- **Berater Beförderungskosten**: Rang-Aufstieg 1→2 kostet 150 Cr, 2→3 kostet 400 Cr. Bei fehlenden Credits wird die Beförderung auf den nächsten Tick verschoben. Konfigurierbar via `config/game.php → advisor.promotion_costs`.
- 32 neue Tests

## Test plan

- [ ] `php artisan test` — alle 501 Tests grün
- [ ] `php artisan migrate` auf Dev-DB → `bar_offers`-Tabelle vorhanden
- [ ] Bar bauen → Tick ausführen → `/colony/bar` aufrufen → Angebote erscheinen
- [ ] Angebot annehmen → Ressourcen korrekt transferiert, Angebot markiert als angenommen
- [ ] Berater auf active_ticks=9 setzen → Tick ohne Credits ausführen → Rang bleibt 1
- [ ] Dann Credits geben → Tick → Rang steigt auf 2, 150 Cr abgezogen