### PR TITLE
fix: Dev Panel — Supply durch CC/Housing Level ersetzen

### DIFF
--- a/tools/dev-panel.php
+++ b/tools/dev-panel.php
@@ -72,19 +72,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $value   = (int) ($_POST['value'] ?? 0);
 
     try {
-        if ($type === 'user' && in_array($field, ['credits', 'supply'], true)) {
-            $stmt = $db->prepare("UPDATE user_resources SET {$field} = ? WHERE user_id = ?");
-            $stmt->execute([$value, $userId]);
-            $message = "Updated user #{$userId} {$field} → {$value}";
+        if ($type === 'user' && $field === 'credits') {
+            $db->prepare("UPDATE user_resources SET credits = ? WHERE user_id = ?")
+               ->execute([$value, $userId]);
+            $message = "Updated user #{$userId} credits → {$value}";
         } elseif ($type === 'colony' && isset($editableColonyResources[(int) $field])) {
             $resourceId = (int) $field;
-            $stmt = $db->prepare(
+            $db->prepare(
                 "INSERT INTO colony_resources (colony_id, resource_id, amount)
                  VALUES (?, ?, ?)
                  ON CONFLICT(colony_id, resource_id) DO UPDATE SET amount = excluded.amount"
-            );
-            $stmt->execute([$colonId, $resourceId, $value]);
+            )->execute([$colonId, $resourceId, $value]);
             $message = "Updated colony #{$colonId} {$editableColonyResources[$resourceId]} → {$value}";
+        } elseif ($type === 'building_level' && in_array((int) $field, [25, 28], true)) {
+            $buildingId = (int) $field;
+            $maxLevel   = $buildingId === 25 ? 5 : 6;
+            $value      = max(0, min($value, $maxLevel));
+            $db->prepare(
+                "UPDATE colony_buildings SET level = ? WHERE colony_id = ? AND building_id = ?"
+            )->execute([$value, $colonId, $buildingId]);
+            $label   = $buildingId === 25 ? 'CC Level' : 'Housing Level';
+            $message = "Updated colony #{$colonId} {$label} → {$value}";
         } else {
             $message = 'Invalid update request.';
         }
@@ -126,6 +134,17 @@ $colonyResRows = $db->query(
 $colonyResMap = [];
 foreach ($colonyResRows as $r) {
     $colonyResMap[$r['colony_id']][$r['resource_id']] = $r['amount'];
+}
+
+// CC (25) + Housing (28) levels per colony — used to calculate supply cap
+$buildingLevels = [];
+foreach ($db->query("SELECT colony_id, building_id, level FROM colony_buildings WHERE building_id IN (25, 28)")
+             ->fetchAll(PDO::FETCH_ASSOC) as $r) {
+    $buildingLevels[$r['colony_id']][$r['building_id']] = (int) $r['level'];
+}
+
+function supplyCapFormula(int $ccLevel, int $housingLevel): int {
+    return $ccLevel > 0 ? min(10 + ($housingLevel * 8), 200) : 0;
 }
 
 // ── Load techtree data ────────────────────────────────────────────────────────
@@ -320,7 +339,7 @@ button.set-btn:hover { background: #2a4a9e; }
 
 <h2>User Resources</h2>
 <table class="res-table">
-<tr><th>User</th><th>Credits</th><th>Supply</th></tr>
+<tr><th>User</th><th>Credits</th></tr>
 <?php foreach ($users as $u): ?>
 <tr>
   <td><span class="user-label"><?= h($u['username']) ?></span><br><span class="id-label">user_id <?= $u['user_id'] ?></span></td>
@@ -335,17 +354,6 @@ button.set-btn:hover { background: #2a4a9e; }
       </div>
     </form>
   </td>
-  <td>
-    <form method="POST" action="?tab=resources">
-      <input type="hidden" name="type" value="user">
-      <input type="hidden" name="user_id" value="<?= $u['user_id'] ?>">
-      <input type="hidden" name="field" value="supply">
-      <div class="field-row">
-        <input type="number" name="value" value="<?= (int) $u['supply'] ?>" min="0">
-        <button type="submit" class="set-btn">Set</button>
-      </div>
-    </form>
-  </td>
 </tr>
 <?php endforeach; ?>
 </table>
@@ -354,14 +362,49 @@ button.set-btn:hover { background: #2a4a9e; }
 <table class="res-table">
 <tr>
   <th>Colony</th>
+  <th>CC Level <span style="font-weight:400;color:#555">(max 5)</span></th>
+  <th>Housing Level <span style="font-weight:400;color:#555">(max 6)</span></th>
+  <th>Supply Cap <span style="font-weight:400;color:#555">(berechnet)</span></th>
   <?php foreach ($editableColonyResources as $name): ?><th><?= h($name) ?></th><?php endforeach; ?>
 </tr>
 <?php foreach ($colonies as $col): ?>
-<?php $res = $colonyResMap[$col['colony_id']] ?? []; ?>
+<?php
+    $res        = $colonyResMap[$col['colony_id']] ?? [];
+    $bldLevels  = $buildingLevels[$col['colony_id']] ?? [];
+    $ccLevel    = $bldLevels[25] ?? 0;
+    $hsLevel    = $bldLevels[28] ?? 0;
+    $supplyCap  = supplyCapFormula($ccLevel, $hsLevel);
+?>
 <tr>
   <td>
     <span class="user-label"><?= h($col['colony_name']) ?></span><br>
     <span class="id-label">colony_id <?= $col['colony_id'] ?> · <?= h($col['username'] ?? 'NPC') ?></span>
+  </td>
+  <td>
+    <form method="POST" action="?tab=resources">
+      <input type="hidden" name="type" value="building_level">
+      <input type="hidden" name="colony_id" value="<?= $col['colony_id'] ?>">
+      <input type="hidden" name="field" value="25">
+      <div class="field-row">
+        <input type="number" name="value" value="<?= $ccLevel ?>" min="0" max="5">
+        <button type="submit" class="set-btn">Set</button>
+      </div>
+    </form>
+  </td>
+  <td>
+    <form method="POST" action="?tab=resources">
+      <input type="hidden" name="type" value="building_level">
+      <input type="hidden" name="colony_id" value="<?= $col['colony_id'] ?>">
+      <input type="hidden" name="field" value="28">
+      <div class="field-row">
+        <input type="number" name="value" value="<?= $hsLevel ?>" min="0" max="6">
+        <button type="submit" class="set-btn">Set</button>
+      </div>
+    </form>
+  </td>
+  <td>
+    <span style="font-family:monospace;color:#7fbbff"><?= $supplyCap ?></span>
+    <br><span class="id-label">10 + <?= $hsLevel ?>×8<?= $ccLevel === 0 ? ' (kein CC)' : '' ?></span>
   </td>
   <?php foreach ($editableColonyResources as $rid => $rname): ?>
   <td>


### PR DESCRIPTION
## Summary

Supply in `user_resources` wird jedes Tick aus CC Level + Housing Level berechnet und überschrieben — der direkte Input war irreführend und wirkungslos.

**Vorher:** Supply als freies Zahlenfeld editierbar  
**Nachher:**
- Supply-Feld aus User-Tabelle entfernt
- Colony-Tabelle: CC Level (0–5) und Housing Level (0–6) direkt editierbar → UPDATE auf `colony_buildings.level`
- Supply Cap als read-only Anzeige mit sichtbarer Formel: `10 + Housing×8`

## Test plan

- [ ] CC Level Set → `colony_buildings` updated korrekt
- [ ] Housing Level Set → Supply Cap Anzeige aktualisiert sich
- [ ] Werte außerhalb Grenzen werden auf max geclippt (0–5 / 0–6)
- [ ] Kein Supply-Input mehr sichtbar