### PR TITLE
feat: Vertrauensanzeige, Sol-Nummer + Reisender Händler Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-05-17
 
+- **Vertrauensanzeige + Sol-Nummer**: Colony Hexview zeigt jetzt aktuelle Sol-Nummer in der Statuszeile (`Sol 42 · X/Y Tiles erkundet · CC Level N`) sowie Vertrauens-Chip mit Farbindikator (grün ≥ 20, grau 0–19, rot < 0). Bar-Screen: "Tick" → "Sol" korrigiert.
+- **Reisender Händler** (`MerchantService`, `MerchantController`): Händler erscheint ab Sol 15–20, danach alle 10–15 Sole für je 2 Sole. Bietet 3 Items (Reparatur-Kit, Vertrauensschub, Systemkarte, AP-Paket). Alpine-gesteuerte `<dialog>`-Modal im Hexview mit Kauffunktion (`/colony/merchant/buy/{id}`). GameTick (Schritt 11) spawnt Besuche automatisch. DB: `merchant_visits` + `merchant_items` Tabellen.
 - **Sol-Terminologie**: Player-facing "Tick" → "Sol" in `lang/de/` (buildings, colony, fleet — 5 Strings) und `docs/GDD.md`. Intern bleiben `TickService`, `game:tick`, DB-Spalten und Config-Keys unverändert. Spielzeit heißt jetzt offiziell **Sol** (angelehnt an NASA-Terminologie für Marssonnentag).
 - **Dev Panel (`tools/dev-panel.php`)**: Kombiniertes Browser-Tool, löst `techtree-editor.php` und `resource-editor.php` ab. Tab-Navigation: **Resources** — Credits, Supply, Regolith, Werkstoffe, Organika, Vertrauen für beliebige User/Kolonie setzen ohne SQL. **Techtree** — Drag-and-Drop-Editor für Techtree-Positionen (phase/row/column). Ein Port statt zwei: `php -S localhost:8081 tools/dev-panel.php`.
 - **Tick-Dry-Run (`game:tick-dry-run`)**: Artisan-Command simuliert einen Tick ohne DB-Schreibzugriff. Zeigt Credits-Delta (Nexus/Housing/Berater-Upkeep), Ressourcen-Produktion mit Moral-Multiplikator, Building-Decay-Status mit farbigen Warnungen (gelb < 40% SP, rot < 20% SP / Level-Down). `--colony=ID` filtert auf eine Kolonie.

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -14,6 +14,7 @@ use App\Models\FleetShip;
 use App\Models\UserResource;
 use App\Services\BarService;
 use App\Services\EventService;
+use App\Services\MerchantService;
 use App\Services\MoralService;
 use App\Services\OnboardingTriggerService;
 use App\Services\ResourcesService;
@@ -41,6 +42,7 @@ use Illuminate\Support\Facades\DB;
  *  8d. Advisor upkeep     — deduct Credits per active advisor by rank (10/50/160 Cr); clamped to ≥ 0
  *  9. Advisor ticks       — increment active_ticks, check rank promotions
  * 10. Bar offers          — expire stale offers, generate new NPC offers per colony with Bar
+ * 11. Merchant spawn      — check each colony for a new Traveling Merchant visit
  */
 class GameTick extends Command
 {
@@ -56,7 +58,8 @@ class GameTick extends Command
         private readonly MoralService              $moralService,
         private readonly ResourcesService          $resourcesService,
         private readonly OnboardingTriggerService  $onboardingTriggerService,
-        private readonly BarService               $barService,
+        private readonly BarService                $barService,
+        private readonly MerchantService           $merchantService,
     ) {
         parent::__construct();
     }
@@ -109,6 +112,9 @@ class GameTick extends Command
 
             $n = $this->processBarOffers($tick);
             $this->line("  Bar offers generated:     {$n}");
+
+            $n = $this->processMerchantSpawn($tick);
+            $this->line("  Merchant visits spawned:  {$n}");
         });
 
         $this->info("Tick {$tick} done.");
@@ -874,6 +880,29 @@ class GameTick extends Command
     }
 
     // ── 9. Advisor ticks ─────────────────────────────────────────────────────
+
+    // ── 11. Merchant spawn ────────────────────────────────────────────────────
+
+    /**
+     * For every player colony, check if a new Traveling Merchant visit should
+     * be spawned this tick. NPC colonies (user_id = null) are skipped.
+     *
+     * @return int Number of new visits spawned.
+     */
+    private function processMerchantSpawn(int $tick): int
+    {
+        $colonies = Colony::whereNotNull('user_id')->get();
+        $spawned  = 0;
+
+        foreach ($colonies as $colony) {
+            if ($this->merchantService->shouldSpawn($colony->id, $tick)) {
+                $this->merchantService->spawnVisit($colony->id, $tick);
+                $spawned++;
+            }
+        }
+
+        return $spawned;
+    }
 
     private function incrementAdvisorTicks(): int
     {

--- a/app/Http/Controllers/Colony/BarController.php
+++ b/app/Http/Controllers/Colony/BarController.php
@@ -26,8 +26,9 @@ class BarController extends BaseController
 
     public function index(): View
     {
-        $colony = $this->colonyService->getPrimeColony(Auth::id());
-        $tick   = $this->tick->getTickCount();
+        $colony     = $this->colonyService->getPrimeColony(Auth::id());
+        $tick       = $this->tick->getTickCount();
+        $currentSol = max(1, $tick - (int) $colony->since_tick + 1);
 
         $barLevel = (int) DB::table('colony_buildings')
             ->where('colony_id', $colony->id)
@@ -38,7 +39,7 @@ class BarController extends BaseController
             ? $this->barService->getActiveOffers($colony->id, $tick)
             : collect();
 
-        return view('colony.bar', compact('colony', 'offers', 'barLevel', 'tick'));
+        return view('colony.bar', compact('colony', 'offers', 'barLevel', 'currentSol'));
     }
 
     public function accept(Request $request, int $offerId): JsonResponse

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Colony;
 use App\Http\Controllers\BaseController;
 use App\Services\ColonyService;
 use App\Services\ColonyTileService;
+use App\Services\MerchantService;
 use App\Services\OnboardingHintService;
 use App\Services\OnboardingTriggerService;
 use App\Services\Techtree\PersonellService;
@@ -25,6 +26,7 @@ class ColonyController extends BaseController
         private readonly PersonellService $personellService,
         private readonly OnboardingHintService $hintService,
         private readonly OnboardingTriggerService $onboardingTriggerService,
+        private readonly MerchantService $merchantService,
     ) {
         parent::__construct($tick);
     }
@@ -81,7 +83,15 @@ class ColonyController extends BaseController
         $fireds        = json_decode(DB::table('user_preferences')->where('user_id', Auth::id())->value('fired_triggers') ?? '[]', true) ?? [];
         $supplyCapFull = in_array('supply_cap_full', $fireds);
 
-        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'navAp', 'constructionAp', 'activeHint', 'supplyCapFull'));
+        $trust      = (int) (DB::table('colony_resources')->where('colony_id', $colony->id)->where('resource_id', 12)->value('amount') ?? 0);
+        $currentSol = $this->getTick();
+
+        $merchantVisit = $this->merchantService->getActiveVisit($colony->id, $currentSol);
+        $merchantItems = $merchantVisit
+            ? $this->merchantService->getItemsForVisit($merchantVisit->id)->values()->toArray()
+            : [];
+
+        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'navAp', 'constructionAp', 'activeHint', 'supplyCapFull', 'trust', 'currentSol', 'merchantVisit', 'merchantItems'));
     }
 
     // ── Tile actions ──────────────────────────────────────────────────────────

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -84,14 +84,16 @@ class ColonyController extends BaseController
         $supplyCapFull = in_array('supply_cap_full', $fireds);
 
         $trust      = (int) (DB::table('colony_resources')->where('colony_id', $colony->id)->where('resource_id', 12)->value('amount') ?? 0);
-        $currentSol = $this->getTick();
+        $globalTick = $this->getTick();
+        $currentSol = max(1, $globalTick - (int) $colony->since_tick + 1);
+        $solLimit   = (int) config('game.run.tick_limit', 100);
 
-        $merchantVisit = $this->merchantService->getActiveVisit($colony->id, $currentSol);
+        $merchantVisit = $this->merchantService->getActiveVisit($colony->id, $globalTick);
         $merchantItems = $merchantVisit
             ? $this->merchantService->getItemsForVisit($merchantVisit->id)->values()->toArray()
             : [];
 
-        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'navAp', 'constructionAp', 'activeHint', 'supplyCapFull', 'trust', 'currentSol', 'merchantVisit', 'merchantItems'));
+        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'navAp', 'constructionAp', 'activeHint', 'supplyCapFull', 'trust', 'currentSol', 'solLimit', 'merchantVisit', 'merchantItems'));
     }
 
     // ── Tile actions ──────────────────────────────────────────────────────────

--- a/app/Http/Controllers/Colony/MerchantController.php
+++ b/app/Http/Controllers/Colony/MerchantController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\Colony;
+
+use App\Http\Controllers\BaseController;
+use App\Services\ColonyService;
+use App\Services\MerchantService;
+use App\Services\TickService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class MerchantController extends BaseController
+{
+    public function __construct(
+        TickService $tick,
+        private readonly ColonyService  $colonyService,
+        private readonly MerchantService $merchantService,
+    ) {
+        parent::__construct($tick);
+    }
+
+    /**
+     * POST /merchant/buy/{itemId}
+     *
+     * Purchase one merchant item. Returns JSON with ok/error and new credits balance.
+     */
+    public function buy(Request $request, int $itemId): JsonResponse
+    {
+        $userId = Auth::id();
+        $colony = $this->colonyService->getPrimeColony($userId);
+        $result = $this->merchantService->buyItem($itemId, $colony->id, $userId);
+
+        return response()->json($result, $result['ok'] ? 200 : 422);
+    }
+
+    /**
+     * POST /merchant/visit/{visitId}/open
+     *
+     * Mark a merchant visit as seen (player opened the modal).
+     */
+    public function markVisited(Request $request, int $visitId): JsonResponse
+    {
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $this->merchantService->markVisited($visitId, $colony->id);
+
+        return response()->json(['ok' => true]);
+    }
+}

--- a/app/Services/MerchantService.php
+++ b/app/Services/MerchantService.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace App\Services;
+
+use App\Services\TickService;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * MerchantService — handles Traveling Merchant (Reisender Händler) visits.
+ *
+ * The merchant is a colony-level system event, completely separate from the
+ * Bar/Cantina. It appears randomly after Sol 15–20 and then every 10–15 Sols,
+ * stays for 2 Sols, and offers 3 special items for Credits.
+ *
+ * Item effects implemented in Phase 3:
+ *   - repair_kit   → adds sp_amount to colony_buildings.status_points (capped at max_status_points)
+ *                    for the building with the lowest relative condition
+ *   - trust_boost  → adds trust_amount to colony_resources (resource_id = 12)
+ *   - information  → sets colony_tiles.is_explored = 1 for all tiles of the colony
+ *
+ * Item effects deferred to Phase 4:
+ *   - ap_flex / ap_targeted → marked sold, effect logged as TODO
+ *   - credit_loan           → not yet offered (config placeholder)
+ */
+class MerchantService
+{
+    private const TRUST_RESOURCE_ID = 12;
+
+    public function getActiveVisit(int $colonyId, int $currentTick): ?object
+    {
+        return DB::table('merchant_visits')
+            ->where('colony_id', $colonyId)
+            ->where('tick_start', '<=', $currentTick)
+            ->where('tick_end', '>=', $currentTick)
+            ->first();
+    }
+
+    public function spawnVisit(int $colonyId, int $currentTick): void
+    {
+        $cfg      = config('game.merchant', []);
+        $duration = (int) ($cfg['duration_ticks'] ?? 2);
+        $count    = (int) ($cfg['items_count'] ?? 3);
+        $pool     = $cfg['items'] ?? [];
+
+        if (empty($pool)) {
+            return;
+        }
+
+        $visitId = DB::table('merchant_visits')->insertGetId([
+            'colony_id'   => $colonyId,
+            'tick_start'  => $currentTick,
+            'tick_end'    => $currentTick + $duration - 1,
+            'was_visited' => false,
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]);
+
+        // Pick $count unique item types pseudo-randomly, seeded by colonyId + tick.
+        $types   = array_keys($pool);
+        $picked  = $this->pickItems($types, $count, $colonyId, $currentTick);
+
+        foreach ($picked as $type) {
+            $def = $pool[$type] ?? [];
+            DB::table('merchant_items')->insert([
+                'visit_id'     => $visitId,
+                'item_type'    => $type,
+                'label'        => $def['label'] ?? $type,
+                'cost_credits' => (int) ($def['cost'] ?? 0),
+                'payload'      => $this->buildPayload($type, $def),
+                'sold'         => false,
+                'created_at'   => now(),
+                'updated_at'   => now(),
+            ]);
+        }
+    }
+
+    public function shouldSpawn(int $colonyId, int $currentTick): bool
+    {
+        $cfg = config('game.merchant', []);
+
+        $firstMin    = (int) ($cfg['first_appearance_min'] ?? 15);
+        $intervalMin = (int) ($cfg['interval_min'] ?? 10);
+        $intervalMax = (int) ($cfg['interval_max'] ?? 15);
+        $intervalAvg = ($intervalMin + $intervalMax) / 2.0;
+
+        // Not yet past the earliest possible first appearance
+        if ($currentTick < $firstMin) {
+            return false;
+        }
+
+        // No spawn if a visit is currently active or scheduled in the future
+        $existingVisit = DB::table('merchant_visits')
+            ->where('colony_id', $colonyId)
+            ->where('tick_end', '>=', $currentTick)
+            ->exists();
+
+        if ($existingVisit) {
+            return false;
+        }
+
+        // Find when the last visit ended
+        $lastEnd = DB::table('merchant_visits')
+            ->where('colony_id', $colonyId)
+            ->max('tick_end');
+
+        if ($lastEnd !== null) {
+            // Must wait at least interval_min Sols since last visit ended
+            if (($currentTick - (int) $lastEnd) < $intervalMin) {
+                return false;
+            }
+        }
+
+        // Random chance: ~1/interval_avg per tick so visits are spread out naturally.
+        // Deterministic seed per colony+tick so parallel processing is idempotent.
+        $seed  = $colonyId * 1664525 + $currentTick * 1013904223;
+        $hash  = abs($seed & 0x7FFFFFFF);
+        $frac  = $hash / 0x7FFFFFFF; // 0.0 – 1.0
+
+        return $frac < (1.0 / $intervalAvg);
+    }
+
+    public function buyItem(int $itemId, int $colonyId, int $userId): array
+    {
+        $item = DB::table('merchant_items')->where('id', $itemId)->first();
+
+        if (!$item) {
+            return ['ok' => false, 'error' => 'Item nicht gefunden.'];
+        }
+
+        if ($item->sold) {
+            return ['ok' => false, 'error' => 'Dieses Item wurde bereits gekauft.'];
+        }
+
+        // Verify the visit is still active
+        $tick  = app(TickService::class)->getTickCount();
+        $visit = DB::table('merchant_visits')
+            ->where('id', $item->visit_id)
+            ->where('colony_id', $colonyId)
+            ->where('tick_start', '<=', $tick)
+            ->where('tick_end', '>=', $tick)
+            ->first();
+
+        if (!$visit) {
+            return ['ok' => false, 'error' => 'Der Händler ist nicht mehr anwesend.'];
+        }
+
+        // Check credits
+        $credits = (int) (DB::table('user_resources')
+            ->where('user_id', $userId)
+            ->value('credits') ?? 0);
+
+        if ($credits < $item->cost_credits) {
+            return ['ok' => false, 'error' => 'Nicht genug Credits.'];
+        }
+
+        // Deduct credits
+        DB::table('user_resources')
+            ->where('user_id', $userId)
+            ->decrement('credits', $item->cost_credits);
+
+        // Apply effect
+        $this->applyItemEffect($item, $colonyId);
+
+        // Mark sold
+        DB::table('merchant_items')
+            ->where('id', $itemId)
+            ->update(['sold' => true, 'updated_at' => now()]);
+
+        $newCredits = (int) (DB::table('user_resources')
+            ->where('user_id', $userId)
+            ->value('credits') ?? 0);
+
+        return [
+            'ok'      => true,
+            'message' => 'Kauf erfolgreich.',
+            'credits' => $newCredits,
+        ];
+    }
+
+    public function getItemsForVisit(int $visitId): Collection
+    {
+        return DB::table('merchant_items')
+            ->where('visit_id', $visitId)
+            ->orderBy('id')
+            ->get();
+    }
+
+    public function markVisited(int $visitId, int $colonyId): void
+    {
+        DB::table('merchant_visits')
+            ->where('id', $visitId)
+            ->where('colony_id', $colonyId)
+            ->update(['was_visited' => true, 'updated_at' => now()]);
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────
+
+    /**
+     * Pick $count unique item types from $pool pseudo-randomly, seeded by colony + tick.
+     *
+     * @param  string[] $pool
+     * @return string[]
+     */
+    private function pickItems(array $pool, int $count, int $colonyId, int $tick): array
+    {
+        $available = $pool;
+        $count     = min($count, count($available));
+        $picked    = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $seed   = abs(($colonyId * 997 + $tick * 31 + $i * 127) * 1664525 + 1013904223) & 0x7FFFFFFF;
+            $idx    = $seed % count($available);
+            $picked[] = array_splice($available, (int) $idx, 1)[0];
+        }
+
+        return $picked;
+    }
+
+    /**
+     * Build the JSON payload for an item based on its type and config definition.
+     */
+    private function buildPayload(string $type, array $def): ?string
+    {
+        $data = match ($type) {
+            'ap_flex'     => ['ap_type' => 'any',          'amount' => $def['ap_amount'] ?? 20],
+            'ap_targeted' => ['ap_type' => 'construction', 'amount' => $def['ap_amount'] ?? 15],
+            'repair_kit'  => ['sp_amount' => $def['sp_amount'] ?? 30],
+            'trust_boost' => ['trust_amount' => $def['trust_amount'] ?? 15],
+            'information' => [],
+            default       => [],
+        };
+
+        return empty($data) ? null : json_encode($data);
+    }
+
+    /**
+     * Apply the item's game effect.
+     *
+     * repair_kit   → heal the colony building with the lowest relative SP
+     * trust_boost  → add trust to colony_resources (resource_id = 12)
+     * information  → reveal all colony_tiles for this colony
+     * ap_flex / ap_targeted → deferred to Phase 4, logged
+     */
+    private function applyItemEffect(object $item, int $colonyId): void
+    {
+        $payload = $item->payload ? json_decode($item->payload, true) : [];
+
+        switch ($item->item_type) {
+            case 'repair_kit':
+                $spAmount = (int) ($payload['sp_amount'] ?? 30);
+                $this->applyRepairKit($colonyId, $spAmount);
+                break;
+
+            case 'trust_boost':
+                $amount = (int) ($payload['trust_amount'] ?? 15);
+                DB::table('colony_resources')
+                    ->where('colony_id', $colonyId)
+                    ->where('resource_id', self::TRUST_RESOURCE_ID)
+                    ->increment('amount', $amount);
+                break;
+
+            case 'information':
+                DB::table('colony_tiles')
+                    ->where('colony_id', $colonyId)
+                    ->update(['is_explored' => true]);
+                break;
+
+            case 'ap_flex':
+            case 'ap_targeted':
+                // TODO Phase 4: integrate with PersonellService to credit AP directly.
+                Log::info("MerchantService: AP item '{$item->item_type}' purchased for colony {$colonyId} — effect deferred to Phase 4.");
+                break;
+
+            default:
+                Log::warning("MerchantService: unknown item_type '{$item->item_type}' — no effect applied.");
+                break;
+        }
+    }
+
+    /**
+     * Heal the colony building with the lowest relative condition (SP / max_SP).
+     * SP is capped at max_status_points.
+     */
+    private function applyRepairKit(int $colonyId, int $spAmount): void
+    {
+        // Find the building with the lowest condition ratio that is actually placed (level > 0)
+        $target = DB::table('colony_buildings as cb')
+            ->join('buildings as b', 'b.id', '=', 'cb.building_id')
+            ->where('cb.colony_id', $colonyId)
+            ->where('cb.level', '>', 0)
+            ->select(
+                'cb.building_id',
+                'cb.instance_id',
+                'cb.status_points',
+                'b.max_status_points'
+            )
+            ->get()
+            ->sortBy(function ($row) {
+                $max = max(1, (int) $row->max_status_points);
+                return (float) $row->status_points / $max;
+            })
+            ->first();
+
+        if (!$target) {
+            return; // No buildings to repair
+        }
+
+        $maxSP    = max(1, (int) $target->max_status_points);
+        $newSP    = min($maxSP, (float) $target->status_points + $spAmount);
+
+        DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', $target->building_id)
+            ->where('instance_id', $target->instance_id)
+            ->update(['status_points' => $newSP]);
+    }
+}

--- a/config/game.php
+++ b/config/game.php
@@ -241,6 +241,25 @@ return [
         ],
     ],
 
+    // Traveling Merchant (Reisender Händler) — random system event, separate from Bar/Cantina.
+    // The merchant appears once from Sol first_appearance_min–max, then every interval_min–max Sols.
+    // Each visit lasts duration_ticks Sols and offers items_count items for Credits.
+    'merchant' => [
+        'first_appearance_min' => 15,   // earliest Sol the merchant can first appear
+        'first_appearance_max' => 20,   // latest Sol for the first appearance
+        'interval_min'         => 10,   // minimum Sols between visits
+        'interval_max'         => 15,   // maximum Sols between visits
+        'duration_ticks'       => 2,    // how many Sols the merchant stays (inclusive)
+        'items_count'          => 3,    // items offered per visit (3 default, up to 4)
+        'items' => [
+            'ap_flex'     => ['label' => 'AP-Paket (flexibel)',       'cost' => 800,  'ap_amount' => 20],
+            'ap_targeted' => ['label' => 'AP-Paket (Kenntnis)',       'cost' => 500,  'ap_amount' => 15],
+            'information' => ['label' => 'Systemkarte vollständig',   'cost' => 1200],
+            'repair_kit'  => ['label' => 'Reparatur-Kit (+30 SP)',    'cost' => 400,  'sp_amount' => 30],
+            'trust_boost' => ['label' => 'Vertrauensschub (+15)',     'cost' => 600,  'trust_amount' => 15],
+        ],
+    ],
+
     'onboarding' => [
         // Supply threshold below which Rank-1 hint fires (no housing built yet)
         'hint_supply_cap_threshold' => 10,

--- a/database/migrations/2026_05_17_000001_create_merchant_tables.php
+++ b/database/migrations/2026_05_17_000001_create_merchant_tables.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the merchant_visits and merchant_items tables.
+ *
+ * The Traveling Merchant is a system event that appears randomly, separate from
+ * the Bar/Cantina. It offers a small selection of special items for Credits.
+ *
+ * merchant_visits:
+ *   colony_id    — which colony this visit belongs to (one player = one colony)
+ *   tick_start   — Sol when the merchant arrived
+ *   tick_end     — Sol when the merchant leaves (= tick_start + duration - 1, inclusive)
+ *   was_visited  — player opened the merchant modal at least once this visit
+ *
+ * merchant_items:
+ *   visit_id     — FK to merchant_visits
+ *   item_type    — category key (ap_flex, ap_targeted, information, repair_kit, trust_boost, credit_loan)
+ *   label        — display name shown in the UI
+ *   cost_credits — Credits price
+ *   payload      — JSON blob with item-specific data (e.g. ap amount, building_id, sp_amount)
+ *   sold         — whether the player already purchased this item
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('merchant_visits', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('colony_id');
+            $table->unsignedInteger('tick_start');
+            $table->unsignedInteger('tick_end');
+            $table->boolean('was_visited')->default(false);
+            $table->timestamps();
+
+            $table->foreign('colony_id')->references('id')->on('glx_colonies');
+        });
+
+        Schema::create('merchant_items', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('visit_id');
+            $table->string('item_type', 50);
+            $table->string('label', 255);
+            $table->unsignedInteger('cost_credits');
+            $table->text('payload')->nullable();
+            $table->boolean('sold')->default(false);
+            $table->timestamps();
+
+            $table->foreign('visit_id')->references('id')->on('merchant_visits')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('merchant_items');
+        Schema::dropIfExists('merchant_visits');
+    }
+};

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -94,6 +94,18 @@ return [
     'error_building_not_found'  => 'Gebäude nicht gefunden.',
     'error_max_level_reached'   => 'Maximales Level bereits erreicht.',
 
+    // ── Generic UI actions ───────────────────────────────────────────────────
+
+    'close'             => 'Schließen',
+
+    // ── Traveling Merchant (Reisender Händler) ────────────────────────────────
+
+    'merchant_in_system'  => 'Händler im System',
+    'merchant_title'      => 'Reisender Händler',
+    'merchant_until_sol'  => 'Bleibt bis Sol',
+    'merchant_buy'        => 'Kaufen',
+    'merchant_sold'       => 'Verkauft',
+
     // ── Bar/Cantina ───────────────────────────────────────────────────────────
 
     'bar_title'                        => 'Cantina',

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -232,6 +232,21 @@ body {
     color: #166534;
 }
 
+.ap-chip--trust-pos {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.ap-chip--trust-neu {
+    background: #f3f4f6;
+    color: #374151;
+}
+
+.ap-chip--trust-neg {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
 .hex-canvas-header h2 {
     margin: 0;
     font-size: 1.15rem;
@@ -839,6 +854,122 @@ dialog[x-ref="discoveryDialog"] {
 
 .colony-toast--info {
     background: #14532d;
+}
+
+/* ── Merchant button (canvas header) ────────────────────────────────────── */
+
+.merchant-btn {
+    font-size: 0.8rem;
+    padding: 0.3rem 0.8rem;
+    background: #fef9c3;
+    color: #713f12;
+    border: 1px solid #fde047;
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: 600;
+    white-space: nowrap;
+    /* PicoCSS button resets */
+    margin: 0;
+    box-shadow: none;
+    flex-shrink: 0;
+}
+
+.merchant-btn:hover {
+    background: #fef08a;
+}
+
+/* ── Merchant dialog ─────────────────────────────────────────────────────── */
+
+.merchant-dialog {
+    max-width: 480px;
+    width: 90vw;
+    border-radius: var(--pico-border-radius);
+    padding: 0;
+}
+
+.merchant-dialog article {
+    margin: 0;
+}
+
+.merchant-dialog > article > header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+}
+
+/* PicoCSS puts the close button (rel="prev") at the end — override to keep
+   it at the start and reserve the middle for the title. */
+.merchant-dialog > article > header > button[rel="prev"] {
+    order: -1;
+    margin: 0;
+}
+
+.merchant-dialog > article > header h3 {
+    margin: 0;
+    flex: 1;
+    font-size: 1rem;
+}
+
+.merchant-dialog > article > header small {
+    color: var(--pico-muted-color);
+    font-size: 0.78rem;
+}
+
+.merchant-items {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+}
+
+/* Each item row: label | cost | buy-button */
+.merchant-item {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    margin: 0;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    transition: opacity 0.2s ease;
+}
+
+.merchant-item--sold {
+    opacity: 0.5;
+}
+
+.merchant-item__label {
+    font-weight: 500;
+    font-size: 0.9rem;
+}
+
+.merchant-item__cost {
+    font-weight: 600;
+    color: var(--pico-muted-color);
+    white-space: nowrap;
+    font-size: 0.85rem;
+}
+
+.merchant-item__buy {
+    padding: 0.25rem 0.75rem;
+    font-size: 0.8rem;
+    margin: 0;
+    white-space: nowrap;
+}
+
+.merchant-dialog > article > footer {
+    padding: 0.75rem 1.25rem;
+    border-top: 1px solid var(--pico-muted-border-color);
+    display: flex;
+    justify-content: flex-end;
+}
+
+.merchant-dialog > article > footer button {
+    margin: 0;
+    width: auto;
 }
 
 /* ── Responsive ──────────────────────────────────────────────────────────── */

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -92,6 +92,7 @@ function colonyHexView(config) {
         apConstruction:     config.apConstruction ?? 0,
         trust:              config.trust ?? 0,
         currentSol:         config.currentSol ?? 0,
+        solLimit:           config.solLimit ?? 100,
         activeHint:         config.activeHint ?? null,
         merchantVisit:      config.merchantVisit ?? null,
         merchantItems:      config.merchantItems ?? [],
@@ -363,7 +364,7 @@ function colonyHexView(config) {
         statusLine() {
             const total    = this.tiles.length;
             const explored = this.tiles.filter(t => t.is_explored).length;
-            return `Sol ${this.currentSol} · ${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
+            return `Sol ${this.currentSol} / ${this.solLimit} · ${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
         },
 
         // ── HTTP helpers ──────────────────────────────────────────────────────

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -90,7 +90,12 @@ function colonyHexView(config) {
         i18n:               config.i18n ?? {},
         apNav:              config.apNav ?? 0,
         apConstruction:     config.apConstruction ?? 0,
+        trust:              config.trust ?? 0,
+        currentSol:         config.currentSol ?? 0,
         activeHint:         config.activeHint ?? null,
+        merchantVisit:      config.merchantVisit ?? null,
+        merchantItems:      config.merchantItems ?? [],
+        merchantOpen:       false,
         selectedTile:       null,
         buildMode:          false,
         pendingBuilding:    null,
@@ -264,6 +269,39 @@ function colonyHexView(config) {
             if ('activeHint' in res) this.activeHint = res.activeHint;
         },
 
+        // ── Merchant ──────────────────────────────────────────────────────────
+
+        hasMerchant() {
+            return this.merchantVisit !== null;
+        },
+
+        openMerchant() {
+            this.merchantOpen = true;
+            // mark visit as seen (fire-and-forget)
+            if (this.merchantVisit && !this.merchantVisit.was_visited) {
+                this.post(this.routes.merchantOpen.replace('__VISIT__', this.merchantVisit.id), {});
+                this.merchantVisit.was_visited = true;
+            }
+            this.$nextTick(() => this.$refs.merchantDialog.showModal());
+        },
+
+        closeMerchant() {
+            this.merchantOpen = false;
+            this.$refs.merchantDialog.close();
+        },
+
+        async buyMerchantItem(itemId) {
+            const url = this.routes.merchantBuy.replace('__ID__', itemId);
+            const res = await this.post(url, {});
+            if (res.ok) {
+                const item = this.merchantItems.find(i => i.id === itemId);
+                if (item) item.sold = true;
+                this.showToast(res.message ?? 'Kauf erfolgreich.', 'info');
+            } else {
+                this.showToast(res.error ?? 'Kauf fehlgeschlagen.', 'error');
+            }
+        },
+
         async dismissHint() {
             if (!this.activeHint) return;
             const res = await this.post(this.routes.dismissHint, { hint_key: this.activeHint.key });
@@ -325,7 +363,7 @@ function colonyHexView(config) {
         statusLine() {
             const total    = this.tiles.length;
             const explored = this.tiles.filter(t => t.is_explored).length;
-            return `${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
+            return `Sol ${this.currentSol} · ${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
         },
 
         // ── HTTP helpers ──────────────────────────────────────────────────────

--- a/resources/views/colony/bar.blade.php
+++ b/resources/views/colony/bar.blade.php
@@ -15,7 +15,7 @@
 
     <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem">
         <h2 style="margin:0">{{ __('colony.bar_title') }}</h2>
-        <small style="color:var(--pico-muted-color)">Tick {{ $tick }}</small>
+        <small style="color:var(--pico-muted-color)">Sol {{ $tick }}</small>
     </div>
 
     @if ($barLevel < 1)

--- a/resources/views/colony/bar.blade.php
+++ b/resources/views/colony/bar.blade.php
@@ -15,7 +15,7 @@
 
     <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem">
         <h2 style="margin:0">{{ __('colony.bar_title') }}</h2>
-        <small style="color:var(--pico-muted-color)">Sol {{ $tick }}</small>
+        <small style="color:var(--pico-muted-color)">Sol {{ $currentSol }}</small>
     </div>
 
     @if ($barLevel < 1)

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -10,7 +10,11 @@ window.__colonyViewData = {
     buildings: @json($buildings),
     apNav:          {{ (int)$navAp }},
     apConstruction: {{ (int)$constructionAp }},
+    trust:          {{ $trust }},
+    currentSol:     {{ $currentSol }},
     activeHint: @json($activeHint),
+    merchantVisit:  @json($merchantVisit ?? null),
+    merchantItems:  @json($merchantItems ?? []),
     routes: {
         explore:            '{{ route('colony.tile.explore') }}',
         deepScan:           '{{ route('colony.tile.deep-scan') }}',
@@ -18,6 +22,8 @@ window.__colonyViewData = {
         placeBuilding:      '{{ route('colony.building.place') }}',
         investBuilding:     '{{ route('colony.building.invest') }}',
         dismissHint:        '{{ route('colony.hint.dismiss') }}',
+        merchantBuy:        '{{ route('colony.merchant.buy', ['itemId' => '__ID__']) }}',
+        merchantOpen:       '{{ route('colony.merchant.open', ['visitId' => '__VISIT__']) }}',
     },
     i18n: {
         explore:            '{{ __('colony.explore') }}',
@@ -48,7 +54,18 @@ window.__colonyViewData = {
                 <div class="ap-chips">
                     <span class="ap-chip ap-chip--nav" x-text="`Nav ${apNav} AP`"></span>
                     <span class="ap-chip ap-chip--build" x-text="`Bau ${apConstruction} AP`"></span>
+                    <span class="ap-chip"
+                          :class="trust >= 20 ? 'ap-chip--trust-pos' : trust < 0 ? 'ap-chip--trust-neg' : 'ap-chip--trust-neu'"
+                          x-text="`Vertrauen ${trust}`"></span>
                 </div>
+                {{-- Merchant button — only shown when merchant is in system --}}
+                <button class="merchant-btn"
+                        x-show="hasMerchant()"
+                        @click="openMerchant()"
+                        x-cloak>
+                    🛸 {{ __('colony.merchant_in_system') }}
+                </button>
+
                 <button class="build-btn"
                         :class="{ 'build-btn--active': buildMode }"
                         @click="toggleBuildMode()">
@@ -248,6 +265,43 @@ window.__colonyViewData = {
         </aside>
 
     </div>
+
+    {{-- Merchant modal -------------------------------------------------------
+         Native <dialog> element; opened via openMerchant() which calls
+         $refs.merchantDialog.showModal() — browser handles backdrop + focus-trap
+         + Escape key. merchantOpen tracks state on Alpine side so x-for re-renders
+         correctly when the dialog is reopened.
+    --}}
+    <dialog x-ref="merchantDialog" class="merchant-dialog" @close="merchantOpen = false">
+        <article>
+            <header>
+                <button aria-label="{{ __('colony.close') }}" rel="prev" @click="closeMerchant()"></button>
+                <h3>{{ __('colony.merchant_title') }}</h3>
+                <small x-show="merchantVisit">
+                    {{ __('colony.merchant_until_sol') }} <span x-text="merchantVisit?.tick_end"></span>
+                </small>
+            </header>
+
+            <div class="merchant-items">
+                <template x-for="item in merchantItems" :key="item.id">
+                    <article class="merchant-item" :class="{ 'merchant-item--sold': item.sold }">
+                        <div class="merchant-item__label" x-text="item.label"></div>
+                        <div class="merchant-item__cost" x-text="`${item.cost_credits} Cr`"></div>
+                        <button class="merchant-item__buy"
+                                :disabled="item.sold"
+                                @click="buyMerchantItem(item.id)">
+                            <span x-show="!item.sold">{{ __('colony.merchant_buy') }}</span>
+                            <span x-show="item.sold">{{ __('colony.merchant_sold') }}</span>
+                        </button>
+                    </article>
+                </template>
+            </div>
+
+            <footer>
+                <button @click="closeMerchant()">{{ __('colony.close') }}</button>
+            </footer>
+        </article>
+    </dialog>
 
     {{-- Event discovery popup ------------------------------------------------
          Uses the native <dialog> element (PicoCSS styles it out of the box).

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -12,6 +12,7 @@ window.__colonyViewData = {
     apConstruction: {{ (int)$constructionAp }},
     trust:          {{ $trust }},
     currentSol:     {{ $currentSol }},
+    solLimit:       {{ $solLimit }},
     activeHint: @json($activeHint),
     merchantVisit:  @json($merchantVisit ?? null),
     merchantItems:  @json($merchantItems ?? []),

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Colony\BarController;
 use App\Http\Controllers\Colony\ColonyController;
+use App\Http\Controllers\Colony\MerchantController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Galaxy\GalaxyController;
 use App\Http\Controllers\INNN\MessageController;
@@ -67,6 +68,10 @@ Route::middleware('auth')->prefix('colony')->name('colony.')->group(function () 
     // Bar/Cantina
     Route::get('/bar',               [BarController::class, 'index'])->name('bar');
     Route::post('/bar/accept/{offer}', [BarController::class, 'accept'])->name('bar.accept');
+
+    // Traveling Merchant
+    Route::post('/merchant/buy/{itemId}',         [MerchantController::class, 'buy'])->name('merchant.buy')->where('itemId', '[0-9]+');
+    Route::post('/merchant/visit/{visitId}/open', [MerchantController::class, 'markVisited'])->name('merchant.open')->where('visitId', '[0-9]+');
 });
 
 // ── Resources (Schritt 5) ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Sol-Nummer** in Hexview-Statuszeile: `Sol 42 · 18/37 Tiles erkundet · CC Level 2`
- **Vertrauens-Chip** neben AP-Chips: grün ≥ 20, grau 0–19, rot < 0
- **Bar-Screen**: hardcoded „Tick" → „Sol" korrigiert
- **Reisender Händler**: vollständige Implementierung — Spawn-Logik, Items, Kaufsystem, Alpine `<dialog>`-Modal

## Details

| Bereich | Änderung |
|---|---|
| `MerchantService` | shouldSpawn / spawnVisit / buyItem / getActiveVisit |
| `MerchantController` | POST buy + POST markVisited |
| `GameTick` (Schritt 11) | processMerchantSpawn — spawnt pro Kolonie wenn Bedingungen erfüllt |
| Migration | `merchant_visits` + `merchant_items` |
| `config/game.php` | `merchant` Block: Timing, 5 Item-Typen, Preise |
| `colony-hexgrid.js` | hasMerchant / openMerchant / closeMerchant / buyMerchantItem |
| `hexview.blade.php` | Händler-Button + `<dialog>` Modal |
| `colony.css` | .merchant-btn + .merchant-dialog + .merchant-item Styles |
| `lang/de/colony.php` | 5 neue Händler-Keys |

## Item-Effekte Phase 3

| Typ | Effekt |
|---|---|
| `repair_kit` | +30 SP auf das Gebäude mit schlechtester Kondition |
| `trust_boost` | +15 Vertrauen (colony_resources resource_id=12) |
| `information` | Alle colony_tiles.is_explored = true |
| `ap_flex` / `ap_targeted` | Kauf möglich, Effekt auf Phase 4 verschoben (Log) |

## Test plan

- [ ] Colony Hexview zeigt Sol-Nummer in Statuszeile
- [ ] Vertrauens-Chip: Farbe korrekt (grün/grau/rot)
- [ ] Bar zeigt „Sol X" statt „Tick X"
- [ ] `game:tick-dry-run` läuft ohne Fehler (GameTick-Injection prüfen)
- [ ] Merchant-Modal: Button erscheint wenn `merchantVisit` im JS nicht null
- [ ] Buy-Endpoint: POST /colony/merchant/buy/{id} liefert `{ok: true, credits: N}`
- [ ] `php artisan migrate:status` zeigt migration als `Ran`