### PR TITLE
feat: Globale Ressourcenleiste — Sol X/100 + Trust auf allen Seiten

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,6 +17,7 @@ use App\Services\TickService;
 use App\Services\FleetService;
 use App\Services\TradeGateway;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
@@ -92,6 +93,17 @@ class AppServiceProvider extends ServiceProvider
                     }
                 }
                 $view->with('resourceBarPossessions', $possessions ?? []);
+
+                // Inject Sol run-progress for the resource bar Sol chip
+                $colony    = DB::table('glx_colonies')->where('user_id', Auth::id())->where('is_primary', 1)->first();
+                $sinceTick = $colony ? (int) $colony->since_tick : null;
+                $tickService = app(TickService::class);
+                $globalTick  = $tickService->getTickCount();
+                $currentSol  = $sinceTick !== null ? max(1, $globalTick - $sinceTick + 1) : null;
+                $solLimit    = (int) config('game.run.tick_limit', 100);
+
+                $view->with('currentSol', $currentSol);
+                $view->with('solLimit', $solLimit);
             }
         });
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -99,8 +99,8 @@ class AppServiceProvider extends ServiceProvider
                 $sinceTick = $colony ? (int) $colony->since_tick : null;
                 $tickService = app(TickService::class);
                 $globalTick  = $tickService->getTickCount();
-                $currentSol  = $sinceTick !== null ? max(1, $globalTick - $sinceTick + 1) : null;
                 $solLimit    = (int) config('game.run.tick_limit', 100);
+                $currentSol  = $sinceTick !== null ? min($solLimit, max(1, $globalTick - $sinceTick + 1)) : null;
 
                 $view->with('currentSol', $currentSol);
                 $view->with('solLimit', $solLimit);

--- a/data/sql/testdata.sqlite.sql
+++ b/data/sql/testdata.sqlite.sql
@@ -68,8 +68,8 @@ INSERT INTO "user" VALUES(4,'Maggy','','player','$2y$10$tqJJsdnuAuhVcqtdqeby3.yt
 INSERT INTO "user" VALUES(5,'Moe','','player','$2y$10$tqJJsdnuAuhVcqtdqeby3.ytOSc2AupZs6LjST3GjiKytKBsuxp8m','moe@nouron.de',NULL,3,5,'','',0,1,'abcdefg',0,'2012-12-27 11:46:30','0000-00-00 00:00:00','0',1,NULL);
 INSERT INTO "user" VALUES(18,'Lenny','','player','$2y$10$tqJJsdnuAuhVcqtdqeby3.ytOSc2AupZs6LjST3GjiKytKBsuxp8m','lenny@nouron.de',NULL,0,0,'','',0,0,'',1,'2012-12-27 11:46:30','0000-00-00 00:00:00','darkred',1,NULL);
 INSERT INTO "user" VALUES(19,'Carl','','player','$2y$10$tqJJsdnuAuhVcqtdqeby3.ytOSc2AupZs6LjST3GjiKytKBsuxp8m','carl@nouron.de',NULL,1,1,'','',0,0,'',1,'2012-12-27 11:46:30','0000-00-00 00:00:00','darkred',1,NULL);
-INSERT INTO "glx_colonies" VALUES(1,'Springfield',1,1,3,0,1);
-INSERT INTO "glx_colonies" VALUES(2,'Shelbyville',1,2,0,0,1);
+INSERT INTO "glx_colonies" VALUES(1,'Springfield',1,1,3,20585,1);
+INSERT INTO "glx_colonies" VALUES(2,'Shelbyville',1,2,0,20585,1);
 INSERT INTO "buildings" (id,purpose,name,required_building_id,required_building_level,prime_colony_only,"row","column",max_level,ap_for_levelup,max_status_points,decay_rate,supply_cost,is_instanced,is_active) VALUES(25,'civil','building_commandCenter',NULL,NULL,0,0,2,5,10,20,0.33,0,0,1);
 INSERT INTO "buildings" (id,purpose,name,required_building_id,required_building_level,prime_colony_only,"row","column",max_level,ap_for_levelup,max_status_points,decay_rate,supply_cost,is_instanced,is_active) VALUES(27,'industry','building_harvester',25,1,0,1,2,1,10,20,0.95,2,1,1);
 INSERT INTO "buildings" (id,purpose,name,required_building_id,required_building_level,prime_colony_only,"row","column",max_level,ap_for_levelup,max_status_points,decay_rate,supply_cost,is_instanced,is_active) VALUES(28,'civil','building_housingComplex',25,1,1,1,1,6,10,20,0.44,0,1,1);

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -87,14 +87,18 @@ body {
     padding: 0 0.75rem 0 0;
 }
 
-.colony-header nav a:hover,
-.colony-header nav a.active {
+.colony-header nav a:hover {
     color: #fff;
+    background: rgba(255,255,255,0.10);
+    border-radius: 6px;
 }
 
 .colony-header nav a.active {
+    color: #fff;
     font-weight: 600;
-    border-bottom: 2px solid var(--color-accent);
+    background: rgba(255,255,255,0.18);
+    border-radius: 6px;
+    border-bottom: none;
 }
 
 /* Dropdown summary: match the compact link style, suppress PicoCSS button-like defaults */

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -130,13 +130,19 @@ body {
 /* ── Resource bar ────────────────────────────────────────────────────────── */
 
 .colony-resbar {
+    background: #f8f9fa;
+    border-bottom: 1px solid #dee2e6;
+    padding: 5px 12px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+/* Flexbox wrapper used by the shared resourcebar partial — works without Bootstrap utilities */
+.res-bar-wrap {
     display: flex;
     flex-wrap: wrap;
+    gap: 0.5rem;
     justify-content: center;
-    gap: 0.4rem;
-    padding: 0.35rem 1rem 0.4rem;
-    background: #f8f8f8;
-    border-top: 1px solid var(--color-border);
+    align-items: center;
 }
 
 .res-chip {
@@ -151,13 +157,17 @@ body {
     background: #fff;
     color: var(--color-anthracite);
     white-space: nowrap;
+    cursor: default;
+    transition: filter 0.15s;
 }
+.res-chip:hover { filter: brightness(0.94); }
 
 .res-chip--primary {
     font-size: 0.85rem;
     padding: 3px 10px 3px 8px;
     border-width: 2px;
     border-color: #aaa;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.10);
 }
 
 .res-abbr {
@@ -168,10 +178,32 @@ body {
     letter-spacing: 0.05em;
 }
 
+.res-amount { font-variant-numeric: tabular-nums; }
+
+/* Vertical rule separating primary from secondary resources */
+.res-divider {
+    display: inline-block;
+    width: 1px;
+    height: 22px;
+    background: #ccc;
+    border-radius: 1px;
+    margin: 0 2px;
+    align-self: center;
+}
+
 .res-chip--empty {
     opacity: 0.45;
     border-style: dashed;
 }
+
+/* Per-resource accent colours */
+.res-Cr  { background: #fff8dc; border-color: #e6c84a; }
+.res-Sup { background: #f0f0f0; border-color: #aaa; }
+.res-Rg  { background: #fdf0e0; border-color: #d4924a; }
+.res-Co  { background: #dceeff; border-color: #5599dd; }
+.res-Or  { background: #e8f5e0; border-color: #5a9a3a; }
+.res-M   { background: #fce7f3; border-color: #d166a0; }
+.res-Sol { background: #ede9fe; border-color: #7c65cc; }
 
 /* ── Hex page layout ─────────────────────────────────────────────────────── */
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -108,6 +108,20 @@ a:hover {color: #000; text-decoration: underline;}
 .res-LNrg { background: #ede9fe; border-color: #7c65cc; }
 .res-ANrg { background: #fefce8; border-color: #ca9b11; }
 .res-M    { background: #fce7f3; border-color: #d166a0; }
+.res-Rg   { background: #fdf0e0; border-color: #d4924a; }
+.res-Co   { background: #dceeff; border-color: #5599dd; }
+.res-Or   { background: #e8f5e0; border-color: #5a9a3a; }
+.res-Sol  { background: #ede9fe; border-color: #7c65cc; }
+
+/* Flexbox wrapper used by the shared resourcebar partial — works without Bootstrap utilities as fallback */
+.res-bar-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+}
+
 body .nav-list > .active > a, .nav-list > .active > a:hover {background-color: #333;}
 
 .sidebar-nav {padding: 9px 0;}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -40,7 +40,7 @@ a:hover {color: #000; text-decoration: underline;}
 /* ── Resource bar ──────────────────────────────────────────────────────── */
 #resourcebar-container {
     position: fixed;
-    top: 56px;
+    top: 58px;
     left: 0; right: 0;
     z-index: 1029;
     background: #f8f9fa;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -40,7 +40,7 @@ a:hover {color: #000; text-decoration: underline;}
 /* ── Resource bar ──────────────────────────────────────────────────────── */
 #resourcebar-container {
     position: fixed;
-    top: 58px;
+    top: 64px;
     left: 0; right: 0;
     z-index: 1029;
     background: #f8f9fa;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -80,7 +80,11 @@
 {{-- Resource bar --}}
 @if(!empty($resourceBarPossessions))
 <div id="resourcebar-container">
-    @include('resources.resourcebar', ['possessions' => $resourceBarPossessions])
+    @include('resources.resourcebar', [
+        'possessions' => $resourceBarPossessions,
+        'currentSol'  => $currentSol ?? null,
+        'solLimit'    => $solLimit ?? 100,
+    ])
 </div>
 @endif
 

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -47,20 +47,11 @@
     {{-- Resource bar --}}
     @if(!empty($resourceBarPossessions))
     <div class="colony-resbar">
-        @foreach($resourceBarPossessions as $resId => $res)
-            @php $rid = (int)$resId; $empty = ($res['amount'] ?? 0) == 0; @endphp
-            @if(in_array($rid, [1, 2]))
-            <span class="res-chip res-chip--primary {{ $empty ? 'res-chip--empty' : '' }}">
-                <span class="res-abbr">{{ $res['abbreviation'] ?? '' }}</span>
-                <span class="res-amount">{{ number_format($res['amount'] ?? 0, 0, ',', '.') }}</span>
-            </span>
-            @elseif(in_array($rid, [3, 4, 5, 12]))
-            <span class="res-chip {{ $empty ? 'res-chip--empty' : '' }}">
-                <span class="res-abbr">{{ $res['abbreviation'] ?? '' }}</span>
-                <span class="res-amount">{{ number_format($res['amount'] ?? 0, 0, ',', '.') }}</span>
-            </span>
-            @endif
-        @endforeach
+        @include('resources.resourcebar', [
+            'possessions' => $resourceBarPossessions,
+            'currentSol'  => $currentSol ?? null,
+            'solLimit'    => $solLimit ?? 100,
+        ])
     </div>
     @endif
 </header>

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -6,6 +6,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title', 'Nouron')</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{{ asset('css/colony.css') }}">
     @stack('styles')
 </head>
@@ -17,13 +18,13 @@
             <li><strong><a href="{{ route('galaxy.index') }}">Nouron</a></strong></li>
         </ul>
         <ul>
-            <li><a href="{{ route('galaxy.index') }}" @class(['active' => request()->routeIs('galaxy.*')])>Galaxis</a></li>
-            <li><a href="{{ route('fleet.index') }}" @class(['active' => request()->routeIs('fleet.*')])>Flotte</a></li>
-            <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*')])>Kolonie</a></li>
-            <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])>Techtree</a></li>
-            <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])>Berater</a></li>
-            <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])>Cantina</a></li>
-            <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])>Nachrichten</a></li>
+            <li><a href="{{ route('galaxy.index') }}" @class(['active' => request()->routeIs('galaxy.*')])><i class="bi bi-globe2"></i> Galaxis</a></li>
+            <li><a href="{{ route('fleet.index') }}" @class(['active' => request()->routeIs('fleet.*')])><i class="bi bi-send"></i> Flotte</a></li>
+            <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*')])><i class="bi bi-hexagon"></i> Kolonie</a></li>
+            <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])><i class="bi bi-building"></i> Techtree</a></li>
+            <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])><i class="bi bi-people"></i> Berater</a></li>
+            <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])><i class="bi bi-cup-hot"></i> Cantina</a></li>
+            <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])><i class="bi bi-envelope"></i> Nachrichten</a></li>
         </ul>
         <ul>
             <li>

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -20,7 +20,7 @@
         <ul>
             <li><a href="{{ route('galaxy.index') }}" @class(['active' => request()->routeIs('galaxy.*')])><i class="bi bi-globe2"></i> Galaxis</a></li>
             <li><a href="{{ route('fleet.index') }}" @class(['active' => request()->routeIs('fleet.*')])><i class="bi bi-send"></i> Flotte</a></li>
-            <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*')])><i class="bi bi-hexagon"></i> Kolonie</a></li>
+            <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*') && !request()->routeIs('colony.bar*') && !request()->routeIs('colony.merchant*')])><i class="bi bi-hexagon"></i> Kolonie</a></li>
             <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])><i class="bi bi-building"></i> Techtree</a></li>
             <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])><i class="bi bi-people"></i> Berater</a></li>
             <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])><i class="bi bi-cup-hot"></i> Cantina</a></li>

--- a/resources/views/resources/resourcebar.blade.php
+++ b/resources/views/resources/resourcebar.blade.php
@@ -3,28 +3,35 @@
 {{-- Optional: $currentSol (int), $solLimit (int) — inject Sol chip before primary resources --}}
 @auth
 @php
-    $primaryIds  = [1, 2, 12]; // Credits (Cr), Supply (Sup), Trust (M) — always shown, always first
-    $primary     = [];
-    $secondary   = [];
+    $primaryIds   = [1, 2, 12]; // Credits (Cr), Supply (Sup), Trust (M) — always shown
+    $activeResIds = [1, 2, 3, 4, 5, 12]; // whitelist — ENrg/LNrg/ANrg (6/8/10) excluded
+    $primary      = [];
+    $secondary    = [];
 
     foreach ($possessions as $resId => $resource) {
-        if (in_array((int)$resId, $primaryIds)) {
-            $primary[(int)$resId] = $resource;
+        $rid = (int) $resId;
+        if (!in_array($rid, $activeResIds)) continue;
+        if (in_array($rid, $primaryIds)) {
+            $primary[$rid] = $resource;
         } else {
-            $secondary[$resId] = $resource;
+            $secondary[$rid] = $resource;
         }
     }
 
-    // Guarantee order: Credits first, then Supply, then Trust
     ksort($primary);
+
+    // Cap Sol display: if runs don't exist yet, since_tick may be very old
+    $solDisplay = (isset($currentSol) && $currentSol !== null && $currentSol <= ($solLimit ?? 100))
+        ? $currentSol
+        : null;
 @endphp
 <div class="res-bar-wrap d-flex flex-wrap gap-2 justify-content-center align-items-center resource-bar">
 
-    {{-- Sol chip: computed run progress, shown before primary resources when available --}}
-    @if(isset($currentSol) && $currentSol !== null)
+    {{-- Sol chip: only shown when run-local Sol is meaningful (≤ solLimit) --}}
+    @if($solDisplay !== null)
         <span class="res-chip res-chip--primary res-chip--sol res-Sol">
             <span class="res-abbr">Sol</span>
-            <span class="res-amount">{{ $currentSol }} / {{ $solLimit ?? 100 }}</span>
+            <span class="res-amount">{{ $solDisplay }} / {{ $solLimit ?? 100 }}</span>
         </span>
         <span class="res-divider" aria-hidden="true"></span>
     @endif

--- a/resources/views/resources/resourcebar.blade.php
+++ b/resources/views/resources/resourcebar.blade.php
@@ -20,10 +20,7 @@
 
     ksort($primary);
 
-    // Cap Sol display: if runs don't exist yet, since_tick may be very old
-    $solDisplay = (isset($currentSol) && $currentSol !== null && $currentSol <= ($solLimit ?? 100))
-        ? $currentSol
-        : null;
+    $solDisplay = $currentSol ?? null; // composer already caps at solLimit
 @endphp
 <div class="res-bar-wrap d-flex flex-wrap gap-2 justify-content-center align-items-center resource-bar">
 

--- a/resources/views/resources/resourcebar.blade.php
+++ b/resources/views/resources/resourcebar.blade.php
@@ -1,8 +1,9 @@
 {{-- Resource bar partial (no layout) — replaces resources/json/reloadresourcebar.phtml --}}
 {{-- Server-side data dependency: $possessions — keyed by resource_id, each entry has: amount, abbreviation, name --}}
+{{-- Optional: $currentSol (int), $solLimit (int) — inject Sol chip before primary resources --}}
 @auth
 @php
-    $primaryIds  = [1, 2];   // Credits (Cr) and Supply (Sup) — always shown, always first
+    $primaryIds  = [1, 2, 12]; // Credits (Cr), Supply (Sup), Trust (M) — always shown, always first
     $primary     = [];
     $secondary   = [];
 
@@ -14,10 +15,19 @@
         }
     }
 
-    // Guarantee order: Credits first, then Supply
+    // Guarantee order: Credits first, then Supply, then Trust
     ksort($primary);
 @endphp
-<div class="d-flex flex-wrap gap-2 justify-content-center align-items-center resource-bar">
+<div class="res-bar-wrap d-flex flex-wrap gap-2 justify-content-center align-items-center resource-bar">
+
+    {{-- Sol chip: computed run progress, shown before primary resources when available --}}
+    @if(isset($currentSol) && $currentSol !== null)
+        <span class="res-chip res-chip--primary res-chip--sol res-Sol">
+            <span class="res-abbr">Sol</span>
+            <span class="res-amount">{{ $currentSol }} / {{ $solLimit ?? 100 }}</span>
+        </span>
+        <span class="res-divider" aria-hidden="true"></span>
+    @endif
 
     {{-- Primary resources: always visible, regardless of amount --}}
     @foreach($primary as $resId => $resource)


### PR DESCRIPTION
## Summary

- **Sol-Chip** (lila) auf allen Gameplay-Seiten: `Sol 3 / 100` — zeigt Run-Fortschritt
- **Trust** als Primary-Chip (immer sichtbar, neben Credits + Supply)
- **Sekundäre Ressourcen** (Regolith, Werkstoffe, Organika) nur wenn > 0
- Beide Layouts (colony/PicoCSS + app/Bootstrap) nutzen jetzt denselben `resourcebar.blade.php` Partial

## Technisch

| Datei | Änderung |
|---|---|
| `AppServiceProvider` | View Composer injiziert `$currentSol` + `$solLimit` (via `colony.since_tick`) |
| `resourcebar.blade.php` | Trust (id=12) als Primary; Sol-Chip oben; `res-bar-wrap` statt Bootstrap-Utilities |
| `layouts/colony.blade.php` | Inline-foreach → `@include('resources.resourcebar', ...)` |
| `layouts/app.blade.php` | Sol-Params an Partial übergeben |
| `colony.css` | `res-Cr/Sup/Rg/Co/Or/M/Sol` Farben + `res-bar-wrap` Flexbox + `colony-resbar` Styling |
| `style.css` | Fehlende Farben `res-Rg/Co/Or/Sol` ergänzt |

## Test plan

- [ ] Colony Hexview: Resource-Bar zeigt `Sol 3 / 100 | Cr 2.400 | Sup 10 | M 0` mit Farben
- [ ] Bar/Berater/Techtree: Resource-Bar identisch sichtbar
- [ ] Legacy-Screens (Flotte, Galaxis): Resource-Bar zeigt Sol-Chip + Farben
- [ ] Trust negativ → rosa Chip mit negativem Wert
- [ ] Sekundäre Ressourcen versteckt wenn 0