### PR TITLE
feat: Händler in Cantina, Advisor-Exploit-Fix, Nav-Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-05-18
+
+- **Reisender Händler in Cantina**: Händler-Dialog aus Hexview entfernt und vollständig in Cantina-Screen (`colony.bar`) integriert. `BarController` lädt `merchantVisit` + `merchantItems`, Alpine-Komponente mit Item-Loop, Kauf-Button, Toast-Feedback. Bug-Fix: `x-data`-Attribut verwendete doppelte Anführungszeichen — JSON-Strukturzeichen terminierten Attribut frühzeitig (SyntaxError). Fix: einfache Anführungszeichen für HTML-Attribut, `@json()`-Routen als Parameter übergeben.
+- **Advisor-Exploit behoben**: Berater konnte im selben Sol eingestellt, gefeuert und sofort wieder eingestellt werden — Credits wurden mehrfach abgezogen. Fix: `PersonellService::fire()` setzt `unavailable_until_tick = currentTick`, `hire()` lehnt Wiedereinstellung im gleichen Tick ab (`dismissed_this_tick`). Fehlermeldung in `lang/de/advisors.php` ergänzt.
+- **Vertrauens-Abkürzung korrigiert**: Ressource 12 (Vertrauen) hatte Abkürzung `M` (veraltet) → `Tr` (englisch, konsistent mit anderen Bezeichnern). CSS-Klasse `.res-M` → `.res-Tr` in `style.css` und `colony.css`. Testdaten aktualisiert.
+- **Navigation vereinfacht**: Galaxis, Flotte und Techtree aus Colony-Nav entfernt. Neue schlanke Nav: Kolonie · Berater · Cantina · Nachrichten. Logo-Link → `colony.view`. Techtree später über Kolonie-Tiles erreichbar.
+- **Händler-Benachrichtigung in Nav**: Hexview-Händler-Dialog entfernt, stattdessen `🛸 Händler im System`-Link in Nav-Leiste (Alpine `x-show="hasMerchant()"`, nur sichtbar bei aktivem Besuch).
+- **Sol-Anzeige behoben**: `currentSol` zeigte globalen Tick (~20591) statt run-lokalen Sol. Fix: `min($solLimit, max(1, $globalTick - $sinceTick + 1))` in `AppServiceProvider`. Testdaten: `since_tick = 20585` → Sol zeigt korrekt ~6/100.
+- **Tests**: `MerchantServiceTest` (22 Tests), `MerchantControllerTest` (8 Tests) neu. `BarControllerTest`, `AdvisorPromotionCostTest`, `BuildingServiceTest`, `TechtreeControllerTest` angepasst (self-contained setUp ohne Testdaten-Abhängigkeit für Berater).
+
 ## 2026-05-17
 
 - **Vertrauensanzeige + Sol-Nummer**: Colony Hexview zeigt jetzt aktuelle Sol-Nummer in der Statuszeile (`Sol 42 · X/Y Tiles erkundet · CC Level N`) sowie Vertrauens-Chip mit Farbindikator (grün ≥ 20, grau 0–19, rot < 0). Bar-Screen: "Tick" → "Sol" korrigiert.

--- a/app/Http/Controllers/Colony/BarController.php
+++ b/app/Http/Controllers/Colony/BarController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Colony;
 use App\Http\Controllers\BaseController;
 use App\Services\BarService;
 use App\Services\ColonyService;
+use App\Services\MerchantService;
 use App\Services\TickService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -18,8 +19,9 @@ class BarController extends BaseController
 
     public function __construct(
         TickService $tick,
-        private readonly ColonyService $colonyService,
-        private readonly BarService    $barService,
+        private readonly ColonyService  $colonyService,
+        private readonly BarService     $barService,
+        private readonly MerchantService $merchantService,
     ) {
         parent::__construct($tick);
     }
@@ -39,7 +41,15 @@ class BarController extends BaseController
             ? $this->barService->getActiveOffers($colony->id, $tick)
             : collect();
 
-        return view('colony.bar', compact('colony', 'offers', 'barLevel', 'currentSol'));
+        $merchantVisit = $this->merchantService->getActiveVisit($colony->id, $tick);
+        $merchantItems = $merchantVisit
+            ? $this->merchantService->getItemsForVisit($merchantVisit->id)->values()->toArray()
+            : [];
+
+        return view('colony.bar', compact(
+            'colony', 'offers', 'barLevel', 'currentSol',
+            'merchantVisit', 'merchantItems',
+        ));
     }
 
     public function accept(Request $request, int $offerId): JsonResponse

--- a/app/Http/Controllers/Techtree/AdvisorController.php
+++ b/app/Http/Controllers/Techtree/AdvisorController.php
@@ -178,6 +178,7 @@ class AdvisorController extends BaseController
                 'duplicate'            => __('advisors.error_duplicate'),
                 'slot_full'            => __('advisors.error_slot_full'),
                 'insufficient_credits' => __('advisors.error_insufficient_credits'),
+                'dismissed_this_tick'  => __('advisors.error_dismissed_this_tick'),
             ];
             $errorMessage = $errorMessages[$result] ?? __('advisors.error_generic');
 

--- a/app/Services/Techtree/PersonellService.php
+++ b/app/Services/Techtree/PersonellService.php
@@ -153,6 +153,16 @@ class PersonellService
                 return 'duplicate';
             }
 
+            // Same-tick re-hire guard — prevent fire→hire→fire exploit within one tick.
+            $currentTick = $this->tickService->getTickCount();
+            if (Advisor::where('user_id', $userId)
+                ->where('personell_id', $personellId)
+                ->whereNull('colony_id')
+                ->where('unavailable_until_tick', $currentTick)
+                ->exists()) {
+                return 'dismissed_this_tick';
+            }
+
             // CC-Level gate — slots available = min(cc_level, max_slots).
             $ccLevel  = (int) (DB::table('colony_buildings')
                 ->where('colony_id', $colonyId)
@@ -219,7 +229,8 @@ class PersonellService
     public function fire(int $advisorId): bool
     {
         return (bool) Advisor::where('id', $advisorId)->update([
-            'colony_id' => null,
+            'colony_id'              => null,
+            'unavailable_until_tick' => $this->tickService->getTickCount(),
         ]);
     }
 

--- a/data/sql/testdata.sqlite.sql
+++ b/data/sql/testdata.sqlite.sql
@@ -6,7 +6,7 @@ INSERT INTO "resources" VALUES(5,'res_organika','Or','Level',1,0,'resicon-silica
 INSERT INTO "resources" VALUES(6,'res_ena','ENrg','Constant',1,100,'resicon-ena');
 INSERT INTO "resources" VALUES(8,'res_lho','LNrg','Constant',1,100,'resicon-lho');
 INSERT INTO "resources" VALUES(10,'res_aku','ANrg','Constant',1,100,'resicon-aku');
-INSERT INTO "resources" VALUES(12,'res_moral','M','Event',0,0,'resicon-moral');
+INSERT INTO "resources" VALUES(12,'res_moral','Tr','Event',0,0,'resicon-moral');
 INSERT INTO "glx_system_types" VALUES(1,'stellar_class_A',8,'stellars/s_white.png','stellars/s_white_quarter.png');
 INSERT INTO "glx_system_types" VALUES(2,'stellar_class_O',12,'stellars/s_blue.png','stellars/s_blue_quarter.png');
 INSERT INTO "glx_system_types" VALUES(3,'stellar_class_B',11,'stellars/s_cyan.png','stellars/s_cyan_quarter.png');
@@ -271,14 +271,7 @@ INSERT INTO "colony_personell" VALUES(2,35,19,10);
 INSERT INTO "colony_personell" VALUES(2,36,19,10);
 INSERT INTO "colony_personell" VALUES(2,89,19,10);
 INSERT INTO "colony_personell" VALUES(2,92,19,10);
-INSERT INTO "advisors" VALUES(1,3,35,1,2,5,NULL);
-INSERT INTO "advisors" VALUES(2,3,36,1,1,0,NULL);
-INSERT INTO "advisors" VALUES(3,3,92,1,1,0,NULL);
-INSERT INTO "advisors" VALUES(4,3,93,1,1,0,NULL);
-INSERT INTO "advisors" VALUES(5,0,35,2,1,0,NULL);
-INSERT INTO "advisors" VALUES(6,0,36,2,1,0,NULL);
-INSERT INTO "advisors" VALUES(8,0,92,2,1,0,NULL);
-INSERT INTO "advisors" VALUES(9,0,93,2,1,0,NULL);
+-- advisors intentionally empty: CC level 1 = 1 slot, start clean for onboarding flow
 INSERT INTO "locked_actionpoints" VALUES(15930,'colony',1,35,22);
 INSERT INTO "locked_actionpoints" VALUES(15930,'colony',1,36,3);
 INSERT INTO "locked_actionpoints" VALUES(15934,'colony',1,35,20);

--- a/lang/de/advisors.php
+++ b/lang/de/advisors.php
@@ -35,6 +35,7 @@ return [
     'error_duplicate'             => 'Für diesen Beratertyp ist bereits ein Berater auf dieser Kolonie aktiv.',
     'error_slot_full'             => 'Kein freier Berater-Slot. Erhöhe das CommandCenter-Level.',
     'error_insufficient_credits'  => 'Nicht genug Credits, um diesen Berater einzustellen.',
+    'error_dismissed_this_tick'   => 'Dieser Berater wurde gerade erst entlassen und kann erst im nächsten Sol wieder eingestellt werden.',
     'error_generic'               => 'Berater konnte nicht eingestellt werden.',
 
 ];

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -103,8 +103,10 @@ return [
     'merchant_in_system'  => 'Händler im System',
     'merchant_title'      => 'Reisender Händler',
     'merchant_until_sol'  => 'Bleibt bis Sol',
-    'merchant_buy'        => 'Kaufen',
-    'merchant_sold'       => 'Verkauft',
+    'merchant_buy'         => 'Kaufen',
+    'merchant_sold'        => 'Verkauft',
+    'merchant_buy_success' => 'Kauf erfolgreich.',
+    'merchant_buy_error'   => 'Kauf fehlgeschlagen.',
 
     // ── Bar/Cantina ───────────────────────────────────────────────────────────
 

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -206,7 +206,7 @@ body {
 .res-Rg  { background: #fdf0e0; border-color: #d4924a; }
 .res-Co  { background: #dceeff; border-color: #5599dd; }
 .res-Or  { background: #e8f5e0; border-color: #5a9a3a; }
-.res-M   { background: #fce7f3; border-color: #d166a0; }
+.res-Tr  { background: #fce7f3; border-color: #d166a0; }
 .res-Sol { background: #ede9fe; border-color: #7c65cc; }
 
 /* ── Hex page layout ─────────────────────────────────────────────────────── */
@@ -892,121 +892,109 @@ dialog[x-ref="discoveryDialog"] {
     background: #14532d;
 }
 
-/* ── Merchant button (canvas header) ────────────────────────────────────── */
+/* ── Merchant notification chip (hexview canvas header) ─────────────────── */
 
-.merchant-btn {
-    font-size: 0.8rem;
-    padding: 0.3rem 0.8rem;
-    background: #fef9c3;
-    color: #713f12;
-    border: 1px solid #fde047;
-    border-radius: 999px;
-    cursor: pointer;
+/*
+ * Amber/gold chip — visible but not dominant.
+ * Replaces the old .merchant-btn trigger now that the modal lives in the bar.
+ */
+.merchant-notify {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    border-radius: 20px;
+    font-size: 0.82rem;
     font-weight: 600;
+    background: #fffbea;
+    border: 1px solid #e6c84a;
+    color: #7a5c00;
+    text-decoration: none;
     white-space: nowrap;
-    /* PicoCSS button resets */
-    margin: 0;
-    box-shadow: none;
     flex-shrink: 0;
 }
 
-.merchant-btn:hover {
-    background: #fef08a;
+.merchant-notify:hover {
+    background: #fff3c4;
+    text-decoration: none;
+    color: #5a4000;
 }
 
-/* ── Merchant dialog ─────────────────────────────────────────────────────── */
+/* ── Merchant section (bar/cantina page) ─────────────────────────────────── */
 
-.merchant-dialog {
-    max-width: 480px;
-    width: 90vw;
-    border-radius: var(--pico-border-radius);
-    padding: 0;
+.merchant-section {
+    margin-bottom: 2rem;
+    padding: 1.25rem;
+    border: 1px solid #e6c84a;
+    border-radius: var(--pico-border-radius, 6px);
+    background: #fffdf0;
+    max-width: 560px;
 }
 
-.merchant-dialog article {
-    margin: 0;
-}
-
-.merchant-dialog > article > header {
+.merchant-section__header {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.75rem;
-    padding: 1rem 1.25rem;
-    border-bottom: 1px solid var(--pico-muted-border-color);
+    margin-bottom: 1rem;
 }
 
-/* PicoCSS puts the close button (rel="prev") at the end — override to keep
-   it at the start and reserve the middle for the title. */
-.merchant-dialog > article > header > button[rel="prev"] {
-    order: -1;
-    margin: 0;
-}
-
-.merchant-dialog > article > header h3 {
-    margin: 0;
-    flex: 1;
-    font-size: 1rem;
-}
-
-.merchant-dialog > article > header small {
-    color: var(--pico-muted-color);
-    font-size: 0.78rem;
-}
-
-.merchant-items {
+.merchant-items-bar {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
-    padding: 1rem 1.25rem;
+    gap: 0.6rem;
 }
 
 /* Each item row: label | cost | buy-button */
-.merchant-item {
+.merchant-item-bar {
     display: grid;
     grid-template-columns: 1fr auto auto;
     align-items: center;
     gap: 0.75rem;
     padding: 0.75rem 1rem;
     margin: 0;
-    border: 1px solid var(--pico-muted-border-color);
-    border-radius: var(--pico-border-radius);
+    border: 1px solid var(--pico-muted-border-color, #ddd);
+    border-radius: var(--pico-border-radius, 6px);
+    background: #fff;
     transition: opacity 0.2s ease;
 }
 
-.merchant-item--sold {
+.merchant-item-bar--sold {
     opacity: 0.5;
 }
 
-.merchant-item__label {
+.merchant-item-bar__label {
     font-weight: 500;
     font-size: 0.9rem;
 }
 
-.merchant-item__cost {
+.merchant-item-bar__cost {
     font-weight: 600;
-    color: var(--pico-muted-color);
+    color: var(--pico-muted-color, #666);
     white-space: nowrap;
     font-size: 0.85rem;
 }
 
-.merchant-item__buy {
+.merchant-item-bar__buy {
     padding: 0.25rem 0.75rem;
     font-size: 0.8rem;
     margin: 0;
     white-space: nowrap;
+    cursor: pointer;
 }
 
-.merchant-dialog > article > footer {
-    padding: 0.75rem 1.25rem;
-    border-top: 1px solid var(--pico-muted-border-color);
-    display: flex;
-    justify-content: flex-end;
+/* ── Merchant buy feedback toast (bar page) ──────────────────────────────── */
+
+.merchant-toast {
+    padding: 0.45rem 0.9rem;
+    border-radius: 4px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    margin-bottom: 0.75rem;
+    color: #fff;
 }
 
-.merchant-dialog > article > footer button {
-    margin: 0;
-    width: auto;
-}
+.merchant-toast--info  { background: #14532d; }
+.merchant-toast--error { background: #7f1d1d; }
 
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -107,7 +107,7 @@ a:hover {color: #000; text-decoration: underline;}
 .res-ENrg { background: #dcfce7; border-color: #3db86e; }
 .res-LNrg { background: #ede9fe; border-color: #7c65cc; }
 .res-ANrg { background: #fefce8; border-color: #ca9b11; }
-.res-M    { background: #fce7f3; border-color: #d166a0; }
+.res-Tr   { background: #fce7f3; border-color: #d166a0; }
 .res-Rg   { background: #fdf0e0; border-color: #d4924a; }
 .res-Co   { background: #dceeff; border-color: #5599dd; }
 .res-Or   { background: #e8f5e0; border-color: #5a9a3a; }

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -96,7 +96,6 @@ function colonyHexView(config) {
         activeHint:         config.activeHint ?? null,
         merchantVisit:      config.merchantVisit ?? null,
         merchantItems:      config.merchantItems ?? [],
-        merchantOpen:       false,
         selectedTile:       null,
         buildMode:          false,
         pendingBuilding:    null,
@@ -276,33 +275,6 @@ function colonyHexView(config) {
             return this.merchantVisit !== null;
         },
 
-        openMerchant() {
-            this.merchantOpen = true;
-            // mark visit as seen (fire-and-forget)
-            if (this.merchantVisit && !this.merchantVisit.was_visited) {
-                this.post(this.routes.merchantOpen.replace('__VISIT__', this.merchantVisit.id), {});
-                this.merchantVisit.was_visited = true;
-            }
-            this.$nextTick(() => this.$refs.merchantDialog.showModal());
-        },
-
-        closeMerchant() {
-            this.merchantOpen = false;
-            this.$refs.merchantDialog.close();
-        },
-
-        async buyMerchantItem(itemId) {
-            const url = this.routes.merchantBuy.replace('__ID__', itemId);
-            const res = await this.post(url, {});
-            if (res.ok) {
-                const item = this.merchantItems.find(i => i.id === itemId);
-                if (item) item.sold = true;
-                this.showToast(res.message ?? 'Kauf erfolgreich.', 'info');
-            } else {
-                this.showToast(res.error ?? 'Kauf fehlgeschlagen.', 'error');
-            }
-        },
-
         async dismissHint() {
             if (!this.activeHint) return;
             const res = await this.post(this.routes.dismissHint, { hint_key: this.activeHint.key });
@@ -364,7 +336,7 @@ function colonyHexView(config) {
         statusLine() {
             const total    = this.tiles.length;
             const explored = this.tiles.filter(t => t.is_explored).length;
-            return `Sol ${this.currentSol} / ${this.solLimit} · ${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
+            return `${explored} / ${total} Tiles erkundet · CC Level ${this.ccLevel}`;
         },
 
         // ── HTTP helpers ──────────────────────────────────────────────────────

--- a/resources/views/colony/bar.blade.php
+++ b/resources/views/colony/bar.blade.php
@@ -11,12 +11,55 @@
     ];
 @endphp
 
-<div x-data="barPage()" x-cloak>
+<div x-data='barPage(
+    @json($merchantVisit),
+    @json($merchantItems),
+    @json(route("colony.merchant.buy", ["itemId" => "__ID__"])),
+    @json(route("colony.merchant.open", ["visitId" => "__VISIT__"])),
+    @json(route("colony.bar.accept", ["offer" => "__OFFER__"]))
+)' x-cloak>
 
     <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem">
         <h2 style="margin:0">{{ __('colony.bar_title') }}</h2>
         <small style="color:var(--pico-muted-color)">Sol {{ $currentSol }}</small>
     </div>
+
+    {{-- Traveling Merchant section — only shown when an active visit exists --}}
+    @if ($merchantVisit !== null)
+    <section class="merchant-section"
+             x-init="markVisitSeen()">
+        <div class="merchant-section__header">
+            <h3 style="margin:0">🛸 {{ __('colony.merchant_title') }}</h3>
+            <small style="color:var(--pico-muted-color)">
+                {{ __('colony.merchant_until_sol') }} {{ $merchantVisit->tick_end }}
+            </small>
+        </div>
+
+        {{-- Toast for buy feedback --}}
+        <div x-show="toast.visible"
+             x-transition
+             :class="'merchant-toast merchant-toast--' + toast.type"
+             x-text="toast.message"
+             aria-live="polite"
+             role="status"></div>
+
+        <div class="merchant-items-bar">
+            <template x-for="item in merchantItems" :key="item.id">
+                <article class="merchant-item-bar"
+                         :class="{ 'merchant-item-bar--sold': item.sold }">
+                    <div class="merchant-item-bar__label" x-text="item.label"></div>
+                    <div class="merchant-item-bar__cost" x-text="`${item.cost_credits} Cr`"></div>
+                    <button class="merchant-item-bar__buy"
+                            :disabled="item.sold || buyLoading"
+                            @click="buyItem(item.id)">
+                        <span x-show="!item.sold">{{ __('colony.merchant_buy') }}</span>
+                        <span x-show="item.sold">{{ __('colony.merchant_sold') }}</span>
+                    </button>
+                </article>
+            </template>
+        </div>
+    </section>
+    @endif
 
     @if ($barLevel < 1)
         <p>{{ __('colony.bar_no_building') }}</p>
@@ -52,11 +95,11 @@
                     </small>
                     <button
                         @click="accept({{ $offer->id }}, $el)"
-                        :disabled="accepted.has({{ $offer->id }}) || loading"
+                        :disabled="accepted[{{ $offer->id }}] || loading"
                         style="margin:0"
                     >
-                        <span x-show="!accepted.has({{ $offer->id }})">{{ __('colony.bar_offer_accept') }}</span>
-                        <span x-show="accepted.has({{ $offer->id }})">✓</span>
+                        <span x-show="!accepted[{{ $offer->id }}]">{{ __('colony.bar_offer_accept') }}</span>
+                        <span x-show="accepted[{{ $offer->id }}]">✓</span>
                     </button>
                 </div>
                 <div x-show="error[{{ $offer->id }}]" x-text="error[{{ $offer->id }}]"
@@ -69,26 +112,86 @@
 </div>
 
 <script>
-function barPage() {
+function barPage(merchantVisit, merchantItems, buyRoute, openRoute, acceptRoute) {
     return {
-        accepted: new Set(),
+        // Bar offer state — plain object for Alpine reactivity compatibility (Set is not tracked)
+        accepted: {},
         loading: false,
         error: {},
+
+        // Merchant state
+        merchantVisit: merchantVisit,
+        merchantItems: merchantItems ?? [],
+        buyLoading: false,
+        toast: { visible: false, message: '', type: 'info' },
+        _toastTimer: null,
+
+        // Mark visit as seen on first render (fire-and-forget)
+        markVisitSeen() {
+            if (!this.merchantVisit || this.merchantVisit.was_visited) return;
+            const url = openRoute.replace('__VISIT__', this.merchantVisit.id);
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]')?.content ?? '',
+                    'Accept': 'application/json',
+                },
+                body: JSON.stringify({}),
+            }).catch(() => {});
+            this.merchantVisit.was_visited = true;
+        },
+
+        async buyItem(itemId) {
+            this.buyLoading = true;
+            const url = buyRoute.replace('__ID__', itemId);
+            try {
+                const res = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]')?.content ?? '',
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify({}),
+                });
+                const data = await res.json();
+                if (data.ok) {
+                    const item = this.merchantItems.find(i => i.id === itemId);
+                    if (item) item.sold = true;
+                    this.showToast(data.message ?? @json(__('colony.merchant_buy_success')), 'info');
+                } else {
+                    this.showToast(data.error ?? @json(__('colony.merchant_buy_error')), 'error');
+                }
+            } catch {
+                this.showToast(@json(__('colony.merchant_buy_error')), 'error');
+            } finally {
+                this.buyLoading = false;
+            }
+        },
+
+        showToast(message, type = 'info') {
+            if (this._toastTimer) clearTimeout(this._toastTimer);
+            this.toast = { visible: true, message, type };
+            this._toastTimer = setTimeout(() => { this.toast.visible = false; }, 3500);
+        },
+
+        // Bar offer accept
         async accept(offerId, btn) {
             this.loading = true;
             this.error[offerId] = null;
             try {
-                const res = await fetch('{{ route('colony.bar.accept', ['offer' => '__ID__']) }}'.replace('__ID__', offerId), {
+                const res = await fetch(acceptRoute.replace('__OFFER__', offerId), {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
-                        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]')?.content ?? '',
                         'Accept': 'application/json',
                     },
                 });
                 const data = await res.json();
                 if (data.ok) {
-                    this.accepted.add(offerId);
+                    this.accepted[offerId] = true;
                 } else {
                     this.error[offerId] = data.error ?? 'Fehler';
                 }

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -23,8 +23,6 @@ window.__colonyViewData = {
         placeBuilding:      '{{ route('colony.building.place') }}',
         investBuilding:     '{{ route('colony.building.invest') }}',
         dismissHint:        '{{ route('colony.hint.dismiss') }}',
-        merchantBuy:        '{{ route('colony.merchant.buy', ['itemId' => '__ID__']) }}',
-        merchantOpen:       '{{ route('colony.merchant.open', ['visitId' => '__VISIT__']) }}',
     },
     i18n: {
         explore:            '{{ __('colony.explore') }}',
@@ -59,13 +57,13 @@ window.__colonyViewData = {
                           :class="trust >= 20 ? 'ap-chip--trust-pos' : trust < 0 ? 'ap-chip--trust-neg' : 'ap-chip--trust-neu'"
                           x-text="`Vertrauen ${trust}`"></span>
                 </div>
-                {{-- Merchant button — only shown when merchant is in system --}}
-                <button class="merchant-btn"
-                        x-show="hasMerchant()"
-                        @click="openMerchant()"
-                        x-cloak>
+                {{-- Merchant notification — links to Bar when merchant is present --}}
+                <a href="{{ route('colony.bar') }}"
+                   class="merchant-notify"
+                   x-show="hasMerchant()"
+                   x-cloak>
                     🛸 {{ __('colony.merchant_in_system') }}
-                </button>
+                </a>
 
                 <button class="build-btn"
                         :class="{ 'build-btn--active': buildMode }"
@@ -266,43 +264,6 @@ window.__colonyViewData = {
         </aside>
 
     </div>
-
-    {{-- Merchant modal -------------------------------------------------------
-         Native <dialog> element; opened via openMerchant() which calls
-         $refs.merchantDialog.showModal() — browser handles backdrop + focus-trap
-         + Escape key. merchantOpen tracks state on Alpine side so x-for re-renders
-         correctly when the dialog is reopened.
-    --}}
-    <dialog x-ref="merchantDialog" class="merchant-dialog" @close="merchantOpen = false">
-        <article>
-            <header>
-                <button aria-label="{{ __('colony.close') }}" rel="prev" @click="closeMerchant()"></button>
-                <h3>{{ __('colony.merchant_title') }}</h3>
-                <small x-show="merchantVisit">
-                    {{ __('colony.merchant_until_sol') }} <span x-text="merchantVisit?.tick_end"></span>
-                </small>
-            </header>
-
-            <div class="merchant-items">
-                <template x-for="item in merchantItems" :key="item.id">
-                    <article class="merchant-item" :class="{ 'merchant-item--sold': item.sold }">
-                        <div class="merchant-item__label" x-text="item.label"></div>
-                        <div class="merchant-item__cost" x-text="`${item.cost_credits} Cr`"></div>
-                        <button class="merchant-item__buy"
-                                :disabled="item.sold"
-                                @click="buyMerchantItem(item.id)">
-                            <span x-show="!item.sold">{{ __('colony.merchant_buy') }}</span>
-                            <span x-show="item.sold">{{ __('colony.merchant_sold') }}</span>
-                        </button>
-                    </article>
-                </template>
-            </div>
-
-            <footer>
-                <button @click="closeMerchant()">{{ __('colony.close') }}</button>
-            </footer>
-        </article>
-    </dialog>
 
     {{-- Event discovery popup ------------------------------------------------
          Uses the native <dialog> element (PicoCSS styles it out of the box).

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -15,13 +15,10 @@
 <header class="colony-header">
     <nav>
         <ul>
-            <li><strong><a href="{{ route('galaxy.index') }}">Nouron</a></strong></li>
+            <li><strong><a href="{{ route('colony.view') }}">Nouron</a></strong></li>
         </ul>
         <ul>
-            <li><a href="{{ route('galaxy.index') }}" @class(['active' => request()->routeIs('galaxy.*')])><i class="bi bi-globe2"></i> Galaxis</a></li>
-            <li><a href="{{ route('fleet.index') }}" @class(['active' => request()->routeIs('fleet.*')])><i class="bi bi-send"></i> Flotte</a></li>
             <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*') && !request()->routeIs('colony.bar*') && !request()->routeIs('colony.merchant*')])><i class="bi bi-hexagon"></i> Kolonie</a></li>
-            <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])><i class="bi bi-building"></i> Techtree</a></li>
             <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])><i class="bi bi-people"></i> Berater</a></li>
             <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])><i class="bi bi-cup-hot"></i> Cantina</a></li>
             <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])><i class="bi bi-envelope"></i> Nachrichten</a></li>

--- a/tests/Feature/Bar/BarControllerTest.php
+++ b/tests/Feature/Bar/BarControllerTest.php
@@ -124,7 +124,7 @@ class BarControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertViewIs('colony.bar');
-        $response->assertViewHasAll(['colony', 'offers', 'barLevel', 'tick']);
+        $response->assertViewHasAll(['colony', 'offers', 'barLevel', 'currentSol']);
     }
 
     public function test_index_shows_bar_page_when_bar_not_built(): void

--- a/tests/Feature/GameTick/AdvisorPromotionCostTest.php
+++ b/tests/Feature/GameTick/AdvisorPromotionCostTest.php
@@ -57,21 +57,19 @@ class AdvisorPromotionCostTest extends TestCase
         parent::setUp();
         $this->app->make(TestSeeder::class)->run();
 
-        // Remove all advisors for Bart except the trader (id=3) so upkeep costs
-        // from other advisors don't contaminate the credits balance under test.
-        DB::table('advisors')
-            ->where('colony_id', self::COLONY_ID)
-            ->where('id', '!=', self::ADVISOR_ID)
-            ->delete();
+        // Clear all advisors for this colony, then insert exactly the one advisor
+        // this test needs so upkeep from others can't contaminate the credits balance.
+        DB::table('advisors')->where('colony_id', self::COLONY_ID)->delete();
 
-        // Reset the trader advisor to rank 1 and place it one tick below the threshold.
-        // After one tick increment it will reach active_ticks = threshold and be eligible.
-        DB::table('advisors')
-            ->where('id', self::ADVISOR_ID)
-            ->update([
-                'rank'        => 1,
-                'active_ticks' => self::RANK1_THRESHOLD - 1,
-            ]);
+        DB::table('advisors')->insert([
+            'id'                    => self::ADVISOR_ID,
+            'user_id'               => self::USER_ID,
+            'personell_id'          => self::ADVISOR_PERSONELL_ID,
+            'colony_id'             => self::COLONY_ID,
+            'rank'                  => 1,
+            'active_ticks'          => self::RANK1_THRESHOLD - 1,
+            'unavailable_until_tick' => null,
+        ]);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/Feature/MerchantControllerTest.php
+++ b/tests/Feature/MerchantControllerTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Tests\Feature;
+
+/**
+ * MerchantController feature tests.
+ *
+ * Covered scenarios:
+ *
+ *  AUTH GUARD
+ *    - test_buy_requires_auth
+ *    - test_open_requires_auth
+ *
+ *  BUY (POST /colony/merchant/buy/{itemId})
+ *    - test_buy_returns_ok_true_for_valid_purchase
+ *    - test_buy_returns_422_when_not_enough_credits
+ *    - test_buy_returns_422_when_item_already_sold
+ *    - test_buy_returns_422_when_item_not_found
+ *    - test_buy_returns_422_when_visit_expired
+ *
+ *  OPEN (POST /colony/merchant/visit/{visitId}/open)
+ *    - test_open_returns_ok_true_for_authenticated_user
+ */
+
+use App\Models\User;
+use App\Services\TickService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MerchantControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Fixture constants ─────────────────────────────────────────────────────
+
+    private const USER_ID   = 3;   // Bart
+    private const COLONY_ID = 1;   // Springfield (user_id=3)
+
+    // ── Setup ─────────────────────────────────────────────────────────────────
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        config(['game.merchant' => [
+            'first_appearance_min' => 15,
+            'first_appearance_max' => 20,
+            'interval_min'         => 10,
+            'interval_max'         => 15,
+            'duration_ticks'       => 2,
+            'items_count'          => 3,
+            'items'                => [
+                'repair_kit'  => ['label' => 'Reparatur-Kit',   'cost' => 100, 'sp_amount'    => 30],
+                'trust_boost' => ['label' => 'Vertrauensschub', 'cost' => 150, 'trust_amount' => 15],
+                'information' => ['label' => 'Systemkarte',     'cost' => 200],
+            ],
+        ]]);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function bart(): User
+    {
+        return User::find(self::USER_ID);
+    }
+
+    private function mockTick(int $tick): void
+    {
+        $this->app->instance(TickService::class, new TickService($tick));
+    }
+
+    private function insertActiveVisit(int $tickStart = 20, int $tickEnd = 21): int
+    {
+        return DB::table('merchant_visits')->insertGetId([
+            'colony_id'   => self::COLONY_ID,
+            'tick_start'  => $tickStart,
+            'tick_end'    => $tickEnd,
+            'was_visited' => false,
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]);
+    }
+
+    private function insertItem(int $visitId, array $overrides = []): int
+    {
+        $defaults = [
+            'visit_id'     => $visitId,
+            'item_type'    => 'trust_boost',
+            'label'        => 'Vertrauensschub',
+            'cost_credits' => 150,
+            'payload'      => json_encode(['trust_amount' => 15]),
+            'sold'         => false,
+            'created_at'   => now(),
+            'updated_at'   => now(),
+        ];
+
+        return DB::table('merchant_items')->insertGetId(array_merge($defaults, $overrides));
+    }
+
+    private function setCredits(int $amount): void
+    {
+        DB::table('user_resources')
+            ->where('user_id', self::USER_ID)
+            ->update(['credits' => $amount]);
+    }
+
+    private function setColonyResource(int $resourceId, int $amount): void
+    {
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => $resourceId],
+            ['amount' => $amount]
+        );
+    }
+
+    // ── Auth guard ────────────────────────────────────────────────────────────
+
+    public function test_buy_requires_auth(): void
+    {
+        $response = $this->postJson(route('colony.merchant.buy', ['itemId' => 1]));
+
+        // JSON clients receive 401, not a redirect.
+        $response->assertUnauthorized();
+    }
+
+    public function test_open_requires_auth(): void
+    {
+        $response = $this->postJson(route('colony.merchant.open', ['visitId' => 1]));
+
+        $response->assertUnauthorized();
+    }
+
+    // ── BUY ───────────────────────────────────────────────────────────────────
+
+    public function test_buy_returns_ok_true_for_valid_purchase(): void
+    {
+        $this->mockTick(20);
+
+        $visitId = $this->insertActiveVisit(20, 21);
+        $itemId  = $this->insertItem($visitId, ['cost_credits' => 150]);
+        $this->setCredits(500);
+        $this->setColonyResource(12, 50);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.merchant.buy', ['itemId' => $itemId]));
+
+        $response->assertOk()
+            ->assertJson(['ok' => true]);
+    }
+
+    public function test_buy_returns_422_when_not_enough_credits(): void
+    {
+        $this->mockTick(20);
+
+        $visitId = $this->insertActiveVisit(20, 21);
+        $itemId  = $this->insertItem($visitId, ['cost_credits' => 500]);
+        $this->setCredits(10); // insufficient
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.merchant.buy', ['itemId' => $itemId]));
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false])
+            ->assertJsonStructure(['ok', 'error']);
+    }
+
+    public function test_buy_returns_422_when_item_already_sold(): void
+    {
+        $this->mockTick(20);
+
+        $visitId = $this->insertActiveVisit(20, 21);
+        $itemId  = $this->insertItem($visitId, ['sold' => true]);
+        $this->setCredits(500);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.merchant.buy', ['itemId' => $itemId]));
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false])
+            ->assertJsonStructure(['ok', 'error']);
+    }
+
+    public function test_buy_returns_422_when_item_not_found(): void
+    {
+        $this->mockTick(20);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.merchant.buy', ['itemId' => 99999]));
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false])
+            ->assertJsonStructure(['ok', 'error']);
+    }
+
+    public function test_buy_returns_422_when_visit_expired(): void
+    {
+        // Current tick=30 but visit ended at tick=21 → expired.
+        $this->mockTick(30);
+
+        $visitId = $this->insertActiveVisit(20, 21);
+        $itemId  = $this->insertItem($visitId);
+        $this->setCredits(500);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.merchant.buy', ['itemId' => $itemId]));
+
+        $response->assertStatus(422)
+            ->assertJson(['ok' => false]);
+    }
+
+    // ── OPEN ─────────────────────────────────────────────────────────────────
+
+    public function test_open_returns_ok_true_for_authenticated_user(): void
+    {
+        $visitId = $this->insertActiveVisit(20, 21);
+
+        $response = $this->actingAs($this->bart())
+            ->postJson(route('colony.merchant.open', ['visitId' => $visitId]));
+
+        $response->assertOk()
+            ->assertJson(['ok' => true]);
+
+        // Verify the was_visited flag was actually set in the DB.
+        $wasVisited = (bool) DB::table('merchant_visits')
+            ->where('id', $visitId)
+            ->value('was_visited');
+
+        $this->assertTrue($wasVisited, 'POST open must persist was_visited=true on the visit');
+    }
+}

--- a/tests/Feature/MerchantServiceTest.php
+++ b/tests/Feature/MerchantServiceTest.php
@@ -1,0 +1,560 @@
+<?php
+
+namespace Tests\Feature;
+
+/**
+ * MerchantService feature tests.
+ *
+ * Covered scenarios:
+ *
+ *  shouldSpawn
+ *    - test_should_spawn_returns_false_before_first_appearance_min
+ *    - test_should_spawn_returns_false_when_active_visit_exists
+ *    - test_should_spawn_returns_false_when_interval_min_not_elapsed
+ *    - test_should_spawn_returns_true_when_conditions_met
+ *
+ *  getActiveVisit
+ *    - test_get_active_visit_returns_visit_within_range
+ *    - test_get_active_visit_returns_null_when_no_visit
+ *    - test_get_active_visit_returns_null_when_tick_outside_range
+ *
+ *  spawnVisit
+ *    - test_spawn_visit_creates_one_merchant_visits_row
+ *    - test_spawn_visit_creates_correct_number_of_items
+ *    - test_spawn_visit_items_have_required_fields
+ *
+ *  buyItem
+ *    - test_buy_item_returns_false_when_item_not_found
+ *    - test_buy_item_returns_false_when_already_sold
+ *    - test_buy_item_returns_false_when_visit_no_longer_active
+ *    - test_buy_item_returns_false_when_not_enough_credits
+ *    - test_buy_item_success_deducts_credits_and_marks_sold
+ *    - test_buy_item_repair_kit_increases_status_points
+ *    - test_buy_item_repair_kit_caps_status_points_at_max
+ *    - test_buy_item_trust_boost_increments_colony_resource
+ *    - test_buy_item_information_sets_all_tiles_explored
+ *
+ *  getItemsForVisit
+ *    - test_get_items_for_visit_returns_all_items
+ *
+ *  markVisited
+ *    - test_mark_visited_sets_was_visited_true
+ */
+
+use App\Services\MerchantService;
+use App\Services\TickService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class MerchantServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── Fixture constants ─────────────────────────────────────────────────────
+
+    private const COLONY_ID = 1;   // Springfield — user_id=3 (Bart)
+    private const USER_ID   = 3;   // Bart
+
+    // Building from TestSeeder: colony_id=1, building_id=25, max_status_points=20
+    private const BUILDING_ID  = 25;
+    private const INSTANCE_ID  = 1;
+    private const MAX_SP       = 20;
+
+    private const TRUST_RESOURCE_ID = 12;
+
+    private MerchantService $service;
+
+    // ── Merchant config used across all tests ─────────────────────────────────
+
+    private static function merchantConfig(): array
+    {
+        return [
+            'first_appearance_min' => 15,
+            'first_appearance_max' => 20,
+            'interval_min'         => 10,
+            'interval_max'         => 15,
+            'duration_ticks'       => 2,
+            'items_count'          => 3,
+            'items'                => [
+                'repair_kit'  => ['label' => 'Reparatur-Kit',  'cost' => 100, 'sp_amount'     => 30],
+                'trust_boost' => ['label' => 'Vertrauensschub','cost' => 150, 'trust_amount'   => 15],
+                'information' => ['label' => 'Systemkarte',    'cost' => 200],
+            ],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        config(['game.merchant' => self::merchantConfig()]);
+        $this->service = $this->app->make(MerchantService::class);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function mockTick(int $tick): void
+    {
+        $this->app->instance(TickService::class, new TickService($tick));
+    }
+
+    private function insertVisit(array $overrides = []): int
+    {
+        $defaults = [
+            'colony_id'   => self::COLONY_ID,
+            'tick_start'  => 20,
+            'tick_end'    => 21,
+            'was_visited' => false,
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ];
+
+        return DB::table('merchant_visits')->insertGetId(array_merge($defaults, $overrides));
+    }
+
+    private function insertItem(int $visitId, array $overrides = []): int
+    {
+        $defaults = [
+            'visit_id'     => $visitId,
+            'item_type'    => 'repair_kit',
+            'label'        => 'Reparatur-Kit',
+            'cost_credits' => 100,
+            'payload'      => json_encode(['sp_amount' => 30]),
+            'sold'         => false,
+            'created_at'   => now(),
+            'updated_at'   => now(),
+        ];
+
+        return DB::table('merchant_items')->insertGetId(array_merge($defaults, $overrides));
+    }
+
+    private function setCredits(int $amount): void
+    {
+        DB::table('user_resources')
+            ->where('user_id', self::USER_ID)
+            ->update(['credits' => $amount]);
+    }
+
+    private function getCredits(): int
+    {
+        return (int) DB::table('user_resources')
+            ->where('user_id', self::USER_ID)
+            ->value('credits');
+    }
+
+    private function setColonyResource(int $resourceId, int $amount): void
+    {
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => $resourceId],
+            ['amount' => $amount]
+        );
+    }
+
+    private function getColonyResource(int $resourceId): int
+    {
+        return (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('resource_id', $resourceId)
+            ->value('amount');
+    }
+
+    // ── shouldSpawn ───────────────────────────────────────────────────────────
+
+    public function test_should_spawn_returns_false_before_first_appearance_min(): void
+    {
+        // Tick 14 is below first_appearance_min=15 → must return false unconditionally.
+        $result = $this->service->shouldSpawn(self::COLONY_ID, 14);
+
+        $this->assertFalse($result, 'shouldSpawn must return false when tick < first_appearance_min');
+    }
+
+    public function test_should_spawn_returns_false_when_active_visit_exists(): void
+    {
+        // tick_end=30 >= currentTick=20 → active visit exists.
+        $this->insertVisit(['tick_start' => 20, 'tick_end' => 30]);
+
+        $result = $this->service->shouldSpawn(self::COLONY_ID, 20);
+
+        $this->assertFalse($result, 'shouldSpawn must return false when an active visit exists');
+    }
+
+    public function test_should_spawn_returns_false_when_interval_min_not_elapsed(): void
+    {
+        // Last visit ended at tick_end=30. interval_min=10 means next spawn earliest at tick=40.
+        // We check tick=39 — not yet past the interval.
+        $this->insertVisit(['tick_start' => 28, 'tick_end' => 30]);
+
+        $result = $this->service->shouldSpawn(self::COLONY_ID, 39);
+
+        $this->assertFalse($result, 'shouldSpawn must return false when interval_min has not elapsed since last visit');
+    }
+
+    public function test_should_spawn_returns_true_when_conditions_met(): void
+    {
+        // No prior visits, tick=17 >= first_appearance_min=15.
+        // Deterministic seed check for colonyId=1, tick=17:
+        //   seed = 1*1664525 + 17*1013904223 = 17238036316
+        //   hash = 58167132, frac ≈ 0.0271 < 0.08 (=1/12.5) → true
+        $result = $this->service->shouldSpawn(self::COLONY_ID, 17);
+
+        $this->assertTrue($result, 'shouldSpawn must return true when no prior visits and tick passes the random threshold');
+    }
+
+    // ── getActiveVisit ────────────────────────────────────────────────────────
+
+    public function test_get_active_visit_returns_visit_within_range(): void
+    {
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+
+        $visit = $this->service->getActiveVisit(self::COLONY_ID, 20);
+
+        $this->assertNotNull($visit, 'getActiveVisit must return the visit when tick is within [tick_start, tick_end]');
+        $this->assertEquals($visitId, $visit->id);
+    }
+
+    public function test_get_active_visit_returns_null_when_no_visit(): void
+    {
+        $visit = $this->service->getActiveVisit(self::COLONY_ID, 50);
+
+        $this->assertNull($visit, 'getActiveVisit must return null when no visit row exists for the colony');
+    }
+
+    public function test_get_active_visit_returns_null_when_tick_outside_range(): void
+    {
+        // Visit covers ticks 20–21; we query at tick=25 → should return null.
+        $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+
+        $visit = $this->service->getActiveVisit(self::COLONY_ID, 25);
+
+        $this->assertNull($visit, 'getActiveVisit must return null when tick is past tick_end');
+    }
+
+    // ── spawnVisit ────────────────────────────────────────────────────────────
+
+    public function test_spawn_visit_creates_one_merchant_visits_row(): void
+    {
+        $this->service->spawnVisit(self::COLONY_ID, 20);
+
+        $count = DB::table('merchant_visits')
+            ->where('colony_id', self::COLONY_ID)
+            ->count();
+
+        $this->assertEquals(1, $count, 'spawnVisit must create exactly one merchant_visits row');
+
+        $visit = DB::table('merchant_visits')->where('colony_id', self::COLONY_ID)->first();
+        $this->assertEquals(20, $visit->tick_start);
+        // duration_ticks=2 → tick_end = 20 + 2 - 1 = 21
+        $this->assertEquals(21, $visit->tick_end);
+    }
+
+    public function test_spawn_visit_creates_correct_number_of_items(): void
+    {
+        // items_count=3 in config, items pool has exactly 3 types → expect 3 items.
+        $this->service->spawnVisit(self::COLONY_ID, 20);
+
+        $visit = DB::table('merchant_visits')->where('colony_id', self::COLONY_ID)->first();
+        $itemCount = DB::table('merchant_items')
+            ->where('visit_id', $visit->id)
+            ->count();
+
+        $this->assertEquals(3, $itemCount, 'spawnVisit must create exactly items_count merchant_items rows');
+    }
+
+    public function test_spawn_visit_items_have_required_fields(): void
+    {
+        $this->service->spawnVisit(self::COLONY_ID, 20);
+
+        $visit = DB::table('merchant_visits')->where('colony_id', self::COLONY_ID)->first();
+        $items = DB::table('merchant_items')->where('visit_id', $visit->id)->get();
+
+        foreach ($items as $item) {
+            $this->assertNotEmpty($item->item_type, 'Each item must have a non-empty item_type');
+            $this->assertNotEmpty($item->label, 'Each item must have a non-empty label');
+            $this->assertGreaterThan(0, $item->cost_credits, 'Each item must have a positive cost_credits');
+        }
+    }
+
+    // ── buyItem ───────────────────────────────────────────────────────────────
+
+    public function test_buy_item_returns_false_when_item_not_found(): void
+    {
+        $this->mockTick(20);
+
+        $result = $this->service->buyItem(99999, self::COLONY_ID, self::USER_ID);
+
+        $this->assertFalse($result['ok']);
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    public function test_buy_item_returns_false_when_already_sold(): void
+    {
+        $this->mockTick(20);
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId, ['sold' => true]);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertFalse($result['ok'], 'buyItem must return ok=false when item is already sold');
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    public function test_buy_item_returns_false_when_visit_no_longer_active(): void
+    {
+        // Visit ended at tick=21, but current tick is 30 → expired.
+        $this->mockTick(30);
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId);
+        $this->setCredits(10000);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertFalse($result['ok'], 'buyItem must return ok=false when the visit is no longer active');
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    public function test_buy_item_returns_false_when_not_enough_credits(): void
+    {
+        $this->mockTick(20);
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId, ['cost_credits' => 500]);
+        $this->setCredits(50); // less than 500
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertFalse($result['ok'], 'buyItem must return ok=false when credits are insufficient');
+        $this->assertArrayHasKey('error', $result);
+    }
+
+    public function test_buy_item_success_deducts_credits_and_marks_sold(): void
+    {
+        $this->mockTick(20);
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId, [
+            'item_type'    => 'trust_boost',
+            'payload'      => json_encode(['trust_amount' => 15]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(300);
+        $this->setColonyResource(self::TRUST_RESOURCE_ID, 50);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertTrue($result['ok'], 'buyItem must return ok=true on a valid purchase');
+        $this->assertEquals(200, $this->getCredits(), 'buyItem must deduct cost_credits from user_resources');
+
+        $sold = (bool) DB::table('merchant_items')->where('id', $itemId)->value('sold');
+        $this->assertTrue($sold, 'buyItem must mark the item as sold=true');
+
+        $this->assertArrayHasKey('credits', $result);
+        $this->assertEquals(200, $result['credits']);
+    }
+
+    public function test_buy_item_repair_kit_increases_status_points(): void
+    {
+        $this->mockTick(20);
+
+        // Max out all colony buildings first so only the target has a low SP ratio.
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->update(['status_points' => self::MAX_SP]);
+
+        // Now give the target building the lowest SP → it will be selected for repair.
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::BUILDING_ID)
+            ->where('instance_id', self::INSTANCE_ID)
+            ->update(['status_points' => 5, 'level' => 1]);
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId, [
+            'item_type' => 'repair_kit',
+            'payload'   => json_encode(['sp_amount' => 10]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(500);
+
+        $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $spAfter = (int) DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::BUILDING_ID)
+            ->where('instance_id', self::INSTANCE_ID)
+            ->value('status_points');
+
+        $this->assertGreaterThan(5, $spAfter, 'repair_kit effect must increase the status_points of the target building');
+    }
+
+    public function test_buy_item_repair_kit_caps_status_points_at_max(): void
+    {
+        $this->mockTick(20);
+
+        // max_status_points=20 for building_id=25 (see TestSeeder + buildings table).
+        // Max out all buildings first, then set the target just below max.
+        // This ensures the target has the lowest relative SP and gets selected.
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->update(['status_points' => self::MAX_SP]);
+
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::BUILDING_ID)
+            ->where('instance_id', self::INSTANCE_ID)
+            ->update(['status_points' => 15, 'level' => 1]);
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId, [
+            'item_type' => 'repair_kit',
+            'payload'   => json_encode(['sp_amount' => 30]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(500);
+
+        $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $spAfter = (int) DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::BUILDING_ID)
+            ->where('instance_id', self::INSTANCE_ID)
+            ->value('status_points');
+
+        $this->assertEquals(self::MAX_SP, $spAfter, 'repair_kit must cap status_points at max_status_points');
+    }
+
+    public function test_buy_item_trust_boost_increments_colony_resource(): void
+    {
+        $this->mockTick(20);
+
+        $initialTrust = 100;
+        $trustAmount  = 15;
+        $this->setColonyResource(self::TRUST_RESOURCE_ID, $initialTrust);
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId, [
+            'item_type' => 'trust_boost',
+            'payload'   => json_encode(['trust_amount' => $trustAmount]),
+            'cost_credits' => 150,
+        ]);
+        $this->setCredits(500);
+
+        $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $trustAfter = $this->getColonyResource(self::TRUST_RESOURCE_ID);
+
+        $this->assertEquals(
+            $initialTrust + $trustAmount,
+            $trustAfter,
+            'trust_boost effect must increment colony_resources amount for resource_id=12'
+        );
+    }
+
+    public function test_buy_item_information_sets_all_tiles_explored(): void
+    {
+        $this->mockTick(20);
+
+        // Insert two unexplored tiles for the colony.
+        DB::table('colony_tiles')->insert([
+            [
+                'colony_id'    => self::COLONY_ID,
+                'q'            => 0,
+                'r'            => 0,
+                'ring'         => 0,
+                'tile_type'    => 'plain',
+                'is_explored'  => false,
+                'is_deep_scanned' => false,
+                'created_at'   => now(),
+                'updated_at'   => now(),
+            ],
+            [
+                'colony_id'    => self::COLONY_ID,
+                'q'            => 1,
+                'r'            => 0,
+                'ring'         => 1,
+                'tile_type'    => 'plain',
+                'is_explored'  => false,
+                'is_deep_scanned' => false,
+                'created_at'   => now(),
+                'updated_at'   => now(),
+            ],
+        ]);
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId  = $this->insertItem($visitId, [
+            'item_type'    => 'information',
+            'payload'      => null,
+            'cost_credits' => 200,
+        ]);
+        $this->setCredits(500);
+
+        $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $unexploredCount = DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('is_explored', false)
+            ->count();
+
+        $this->assertEquals(
+            0,
+            $unexploredCount,
+            'information effect must set is_explored=true on all colony tiles'
+        );
+    }
+
+    // ── getItemsForVisit ──────────────────────────────────────────────────────
+
+    public function test_get_items_for_visit_returns_all_items(): void
+    {
+        $visitId = $this->insertVisit();
+        $this->insertItem($visitId, ['item_type' => 'repair_kit']);
+        $this->insertItem($visitId, ['item_type' => 'trust_boost', 'cost_credits' => 150]);
+        $this->insertItem($visitId, ['item_type' => 'information', 'cost_credits' => 200]);
+
+        $items = $this->service->getItemsForVisit($visitId);
+
+        $this->assertCount(3, $items, 'getItemsForVisit must return all items linked to the given visit_id');
+        $types = $items->pluck('item_type')->sort()->values()->all();
+        $this->assertContains('repair_kit', $types);
+        $this->assertContains('trust_boost', $types);
+        $this->assertContains('information', $types);
+    }
+
+    // ── markVisited ───────────────────────────────────────────────────────────
+
+    public function test_mark_visited_sets_was_visited_true(): void
+    {
+        $visitId = $this->insertVisit(['was_visited' => false]);
+
+        $this->service->markVisited($visitId, self::COLONY_ID);
+
+        $wasVisited = (bool) DB::table('merchant_visits')
+            ->where('id', $visitId)
+            ->value('was_visited');
+
+        $this->assertTrue($wasVisited, 'markVisited must set was_visited=true on the visit');
+    }
+
+    public function test_mark_visited_does_not_affect_other_colony_visits(): void
+    {
+        // Insert a visit for colony 2 (Shelbyville) — must not be touched.
+        $foreignVisitId = DB::table('merchant_visits')->insertGetId([
+            'colony_id'   => 2,
+            'tick_start'  => 20,
+            'tick_end'    => 21,
+            'was_visited' => false,
+            'created_at'  => now(),
+            'updated_at'  => now(),
+        ]);
+
+        $ownVisitId = $this->insertVisit(['was_visited' => false]);
+
+        // Mark own visit as visited using colony 1.
+        $this->service->markVisited($ownVisitId, self::COLONY_ID);
+
+        $foreignStillFalse = !(bool) DB::table('merchant_visits')
+            ->where('id', $foreignVisitId)
+            ->value('was_visited');
+
+        $this->assertTrue($foreignStillFalse, 'markVisited must not affect visits belonging to other colonies');
+    }
+}

--- a/tests/Feature/Techtree/BuildingServiceTest.php
+++ b/tests/Feature/Techtree/BuildingServiceTest.php
@@ -22,6 +22,17 @@ class BuildingServiceTest extends TestCase
         parent::setUp();
         $this->app->make(TestSeeder::class)->run();
         $this->service = $this->app->make(BuildingService::class);
+
+        // Provide a construction advisor for colony 1 so invest() has AP available.
+        DB::table('advisors')->where('colony_id', $this->colonyId)->delete();
+        DB::table('advisors')->insert([
+            'user_id'               => 3,
+            'personell_id'          => 35, // engineer (construction AP)
+            'colony_id'             => $this->colonyId,
+            'rank'                  => 3,  // 12 AP — enough for any invest test
+            'active_ticks'          => 0,
+            'unavailable_until_tick' => null,
+        ]);
     }
 
     public function testGetEntities(): void

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -27,6 +27,17 @@ class TechtreeControllerTest extends TestCase
     {
         parent::setUp();
         $this->app->make(TestSeeder::class)->run();
+
+        // Provide a construction advisor for colony 1 so techtree invest actions have AP.
+        DB::table('advisors')->where('colony_id', $this->colonyIdBart)->delete();
+        DB::table('advisors')->insert([
+            'user_id'               => $this->userIdBart,
+            'personell_id'          => 35, // engineer (construction AP)
+            'colony_id'             => $this->colonyIdBart,
+            'rank'                  => 3,
+            'active_ticks'          => 0,
+            'unavailable_until_tick' => null,
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary

- **Reisender Händler → Cantina**: Händler-Dialog aus Hexview entfernt, vollständig in `colony.bar` integriert. Alpine-Komponente mit Item-Loop, Kauf-Button, Toast-Feedback. Händler-Benachrichtigung bleibt als Nav-Link mit `x-show`.
- **Alpine SyntaxError behoben**: `@json()` in doppelt-quoted `x-data`-Attribut terminierte durch strukturelle JSON-Anführungszeichen das Attribut vorzeitig. Fix: einfache Anführungszeichen, Routen als `@json()`-Parameter übergeben.
- **Advisor same-tick Rehire-Exploit**: `fire()` setzt `unavailable_until_tick = currentTick`, `hire()` lehnt Wiedereinstellung im gleichen Tick ab.
- **Vertrauens-Abkürzung `M` → `Tr`**: Konsistent mit englischen Bezeichnern. CSS + Testdaten aktualisiert.
- **Nav vereinfacht**: Galaxis/Flotte/Techtree entfernt → Kolonie · Berater · Cantina · Nachrichten.
- **Sol-Anzeige**: Run-lokal berechnet (`min(solLimit, max(1, globalTick - sinceTick + 1))`).
- **Tests**: `MerchantServiceTest` (22), `MerchantControllerTest` (8) neu; 4 bestehende Tests self-contained gemacht.

## Test plan

- [ ] Cantina aufrufen wenn Händler aktiv → Items sichtbar, Kauf funktioniert, Toast erscheint
- [ ] Berater einstellen → feuern → sofort wieder einstellen → Fehlermeldung erscheint
- [ ] Sol-Anzeige in Ressourcenleiste zeigt run-lokalen Wert (~6/100), nicht globalen Tick
- [ ] Nav zeigt nur: Kolonie, Berater, Cantina, Nachrichten
- [ ] `php artisan test` — alle Tests grün