### PR TITLE
feat(ui): Design Guide, helle Navbar, Mobile-Fixes, Messages-Migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2026-05-29 (Session 2)
+
+- **Design Guide**: `docs/design-guide.md` erstellt — verbindliche Referenz für Farben (`#8c2030` Nouron-Rot), Typografie (Libre Baskerville für H1/H2/Logo, system-ui für alles andere), Spacing-System (8px-Basis), Komponenten (Navbar, Cards, Buttons, Chips), Screen-Typen (Lobby, In-Run, Cantina).
+
+- **Navbar-Migration hell**: Bootstrap-Navbar von `navbar-dark bg-dark` auf helle Variante (`navbar-nouron`) umgestellt. Libre-Baskerville-Logo. Beide Layouts (`app.blade.php` + `colony.blade.php`) migriert. Colony-Layout: Techtree-Navlink ergänzt. Navbar kontextbewusst: Run-Navigation (Galaxis, Flotte etc.), Nexus-Kredit, Sol-Button nur sichtbar wenn aktiver Run + nicht auf Lobby-Route.
+
+- **CSS-Refactor**: Alle Ressourcen-Chip-Styles in eigene `public/css/resources.css` ausgelagert (importiert von `style.css` + `colony.css`). Design-Tokens als CSS Custom Properties in `:root` (`--color-accent`, `--color-bg`, etc.). Sol/AP-Overlay-Styles ergänzt.
+
+- **Ressourcenleiste vereinfacht**: Trust (resource_id=12) aus Bar entfernt (Duplikat mit Colony-Header). Nexus-Kredit aus Navbar in CR-Chip-Popup verschoben (hover/tap). Sol-Chip ohne Max-Wert und ohne Border. Alle Chips einheitliche Größe (`0.82rem`, kein `res-chip--primary` size-jump).
+
+- **Chip-Popups (reusable)**: `resources/views/partials/res-popup.blade.php` — Alpine-Hover/Tap-Popup für alle Chips (SOL, CR, SUP, sekundäre, Nav-AP, Bau-AP, Vertrauen). Beschreibungstexte in `lang/de/resources.php`.
+
+- **Sol-Button Flow**: AP-Check vor Sol-Ende via `GET /sol/remaining-ap`. Confirm-Dialog wenn ungenutzte AP vorhanden (zeigt AP-Aufschlüsselung). Ladescree (Blur-Overlay, Spinner, min. 5 Sekunden). `partials/sol-button.blade.php` als wiederverwendbarer Alpine-Komponent für beide Layouts.
+
+- **Lobby-Fixes**: Dunkle PicoCSS-Karte → hell (`data-theme="light"`). Sol 1938/100 → gecappt auf tick_limit. Run-Nav + Ressourcenleiste auf Lobby-Route ausgeblendet.
+
+- **Techtree-Verbesserungen**: Onboarding-Hint 4 Route `/techtree/research` → `/techtree` (404 gefixt). Hint-Text klarer formuliert. AP-Hinweis unter Progress-Bar wenn `apAvailable = 0` ("Analytiker einstellen" bzw. "Baumeister einstellen").
+
+- **Supply-Kosten im Bau-Dialog**: `supply_cost` wird jetzt im Gebäude-Bau-Panel angezeigt (`X SUP` Badge, nur bei supply_cost > 0).
+
+- **Testdata Springfield bereinigt**: Von korruptem Viel-Gebäude-Stand (Usage 70 >> Cap 26) auf validen Sol-5-Startstand zurückgesetzt — CC Lv1, Harvester Lv1, 1× WH Lv1, Baumeister-Berater, Credits 2700, Supply 18.
+
+- **`game:validate-colony` Artisan Command**: Prüft aktiven Run, Supply-Cap vs. Usage, CC-Level, Trust-Ressource, Tick-Sanity. Exit-Code 1 bei Fehlern (CI-fähig). Aufruf: `php artisan game:validate-colony [colony_id]`.
+
+- **image-gen crop-Feature**: `tools/image-gen/generate.py` — center-crop nach Resize über `crop`-Key in Kategorie-Config.
+
 ## 2026-05-29
 
 - **PR #142 Review-Fixes**: ROADMAP Phase-4-TODO Objective Discovery: Sol +5 auf Sol +15 korrigiert (war nach §17.1-Timing-Korrektur nicht mitgezogen). Hook-Kommentar in `pre-merge-check.sh` präzisiert (kein PR-Description-Check vorhanden). `advisor_dialogs.status`-Semantik geschärft: `declined` = explizite Spieler-Ablehnung, `expired` = automatischer Verfall durch Postpone-Maximum oder Timeout — in GDD §17.2 und `game-reference.md` konsistent dokumentiert. CHANGELOG doppelte Leerzeile entfernt. CLAUDE.md abschließendes Newline ergänzt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
 
 - **Messages Swipe-Navigation**: Alle Messages-Views (`inbox`, `outbox`, `archive`, `events`, `news`) haben `swipeNav`-Wrapper — auf Mobile zwischen Tabs hin- und herwischen (Eingang → Ausgang → Archiv → Ereignisse → INNN).
 
+- **Hamburger-Menü (Mobile)**: Unter 600px kollabiert die Colony-Navbar zu Logo + Hamburger-Icon. Flyout-Menü mit allen 5 Nav-Links + Profil/Einstellungen/Abmelden. Hamburger via Alpine `@click.outside` schließbar.
+
+- **Sol-Button Mobile**: Auf Mobile nur auf der Kolonie-View sichtbar (`body.page-colony`). Auf Messages, Techtree, Berater, Cantina ausgeblendet — Sol beenden ist die zentrale Hub-Aktion der Kolonie-View.
+
+- **Messages Mobile**: Tabs-Bar unter 600px ausgeblendet. Stattdessen: aktueller Tab-Name + 5 Dot-Indikatoren. Swipe-Logik via window-level vanilla JS (zuverlässiger als Alpine für touch-Events).
+
 ## 2026-05-29
 
 - **PR #142 Review-Fixes**: ROADMAP Phase-4-TODO Objective Discovery: Sol +5 auf Sol +15 korrigiert (war nach §17.1-Timing-Korrektur nicht mitgezogen). Hook-Kommentar in `pre-merge-check.sh` präzisiert (kein PR-Description-Check vorhanden). `advisor_dialogs.status`-Semantik geschärft: `declined` = explizite Spieler-Ablehnung, `expired` = automatischer Verfall durch Postpone-Maximum oder Timeout — in GDD §17.2 und `game-reference.md` konsistent dokumentiert. CHANGELOG doppelte Leerzeile entfernt. CLAUDE.md abschließendes Newline ergänzt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
 
 - **image-gen crop-Feature**: `tools/image-gen/generate.py` — center-crop nach Resize über `crop`-Key in Kategorie-Config.
 
+- **Messages-Screen auf neues Design migriert**: Von `layouts.app` (Bootstrap) auf `layouts.colony` (PicoCSS/Alpine). Bootstrap-Accordion durch Alpine `x-data`/`x-show` ersetzt. Tabs-Partial mit neuem `msg-tabs`-Stil. `messages.css` als eigene CSS-Datei extrahiert (geladen via `@push('styles')` im Tabs-Partial). `msg-*`-CSS aus `resources.css` entfernt (gehört dort nicht hin).
+
+- **Navbar Icon-only auf Mobile**: Nav-Label-Text in `<span class="nav-label">` gewrappt — auf Mobilgeräten (< 768px) via `swipe.css` ausgeblendet, nur Icons bleiben sichtbar. Gilt für beide Layouts.
+
+- **Swipe-Infrastruktur**: `public/js/swipe.js` — zwei Alpine-Komponenten: `swipeNav({prev, next})` (URL-Navigation via Swipe) + `swipeCarousel(count, initial)` (In-Page-Panels, für Berater/Cantina/Hangar geplant). `public/css/swipe.css` — Container, Track, Panel, Dot-Indikatoren. Geladen in `layouts.colony` + `layouts.app`.
+
+- **Messages Swipe-Navigation**: Alle Messages-Views (`inbox`, `outbox`, `archive`, `events`, `news`) haben `swipeNav`-Wrapper — auf Mobile zwischen Tabs hin- und herwischen (Eingang → Ausgang → Archiv → Ereignisse → INNN).
+
 ## 2026-05-29
 
 - **PR #142 Review-Fixes**: ROADMAP Phase-4-TODO Objective Discovery: Sol +5 auf Sol +15 korrigiert (war nach §17.1-Timing-Korrektur nicht mitgezogen). Hook-Kommentar in `pre-merge-check.sh` präzisiert (kein PR-Description-Check vorhanden). `advisor_dialogs.status`-Semantik geschärft: `declined` = explizite Spieler-Ablehnung, `expired` = automatischer Verfall durch Postpone-Maximum oder Timeout — in GDD §17.2 und `game-reference.md` konsistent dokumentiert. CHANGELOG doppelte Leerzeile entfernt. CLAUDE.md abschließendes Newline ergänzt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 
 **Abgeschlossen:** ZF2 → Laminas → Laravel Migration, Techtree-Redesign, Tick-System, AP-System, Berater-System, Flottenoperationen, Decay-System, Moralsystem, Supply-System, INNN-Nachrichten, Hex-Grid Kolonieansicht, Systemkarte, Reisender Händler, jQuery-Migration (vollständig), Berater-Screen (Alpine.js + PicoCSS), Onboarding-System (Triggers + Hints-Bar), Run-System, Lobby/Runs-Übersicht, Debug-Statusleiste (Admin), Fleet Command Overlay (Systemkarte).
 
-**Laufend (Phase 3):** UI-Migration Bootstrap 5 → Alpine.js + PicoCSS. Ausstehend: GDD-Cleanup (Balance-TODOs nach Playtest), Onboarding-Wizard (Triggers + Hints implementiert, kein dedizierter New-Player-Flow), Kommandanten-Zuweisung UI (Fleet), Ressourcen-DB-Cleanup (ENrg/LNrg/ANrg noch in DB, per Whitelist gefiltert).
+**Laufend (Phase 3):** UI-Migration Bootstrap 5 → Alpine.js + PicoCSS. Ausstehend: GDD-Cleanup (Balance-TODOs nach Playtest), Onboarding-Wizard (Triggers + Hints implementiert, kein dedizierter New-Player-Flow), Kommandanten-Zuweisung UI (Fleet), Ressourcen-DB-Cleanup (ENrg/LNrg/ANrg noch in DB, per Whitelist gefiltert), Cantina-Redesign (Bar-Hintergrund + NPC-Charaktere geplant).
 
 ## Wichtige Korrekturen
 
@@ -23,6 +23,7 @@
   - `data/db/test.db` — Testdatenbank (befüllt via `data/sql/testdata.sqlite.sql`)
 - `Routen.txt` und `code/nouron_(pre_zend)/` veraltet — nur GitHub-Repo relevant
 - Vollständige Referenztabellen (Ressourcen, Gebäude, Schiffe, DB-Schema) → `docs/game-reference.md`
+- Design Guide (Farben, Typo, Spacing, Komponenten) → `docs/design-guide.md`
 
 ## Architektur (Laravel)
 
@@ -40,7 +41,8 @@ database/migrations/  -- Schema-Migrationen
 data/sql/
   testdata.sqlite.sql -- Testdaten (INSERT + UPDATE, wird von TestSeeder ausgeführt)
 resources/views/      -- Blade-Templates
-public/js|css/        -- techtree-view.js, advisors.js, techtree-view.css, ...
+  partials/           -- sol-button.blade.php, res-popup.blade.php (wiederverwendbar)
+public/js|css/        -- techtree-view.js, advisors.js, techtree-view.css, resources.css, ...
 ```
 
 Schichtung: `Controller → Service → Eloquent Model → SQLite`

--- a/app/Console/Commands/ValidateColony.php
+++ b/app/Console/Commands/ValidateColony.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class ValidateColony extends Command
+{
+    protected $signature   = 'game:validate-colony {colony_id? : Colony ID to check (default: all active colonies)}';
+    protected $description = 'Validate colony game state — detect supply overrun, AP inconsistencies, missing run, etc.';
+
+    public function handle(): int
+    {
+        $colonyIdArg = $this->argument('colony_id');
+        $colonies = $colonyIdArg
+            ? [DB::table('glx_colonies')->where('id', $colonyIdArg)->first()]
+            : DB::table('glx_colonies')->get()->all();
+
+        $hasErrors = false;
+
+        foreach ($colonies as $colony) {
+            if (!$colony) {
+                $this->error("Colony {$colonyIdArg} not found.");
+                return 1;
+            }
+
+            $issues = [];
+            $id   = $colony->id;
+            $name = $colony->name ?? "Colony #{$id}";
+
+            // --- Check 1: Active run exists ---
+            $run = DB::table('runs')
+                ->where('colony_id', $id)
+                ->where('status', 'active')
+                ->first();
+            if (!$run) {
+                $issues[] = ['WARN', 'No active run for colony'];
+            }
+
+            // --- Check 2: Supply cap vs usage ---
+            $userResource = DB::table('user_resources')
+                ->where('user_id', $colony->user_id)
+                ->first();
+            $supplyCap   = $userResource ? (int) $userResource->supply : 0;
+
+            $buildingUsage = DB::table('colony_buildings as cb')
+                ->join('buildings as b', 'cb.building_id', '=', 'b.id')
+                ->where('cb.colony_id', $id)
+                ->where('cb.level', '>', 0)
+                ->selectRaw('SUM(cb.level * b.supply_cost) as total_usage')
+                ->value('total_usage') ?? 0;
+
+            if ($buildingUsage > $supplyCap) {
+                $issues[] = ['ERROR', "Supply overrun: usage={$buildingUsage} > cap={$supplyCap} (deficit=" . ($buildingUsage - $supplyCap) . ")"];
+            } else {
+                $issues[] = ['OK', "Supply: usage={$buildingUsage} / cap={$supplyCap}"];
+            }
+
+            // --- Check 3: CC level exists ---
+            $ccLevel = DB::table('colony_buildings')
+                ->where('colony_id', $id)
+                ->where('building_id', 25)
+                ->value('level') ?? 0;
+            if ($ccLevel === 0) {
+                $issues[] = ['ERROR', 'CommandCenter missing or level 0'];
+            } else {
+                $issues[] = ['OK', "CC level: {$ccLevel}"];
+            }
+
+            // --- Check 4: Trust resource exists ---
+            $trust = DB::table('colony_resources')
+                ->where('colony_id', $id)
+                ->where('resource_id', 12)
+                ->value('amount');
+            if ($trust === null) {
+                $issues[] = ['WARN', 'Trust resource row missing'];
+            } elseif ((int)$trust < -50) {
+                $issues[] = ['WARN', "Trust critically low: {$trust}"];
+            }
+
+            // --- Check 5: run current_tick sanity ---
+            if ($run) {
+                $tickLimit = json_decode($run->settings ?? '{}', true)['tick_limit'] ?? 100;
+                if ($run->current_tick > $tickLimit) {
+                    $issues[] = ['ERROR', "current_tick={$run->current_tick} exceeds tick_limit={$tickLimit} — run should have ended"];
+                } else {
+                    $issues[] = ['OK', "current_tick={$run->current_tick} / {$tickLimit}"];
+                }
+            }
+
+            // --- Output ---
+            $this->line('');
+            $this->line("<options=bold>{$name}</> (id={$id})");
+            foreach ($issues as [$level, $msg]) {
+                match ($level) {
+                    'OK'    => $this->line("  <fg=green>✓</> {$msg}"),
+                    'WARN'  => $this->warn("  ⚠ {$msg}"),
+                    'ERROR' => $this->error("  ✗ {$msg}"),
+                    default => $this->line("  {$msg}"),
+                };
+            }
+
+            if (collect($issues)->contains(fn($i) => $i[0] === 'ERROR')) {
+                $hasErrors = true;
+            }
+        }
+
+        $this->line('');
+        return $hasErrors ? 1 : 0;
+    }
+}

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -136,7 +136,7 @@ class ColonyController extends BaseController
 
         $buildings = DB::table('buildings')
             ->select('id', 'name', 'ap_for_levelup', 'max_status_points', 'max_level',
-                     'required_building_id', 'required_building_level', 'is_instanced')
+                     'required_building_id', 'required_building_level', 'is_instanced', 'supply_cost')
             ->get()
             ->filter(function ($b) use ($ccLevel, $placedCounts) {
                 if ($b->id === 25) return false;  // CC — already exists
@@ -160,6 +160,7 @@ class ColonyController extends BaseController
                 'max_level'         => $b->max_level,
                 'max_status_points' => $b->max_status_points,
                 'is_instanced'      => (bool) $b->is_instanced,
+                'supply_cost'       => (int) $b->supply_cost,
             ])
             ->values();
 

--- a/app/Http/Controllers/SolController.php
+++ b/app/Http/Controllers/SolController.php
@@ -3,34 +3,54 @@
 namespace App\Http\Controllers;
 
 use App\Models\Run;
+use App\Services\Techtree\PersonellService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
 
 /**
  * SolController — handles player-triggered Sol (tick) advancement.
- *
- * In singleplayer mode the player decides when to advance time.
- * Each call to next() increments current_tick on the active run and
- * immediately processes that tick via the game:tick Artisan command.
- *
- * Atomicity note: increment() issues a single SQL UPDATE ... SET current_tick = current_tick + 1
- * which is safe for SQLite singleplayer. No job queue or event system needed here.
  */
 class SolController extends Controller
 {
+    public function __construct(
+        private readonly PersonellService $personellService,
+    ) {}
+
     public function next(Request $request): RedirectResponse
     {
         $run = Run::where('user_id', auth()->id())
             ->where('status', 'active')
             ->firstOrFail();
 
-        // Increment first (atomic), then process so the tick command sees the updated value.
         $run->increment('current_tick');
         $run->refresh();
 
         Artisan::call('game:tick', ['--run' => $run->id]);
 
         return redirect()->back()->with('sol_advanced', $run->current_tick);
+    }
+
+    /**
+     * Return remaining unspent AP for the current player's colony.
+     * Used by the Sol-button JS component to decide whether to show a confirm dialog.
+     */
+    public function remainingAp(): JsonResponse
+    {
+        $colonyId = session('activeIds.colonyId', 1);
+
+        $construction = $this->personellService->getConstructionPoints($colonyId);
+        $research     = $this->personellService->getAvailableActionPoints('research', $colonyId);
+        $navigation   = $this->personellService->getAvailableActionPoints('navigation', $colonyId);
+
+        return response()->json([
+            'construction' => $construction,
+            'research'     => $research,
+            'navigation'   => $navigation,
+            'total'        => $construction + $research + $navigation,
+        ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -119,12 +119,15 @@ class AppServiceProvider extends ServiceProvider
 
                 // Feature 3: Nexus debt from the active run — shown in the navbar.
                 // nexus_debt_max = 12000 Cr (Nexus cancels the concession above this cap, GDD §15).
+                // Only runs with started_at set count as "in-run" — pending runs do not show run UI.
                 $activeRun = \App\Models\Run::where('user_id', Auth::id())
                     ->where('status', 'active')
+                    ->whereNotNull('started_at')
                     ->first(['nexus_debt']);
 
                 $view->with('nexusDebt', $activeRun?->nexus_debt);
                 $view->with('nexusDebtMax', 12000);
+                $view->with('inActiveRun', $activeRun !== null);
             }
         });
     }

--- a/app/Services/OnboardingHintService.php
+++ b/app/Services/OnboardingHintService.php
@@ -125,7 +125,7 @@ class OnboardingHintService
                 'key'        => 'hint_4',
                 'active'     => $this->checkHint4($colonyId, $currentTick),
                 'text_key'   => 'colony.onboarding_hint_4',
-                'target_url' => '/techtree/research',
+                'target_url' => '/techtree',
             ],
             [
                 'rank'       => 5,

--- a/data/sql/testdata.sqlite.sql
+++ b/data/sql/testdata.sqlite.sql
@@ -204,17 +204,9 @@ INSERT INTO "innn_message_types" VALUES(10,'subject_pact',39,1);
 INSERT INTO "innn_message_types" VALUES(11,'subject_peace_treaty',25,1);
 INSERT INTO "innn_message_types" VALUES(12,'subject_declaration_of_war',-49,1);
 INSERT INTO "innn_message_types" VALUES(13,'subject_nap',10,1);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,25,3,16,1);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,27,1,11,10);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,28,2,10,0);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,30,3,10,10);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,31,2,11,1);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,32,1,10,1);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,41,1,10,4);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,44,1,15,0);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,46,1,9,1);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,50,1,9,9);
-INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,52,1,10,0);
+INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,25,1,20,0);
+INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,27,1,20,0);
+INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(1,28,1,20,2);
 INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(2,25,5,10,1);
 INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(2,27,1,10,1);
 INSERT INTO "colony_buildings" (colony_id,building_id,level,status_points,ap_spend) VALUES(2,28,4,10,1);
@@ -245,13 +237,10 @@ INSERT INTO "colony_researches" VALUES(2,76,19,10,1);
 INSERT INTO "colony_researches" VALUES(2,79,19,10,1);
 INSERT INTO "colony_researches" VALUES(2,80,19,10,1);
 INSERT INTO "colony_researches" VALUES(2,81,19,10,1);
-INSERT INTO "colony_resources" VALUES(3,1,200);
+INSERT INTO "colony_resources" VALUES(3,1,250);
 INSERT INTO "colony_resources" VALUES(4,1,0);
 INSERT INTO "colony_resources" VALUES(5,1,0);
-INSERT INTO "colony_resources" VALUES(6,1,9400);
-INSERT INTO "colony_resources" VALUES(8,1,9400);
-INSERT INTO "colony_resources" VALUES(10,1,9400);
-INSERT INTO "colony_resources" VALUES(12,1,9500);
+INSERT INTO "colony_resources" VALUES(12,1,0);
 INSERT INTO "colony_ships" VALUES(1,29,0,10,1);
 INSERT INTO "colony_ships" VALUES(1,37,9,10,1);
 INSERT INTO "colony_ships" VALUES(1,49,12,10,1);
@@ -271,22 +260,7 @@ INSERT INTO "colony_personell" VALUES(2,35,19,10);
 INSERT INTO "colony_personell" VALUES(2,36,19,10);
 INSERT INTO "colony_personell" VALUES(2,89,19,10);
 INSERT INTO "colony_personell" VALUES(2,92,19,10);
--- advisors intentionally empty: CC level 1 = 1 slot, start clean for onboarding flow
-INSERT INTO "locked_actionpoints" VALUES(15930,'colony',1,35,22);
-INSERT INTO "locked_actionpoints" VALUES(15930,'colony',1,36,3);
-INSERT INTO "locked_actionpoints" VALUES(15934,'colony',1,35,20);
-INSERT INTO "locked_actionpoints" VALUES(15935,'colony',1,35,1);
-INSERT INTO "locked_actionpoints" VALUES(15942,'colony',1,35,26);
-INSERT INTO "locked_actionpoints" VALUES(15947,'colony',1,35,8);
-INSERT INTO "locked_actionpoints" VALUES(15962,'colony',1,35,3);
-INSERT INTO "locked_actionpoints" VALUES(15983,'colony',1,35,5);
-INSERT INTO "locked_actionpoints" VALUES(15990,'colony',1,35,3);
-INSERT INTO "locked_actionpoints" VALUES(15990,'colony',1,36,5);
-INSERT INTO "locked_actionpoints" VALUES(15991,'colony',1,36,1);
-INSERT INTO "locked_actionpoints" VALUES(15997,'colony',1,35,37);
-INSERT INTO "locked_actionpoints" VALUES(15997,'colony',1,36,0);
-INSERT INTO "locked_actionpoints" VALUES(15998,'colony',1,35,1);
-INSERT INTO "locked_actionpoints" VALUES(16005,'colony',1,35,9);
+INSERT INTO "advisors" (user_id,colony_id,personell_id,rank,active_ticks) VALUES(3,1,35,1,0);
 INSERT INTO "fleets" (id,fleet,user_id,artefact,x,y) VALUES(8,'B. Flotte 1',18,NULL,6828,3016);
 INSERT INTO "fleets" (id,fleet,user_id,artefact,x,y) VALUES(9,'B. Flotte 2',18,NULL,6818,3006);
 INSERT INTO "fleets" (id,fleet,user_id,artefact,x,y) VALUES(10,'Test Flotte 1',3,NULL,6828,3016);
@@ -409,7 +383,7 @@ INSERT INTO "trade_resources" VALUES(2,0,6,45,45,0);
 INSERT INTO "trade_resources" VALUES(1,0,10,4,3,0);
 INSERT INTO "trade_resources" VALUES(1,0,8,100,50,0);
 
-INSERT INTO "user_resources" VALUES(3,49615,1938);
+INSERT INTO "user_resources" VALUES(3,2700,18);
 
 INSERT OR REPLACE INTO "user_preferences" VALUES(1,0,1,NULL,NULL,NULL,NULL);
 INSERT OR REPLACE INTO "user_preferences" VALUES(2,1,1,NULL,NULL,NULL,NULL);
@@ -457,6 +431,6 @@ INSERT INTO "bar_offers" (colony_id,give_resource_id,give_amount,get_resource_id
 INSERT INTO "bar_offers" (colony_id,give_resource_id,give_amount,get_resource_id,get_amount,expires_tick,is_accepted,created_at,updated_at) VALUES(1,3,20,5,30,9999999,0,'2026-05-14 00:00:00','2026-05-14 00:00:00');
 
 -- Active run for Bart (user_id=3) on Springfield (colony_id=1).
-INSERT OR REPLACE INTO "runs" (id,user_id,colony_id,current_tick,status,started_at,ended_at,settings,phase,fail_reason,nexus_debt,phase2_start_tick,created_at,updated_at) VALUES(1,3,1,1938,'active','2026-05-23 00:00:00',NULL,'{"tick_limit":100,"bypass":{"ap_checks":false,"resource_costs":false,"supply_checks":false},"supply_cap_max":200,"max_players":1}',1,NULL,3000,NULL,'2026-05-23 00:00:00','2026-05-23 00:00:00');
+INSERT OR REPLACE INTO "runs" (id,user_id,colony_id,current_tick,status,started_at,ended_at,settings,phase,fail_reason,nexus_debt,phase2_start_tick,created_at,updated_at) VALUES(1,3,1,5,'active','2026-05-23 00:00:00',NULL,'{"tick_limit":100,"bypass":{"ap_checks":false,"resource_costs":false,"supply_checks":false},"supply_cap_max":200,"max_players":1}',1,NULL,3000,NULL,'2026-05-23 00:00:00','2026-05-23 00:00:00');
 -- Active run for Homer (user_id=0) on Shelbyville (colony_id=2).
-INSERT OR REPLACE INTO "runs" (id,user_id,colony_id,current_tick,status,started_at,ended_at,settings,phase,fail_reason,nexus_debt,phase2_start_tick,created_at,updated_at) VALUES(2,0,2,1938,'active','2026-05-23 00:00:00',NULL,'{"tick_limit":100,"bypass":{"ap_checks":false,"resource_costs":false,"supply_checks":false},"supply_cap_max":200,"max_players":1}',1,NULL,3000,NULL,'2026-05-23 00:00:00','2026-05-23 00:00:00');
+INSERT OR REPLACE INTO "runs" (id,user_id,colony_id,current_tick,status,started_at,ended_at,settings,phase,fail_reason,nexus_debt,phase2_start_tick,created_at,updated_at) VALUES(2,0,2,20,'active','2026-05-23 00:00:00',NULL,'{"tick_limit":100,"bypass":{"ap_checks":false,"resource_costs":false,"supply_checks":false},"supply_cap_max":200,"max_players":1}',1,NULL,3000,NULL,'2026-05-23 00:00:00','2026-05-23 00:00:00');

--- a/docs/design-guide.md
+++ b/docs/design-guide.md
@@ -1,0 +1,398 @@
+# Nouron — Design Guide
+
+**Version:** 1.0 (Mai 2026)
+**Verbindlich für:** Alle neuen Screens ab Phase 3b (Alpine.js + PicoCSS). Legacy-Screens (Bootstrap 5) folgen diesem Guide bei der schrittweisen Migration.
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Prinzipien](#1-prinzipien)
+2. [Farbpalette](#2-farbpalette)
+3. [Typografie](#3-typografie)
+4. [Spacing-System](#4-spacing-system)
+5. [Komponenten](#5-komponenten)
+   - 5.1 [Navbar (Haupt-Navigation)](#51-navbar-haupt-navigation)
+   - 5.2 [Resource Bar](#52-resource-bar)
+   - 5.3 [Subnav / Tabs](#53-subnav--tabs)
+   - 5.4 [Cards und Panels](#54-cards-und-panels)
+   - 5.5 [Buttons](#55-buttons)
+   - 5.6 [Resource Pills (res-chip)](#56-resource-pills-res-chip)
+   - 5.7 [Tabellen](#57-tabellen)
+   - 5.8 [Status-Badges und Labels](#58-status-badges-und-labels)
+6. [Screen-Typen](#6-screen-typen)
+   - 6.1 [Lobby](#61-lobby)
+   - 6.2 [In-Run Screens (Standard)](#62-in-run-screens-standard)
+   - 6.3 [Cantina / Bar](#63-cantina--bar)
+7. [Grafik-Assets](#7-grafik-assets)
+8. [Do / Don't Kurzreferenz](#8-do--dont-kurzreferenz)
+
+---
+
+## 1. Prinzipien
+
+Nouron ist ein Browserspiel mit dem Anspruch, elegant und konzentriert zu wirken — nicht überladen, nicht dramatisch dunkel. Die visuelle Sprache soll die Kern-Fantasie unterstützen: eine kleine Kolonie, sorgfältig verwaltet, unter knappen Bedingungen.
+
+**Hell, fokussiert, viel Luft.** Weißraum ist ein aktives Gestaltungsmittel, keine Lücke. Screens sind nicht vollgepackt. Jedes Element rechtfertigt seinen Platz.
+
+**Minimal Boxen.** Cards und Panels nur dort, wo sie semantisch Sinn ergeben — um eine Entität (einen Run, einen Berater, ein Gebäude) zu gruppieren. Kein Boxen-um-alles-Reflex.
+
+**Serif für Identität, System-Sans für Funktion.** Das Nouron-Logo und Haupt-Überschriften tragen die Markenidentität via Libre Baskerville. Alles Funktionale — Navigation, Labels, Buttons, Tabellen — nutzt system-ui. Kein Mix innerhalb einer Ebene.
+
+**Akzentfarbe sparsam.** Nouron-Rot (`#8c2030`) ist eine elegante Markenfarbe, kein Signal-Rot. Sie markiert aktive Zustände und primäre Aktionen — nicht Warnungen, nicht Fehler. Für Warnungen und Fehler gelten eigene semantische Farben.
+
+**Keine Dark-Mode-Defaults.** Neue Screens sind hell by default. `data-theme="light"` explizit setzen wenn PicoCSS geladen wird, damit Systemeinstellungen nicht durchschlagen.
+
+---
+
+## 2. Farbpalette
+
+| Token | Wert | Verwendung |
+|---|---|---|
+| `--color-bg` | `#ffffff` | Seiten-Hintergrund |
+| `--color-surface` | `#f7f7f5` | Subtile Sektionsflächen, alternating rows |
+| `--color-text-primary` | `#1a1a1e` | Fliesstext, Headings, Labels |
+| `--color-text-secondary` | `#6b6b7a` | Metadaten, Hints, Timestamps, Muted-Text |
+| `--color-accent` | `#8c2030` | Primär-Buttons, aktive Nav-Links, Marken-Elemente |
+| `--color-border` | `#e8e8ec` | Trennlinien, Card-Borders, Divider |
+| `--color-navbar-bg` | `#ffffff` | Navbar-Hintergrund |
+| `--color-navbar-border` | `#e8e8ec` | Navbar border-bottom |
+
+### Semantische Zustände
+
+Semantische Farben (Erfolg, Fehler, Warnung) sind von der Markenfarbe getrennt. Konkrete Werte werden bei der Implementierung aus dem PicoCSS-Custom-Property-System bezogen (`--pico-ins-color`, `--pico-del-color`), nicht als Hex-Konstanten hardcodiert.
+
+---
+
+## 3. Typografie
+
+### Schriftarten
+
+**Libre Baskerville** — ausschliesslich für H1 und H2, Logo-Text, Seiten-Titel.
+
+```css
+@import url("https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400&display=swap");
+```
+
+**system-ui** — für alles andere: H3, H4, Body, Labels, Buttons, Navigation.
+
+```css
+font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+```
+
+### Hierarchie
+
+| Ebene | Schrift | Weight | Transform | Letter-Spacing | Grösse |
+|---|---|---|---|---|---|
+| H1 (Seiten-Titel) | Libre Baskerville | 400 | uppercase | 0.45em | 2rem |
+| H2 (Abschnitts-Titel) | Libre Baskerville | 400 | uppercase | 0.45em | 1.4rem |
+| H3 (Card-Titel, Gruppen) | system-ui | 600 | keine | keine | 1.1rem |
+| H4 (Sub-Gruppen) | system-ui | 600 | keine | keine | 1rem |
+| Body | system-ui | 400 | keine | keine | 1rem |
+| Meta / Muted | system-ui | 400 | keine | keine | 0.85rem |
+| Button-Text | system-ui | 600 | keine | 0.02em | 0.9rem |
+| Nav-Link | system-ui | 400 | keine | keine | 0.875rem |
+
+H3 und H4 sind **nicht** uppercase. Die Serif-/Uppercase-Behandlung bleibt H1 und H2 vorbehalten.
+
+### Farben im Text
+
+- Primärer Text: `#1a1a1e`
+- Muted / sekundärer Text: `#6b6b7a`
+- Aktiver Link / aktiver Nav-State: `#8c2030`
+- Regulärer Link (Inline-Text): `#1a1a1e`, underline on hover
+
+---
+
+## 4. Spacing-System
+
+Basis: 8 px. Alle Abstände sind Vielfache dieser Basis.
+
+| Token | Wert | Typische Verwendung |
+|---|---|---|
+| `xs` | 4 px | Intra-Element-Gaps (Icon zu Label) |
+| `sm` | 8 px | Interne Padding, Gap zwischen Chips |
+| `md` | 16 px | Standard-Padding, Abstand zwischen Elementen |
+| `lg` | 32 px | Abstand zwischen Sektionen |
+| `xl` | 64 px | Grosse vertikale Abstände, Hero-Bereiche |
+| `2xl` | 96 px | Sehr grosser Whitespace, nur auf grossen Seiten |
+
+In CSS: `rem`-Werte auf Basis 1rem = 16px. Konkret: `0.25rem` (4px), `0.5rem` (8px), `1rem` (16px), `2rem` (32px), `4rem` (64px), `6rem` (96px).
+
+Padding in Cards und Panels: `1.5rem` innen.
+
+---
+
+## 5. Komponenten
+
+### 5.1 Navbar (Haupt-Navigation)
+
+Die Navbar ist immer hell.
+
+**Struktur:**
+- Hintergrund: `#ffffff`
+- Border-bottom: `1px solid #e8e8ec`
+- Position: `fixed-top` (über Spielinhalt)
+
+**Logo / Markenname "Nouron":**
+- Schrift: Libre Baskerville
+- Transform: uppercase
+- Letter-Spacing: 0.45em
+- Farbe: `#1a1a1e`
+- Kein Icon, nur Text
+
+**Nav-Links:**
+- Schrift: system-ui, 0.875rem
+- Farbe: `#4a4a58`
+- Hover: `#1a1a1e`
+- Aktiver Link: `#8c2030`, optional thin underline (kein Hintergrund-Highlight)
+
+**Rechts in der Navbar (nur in-run Screens, nicht Lobby):**
+- Nexus-Kredit Badge — zeigt aktuellen Schuldenstand
+- Sol-Button — löst den nächsten Sol aus
+
+**Dropdown (User-Menü):**
+- Schrift: system-ui
+- Hintergrund: `#ffffff`
+- Border: `1px solid #e8e8ec`
+- Items: reguläre Schriftgrösse, `#1a1a1e`
+
+Die dunkle Bootstrap-Navbar (`navbar-dark bg-dark`) ist das Erbe des Legacy-Layouts und wird im Rahmen der Migration ersetzt. Neue Layouts verwenden ausschliesslich die helle Variante.
+
+---
+
+### 5.2 Resource Bar
+
+Die Resource Bar erscheint unterhalb der Navbar als eigene horizontale Leiste. Sie ist **nicht** Teil der Navbar.
+
+- Nicht auf der Lobby sichtbar
+- Nicht auf Screens ohne aktiven Run sichtbar
+- Enthält Resource Pills (siehe 5.6)
+- Hintergrund: `#ffffff` oder `#f7f7f5` (subtil abgesetzt)
+- Border-bottom: `1px solid #e8e8ec`
+
+---
+
+### 5.3 Subnav / Tabs
+
+Modul-spezifische Tab-Navigation direkt unterhalb der Resource Bar.
+
+- Hintergrund: `#ffffff`
+- Border-bottom: `1px solid #e8e8ec`
+- Tabs sind Textlinks (system-ui, 0.875rem)
+- Aktiver Tab: `#8c2030`, Border-bottom-Highlight `2px solid #8c2030`
+- Inaktive Tabs: `#6b6b7a`, Hover `#1a1a1e`
+- Kein dunkler Subnav-Hintergrund
+
+Gilt für: Colony, Berater, Handel, Nachrichten, Cantina.
+
+---
+
+### 5.4 Cards und Panels
+
+Cards werden nur eingesetzt wenn eine klar abgegrenzte Entität dargestellt wird (z.B. ein Run in der Lobby, ein Berater, ein Gebäude).
+
+**Grundregeln:**
+- Hintergrund: `#ffffff`
+- Border: `1px solid #e8e8ec` **oder** Box-Shadow `0 1px 4px rgba(0,0,0,0.06)`  — eines davon, nicht beides zusammen
+- Border-Radius: `4px` (zurückhaltend)
+- Padding innen: `1.5rem`
+- Kein dunkler Card-Hintergrund auf hellem Screen
+- Kein Gradient, keine dekorativen Hintergründe
+
+**Card-Header:**
+- Enthält Titel (H3) und optional ein Status-Badge
+- Kein eigener Hintergrund innerhalb der Card
+- Kein Separator-Border zwischen Header und Body (ausser wenn semantisch begründet)
+
+**Card-Footer:**
+- Enthält Aktionen (Buttons)
+- Kein eigener Hintergrund
+- Margin-top `1rem` zum Card-Body
+
+**Card-Grid:**
+- `display: grid`, `grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr))`
+- Gap: `1rem`
+
+---
+
+### 5.5 Buttons
+
+Alle Buttons verwenden system-ui, font-weight 600, font-size 0.9rem, letter-spacing 0.02em, border-radius 4px.
+
+**Primary:**
+- Hintergrund: `#8c2030`
+- Text: `#ffffff`
+- Border: keine
+- Hover: etwas dunkler (z.B. `#731a27`), kein Outline
+
+**Secondary / Outline:**
+- Hintergrund: transparent
+- Border: `1px solid #1a1a1e`
+- Text: `#1a1a1e`
+- Hover: leichter Hintergrund `#f7f7f5`
+
+**Ghost:**
+- Kein Hintergrund, kein Border
+- Text: `#1a1a1e`
+- Hover: Underline
+
+**Deaktiviert (disabled):**
+- Opacity: 0.45
+- cursor: not-allowed
+- pointer-events: none
+
+**Grösse:** Standard-Buttons ohne übertriebene Padding-Inflation. Keine XL-Hero-Buttons ausser in explizit dafür vorgesehenen leeren Zuständen.
+
+---
+
+### 5.6 Resource Pills (res-chip)
+
+Die Resource Pills sind ein bestehendes, gut funktionierendes Muster — sie werden unverändert behalten.
+
+- Farbige Outline-Pills mit Abkürzung (Sol, Cr, Sup, TR, RG, ...)
+- Jede Ressource hat eine eigene Akzentfarbe (CSS-Klassen per Ressource)
+- Primäre Ressourcen immer sichtbar, sekundäre nur wenn Menge > 0
+- Sol-Chip kommt zuerst, dann Trennlinie, dann Credits / Supply / Trust, dann Trennlinie, dann handelbare Ressourcen
+- Chips sind `inline-flex`, font-size `0.85rem`, padding `xs sm`
+
+---
+
+### 5.7 Tabellen
+
+- Volle Breite, `border-collapse: collapse`
+- `font-size: 0.9rem`
+- Zellen: padding `0.55rem 0.75rem`, `text-align: left`, `vertical-align: middle`
+- Zeilen-Trennlinie: `1px solid #e8e8ec`
+- Letzte Zeile ohne Border-bottom
+- Thead: font-weight 600, font-size 0.8rem, uppercase, letter-spacing 0.04em, Farbe `#6b6b7a`
+- Thead border-bottom: `2px solid #e8e8ec`
+- Hover-Zeile: Hintergrund `#f7f7f5`
+- Numerische Spalten: `text-align: right`, `font-variant-numeric: tabular-nums`
+
+---
+
+### 5.8 Status-Badges und Labels
+
+**Status-Pills** (z.B. Run-Status: abgeschlossen / gescheitert):
+- Inline-Block, padding `0.15em 0.6em`
+- border-radius `0.3em`
+- font-size `0.78rem`, font-weight 600, uppercase, letter-spacing 0.03em
+- Farben: semantisch (`--pico-ins-color` für Erfolg, `--pico-del-color` für Fehler)
+
+**Warn-Badges** (z.B. Bypass-Warnung):
+- Wie Status-Pill, aber Hintergrund immer semantisch Rot
+- Nur für tatsächliche Warnzustände, nicht für Kategorie-Labels
+
+**AP-Chips / Typ-Chips:**
+- Schlichter Stil: leichter Hintergrund `#f7f7f5`, Border `#e8e8ec`
+- font-size `0.85rem`
+- Kein kräftiger Farbhintergrund
+
+---
+
+## 6. Screen-Typen
+
+### 6.1 Lobby
+
+Der Lobby-Screen ist der Einstiegspunkt vor und nach einem Run.
+
+**Layout-Regeln:**
+- Kein Subnav, keine Resource Bar
+- Maximale Breite: `56rem`, zentriert (`margin: 0 auto`)
+- Padding: `2rem` oben, `3rem` unten
+
+**Inhalt:**
+- H1 (Libre Baskerville, uppercase) als Seiten-Titel
+- Untertitel als Muted-Text direkt darunter
+- Sektionen (Aktive Runs, Ausstehende Runs, Abgeschlossene Runs, Highscore) durch H2-Überschriften mit Border-bottom getrennt
+- Run-Cards im Card-Grid
+- Highscore-Tabelle am Ende
+
+**Leerer Zustand:** Zentrierter Text in Muted-Farbe, padding `3rem 1rem`.
+
+---
+
+### 6.2 In-Run Screens (Standard)
+
+Gilt für: Colony, Berater, Techtree, Handel, Nachrichten, Flotte, Galaxis, Systemkarte.
+
+**Schichtung (von oben nach unten):**
+1. Navbar (fixed-top, hell)
+2. Resource Bar (direkt darunter, horizontale Leiste)
+3. Subnav / Tabs (wenn der Screen interne Sektionen hat)
+4. Screen-Content (`container-fluid`, `margin-top: 1rem`)
+
+**Content-Bereich:**
+- Kein eigener Page-Title als H1 nötig wenn der Screen-Name bereits in der Navbar-Navigation aktiv ist
+- H2 für Abschnitte innerhalb des Screens
+- Whitespace zwischen Sektionen: `lg` (32px)
+
+**Flash-Messages (Erfolg / Fehler):**
+- Werden oberhalb des Contents als Alert-Banner eingeblendet
+- Schliessbar, zeitlich begrenzt sichtbar (kein permanentes Element)
+
+---
+
+### 6.3 Cantina / Bar
+
+Die Cantina hat einen eigenen visuellen Charakter: ein Bar-Hintergrundbild als atmosphärisches Element.
+
+**Regeln:**
+- Subnav und Resource Bar wie bei Standard In-Run Screens
+- Hintergrundbild als dekoratives Layer, nicht als Content-Hintergrund
+- Overlay oder Surface-Panel (`#ffffff` oder `rgba(255,255,255,0.92)`) damit Text lesbar bleibt
+- NPC-Charaktere als Platzhalter-Grafiken, klickbar wenn handelbar (Händler-Interaktion)
+- Händler-Auswahl führt zu einem Angebotsbereich (Implementierung ausstehend)
+- Kein dunkles Theme für die Cantina — die Atmosphäre kommt durch das Bild, nicht durch dunkle Flächen
+
+---
+
+## 7. Grafik-Assets
+
+Verbindlich gemäss ADR 0001.
+
+**Stil:** Illustriert/gezeichnet. Kein Pixel-Art. Keine fotorealistischen Renderings.
+
+**Format:** WebP mit transparentem Hintergrund (Alpha-Kanal). Kein PNG, kein SVG für Illustrationen.
+
+**Auflösung:** Immer 2× Zielgrösse (HiDPI-ready).
+
+| Asset-Typ | Zielgrösse | Datei-Liefergrösse |
+|---|---|---|
+| Ressourcen-Icons | 24×24 px | 48×48 px |
+| Gebäude-Icons (Sidebar) | 32×32 px | 64×64 px |
+| Gebäude/Schiff (Tile) | 48×48 px | 96×96 px |
+| Berater-Portraits | 128×128 px | 256×256 px |
+
+**CSS-Integration:**
+- Container-Grössen in `em` oder `rem`, nie fixe `px`
+- Bilder: `width: 100%; height: 100%; object-fit: contain;`
+
+**SVG:** Nur für UI-Struktur (Hex-Grid, strukturelle Icons, Platzhalter-Silhouetten). Nicht für illustrierte Spielgrafiken.
+
+**Ablage:**
+```
+public/img/icons/       -- Ressourcen-Icons, UI-Icons
+public/img/buildings/   -- Gebäude-Icons
+public/img/ships/       -- Schiffs-Icons
+public/img/advisors/    -- Berater-Portraits
+public/img/tiles/       -- Hex-Tile-Texturen
+```
+
+---
+
+## 8. Do / Don't Kurzreferenz
+
+| Do | Don't |
+|---|---|
+| Weisse/helle Navbar | Dunkle Navbar auf neuen Screens |
+| Libre Baskerville nur für H1/H2 und Logo | Libre Baskerville für Buttons, Labels, Body |
+| Akzentrot für aktive States und Primary-Buttons | Akzentrot für Warnungen oder Fehler |
+| Whitespace aktiv einsetzen | Jeden Pixel mit Inhalt füllen |
+| Cards nur für abgegrenzte Entitäten | Cards als generelles Layout-Werkzeug |
+| Border oder Shadow — eines davon | Border und Shadow kombinieren |
+| `data-theme="light"` bei PicoCSS setzen | Dark-Mode von Systemeinstellung erben lassen |
+| Container in `em`/`rem` | Fixe `px`-Grössen für Icons und Portraits |
+| WebP 2× für alle Illustrationen | PNG, SVG für illustrierte Spielgrafiken |
+| system-ui für alle funktionalen Texte | Mixed Fonts innerhalb einer Ebene |

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -50,7 +50,7 @@ return [
     'onboarding_hint_1' => 'Kein Wohnhabitat gebaut — Supply-Cap bleibt bei 10.',
     'onboarding_hint_2' => 'Noch kein Baumeister eingestellt — Bau-AP bleibt beim Grundwert.',
     'onboarding_hint_3' => 'Harvester produziert nichts — auf ein Regolith-Tile verlegen.',
-    'onboarding_hint_4' => 'Noch keine Kenntnis erforscht — Analytik-Labor baut AP auf.',
+    'onboarding_hint_4' => 'Noch keine Kenntnis erforscht — im Techtree eine Kenntnis auf Level 1 bringen.',
     'onboarding_hint_5' => 'Vertrauen sinkt — Zivilgebäude bauen oder reparieren.',
 
     // ── Onboarding — Nexus-Briefing (INNN, event_type = 'onboarding.nexus_briefing') ──
@@ -125,7 +125,7 @@ return [
 
     // ── Sol trigger (navbar button) ───────────────────────────────────────────
 
-    'next_sol_button' => 'Nächsten Sol starten',
+    'next_sol_button' => 'Sol beenden',
 
     // ── Nexus-Schulden-Anzeige (Feature 3) ───────────────────────────────────
 

--- a/lang/de/resources.php
+++ b/lang/de/resources.php
@@ -1,10 +1,42 @@
 <?php
 
 return [
+    // Resource names (used in tooltips)
     'res_credits'    => 'Credits',
     'res_supply'     => 'Versorgung',
     'res_regolith'   => 'Regolith',
     'res_werkstoffe' => 'Werkstoffe',
     'res_organika'   => 'Organika',
-    'res_moral'      => 'Moral',
+    'res_moral'      => 'Vertrauen',
+
+    // Chip popup descriptions
+    'popup_sol_title' => 'Sol',
+    'popup_sol_desc'  => 'Aktueller Sol im Run. Jeder Sol ist ein Spielzug — du entscheidest wann er endet.',
+
+    'popup_cr_title'  => 'Credits',
+    'popup_cr_desc'   => 'Universelle Währung. Bezahle Berater, Gebäude, Handel und Nexus-Raten.',
+
+    'popup_nx_title'  => 'Nexus-Schuld',
+    'popup_nx_desc'   => 'Offener Kredit beim Nexus. Überschreitest du das Limit, zieht der Nexus die Konzession ein.',
+
+    'popup_sup_title' => 'Supply',
+    'popup_sup_desc'  => 'Versorgungskapazität der Kolonie. Begrenzt Flottengröße und aktive Einheiten.',
+
+    'popup_rg_title'  => 'Regolith',
+    'popup_rg_desc'   => 'Primärer Baustoff — gewonnen durch den Harvester. Basis für alle Gebäude.',
+
+    'popup_w_title'   => 'Werkstoffe',
+    'popup_w_desc'    => 'Veredelte Industriegüter. Nötig für High-Tech-Gebäude und Schiffsbau.',
+
+    'popup_o_title'   => 'Organika',
+    'popup_o_desc'    => 'Biologische Grundstoffe. Benötigt für Forschung, Schiffe und bestimmte Gebäude.',
+
+    'popup_nav_ap_title' => 'Navigations-AP',
+    'popup_nav_ap_desc'  => 'Aktionspunkte für Flottenorders. Generiert durch den Raumfahrer-Berater.',
+
+    'popup_bau_ap_title' => 'Bau-AP',
+    'popup_bau_ap_desc'  => 'Aktionspunkte für Gebäude und Infrastruktur. Generiert durch den Baumeister-Berater.',
+
+    'popup_trust_title' => 'Vertrauen',
+    'popup_trust_desc'  => 'Vertrauenslevel der Koloniebevölkerung. Sinkt bei Bedrohungen, steigt durch stabile Versorgung.',
 ];

--- a/lang/de/techtree.php
+++ b/lang/de/techtree.php
@@ -81,4 +81,8 @@ return [
     'max_level'               => 'Maximalstufe',
     'moving_speed'            => 'Geschwindigkeit',
     'costs and requirements'  => 'Kosten und Voraussetzungen',
+
+    // ── AP-Hinweise (wenn keine AP verfügbar) ─────────────────────────────────
+    'hint_no_research_ap'     => 'Kein Forschungs-AP verfügbar — Analytiker-Berater einstellen.',
+    'hint_no_construction_ap' => 'Kein Bau-AP verfügbar — Baumeister-Berater einstellen.',
 ];

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -1,4 +1,7 @@
 /* Colony view — helles UI: Weiß 60%, Anthrazit 30%, Rot 10% */
+
+@import url("resources.css");
+
 :root {
     --color-anthracite: #333;
     --color-accent:     #c0392b;
@@ -35,9 +38,8 @@ body {
     position: sticky;
     top: 0;
     z-index: 100;
-    background: var(--color-anthracite);
-    color: #fff;
-    border-bottom: 2px solid var(--color-accent);
+    background: #ffffff;
+    padding: 0;
 }
 
 /* Compact nav: override PicoCSS default padding/min-height on the <nav> element */
@@ -46,7 +48,7 @@ body {
     margin: 0;
     background: transparent;
     min-height: unset;
-    height: 44px;
+    height: 60px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -58,8 +60,8 @@ body {
     flex-direction: row;
     align-items: center;
     margin: 0;
-    padding: 0;
-    gap: 0.25rem;
+    padding: 10px;
+    gap: 1rem;
     list-style: none;
 }
 
@@ -71,143 +73,184 @@ body {
 /* Nav links: slightly smaller text, no PicoCSS vertical padding */
 .colony-header nav a {
     font-size: 0.85rem;
-    color: rgba(255,255,255,0.85);
+    color: #4a4a58;
     text-decoration: none;
-    padding: 0 0.5rem;
-    line-height: 44px;    /* vertically centred within the nav bar */
+    padding: 10px;
+    line-height: 40px;
     display: inline-block;
 }
 
-/* Brand link: slightly larger + bold so it stands out from regular nav items */
-.colony-header nav strong a {
-    font-size: 1rem;
-    font-weight: 700;
-    color: #fff;
-    letter-spacing: 0.02em;
-    padding: 0 0.75rem 0 0;
+.colony-header nav a:hover {
+    color: var(--color-text-primary, #1a1a1e);
+    background: rgba(0,0,0,0.04);
+    border-radius: 6px;
+    text-decoration: none;
 }
 
-.colony-header nav a:hover {
-    color: #fff;
-    background: rgba(255,255,255,0.10);
-    border-radius: 6px;
+/* Colony logo — Libre Baskerville wordmark */
+.colony-logo {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-weight: 400;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: var(--color-text-primary, #1a1a1e) !important;
+    font-size: 0.9rem;
+    text-decoration: none;
+    padding: 0 0.75rem 0 0;
+    line-height: 40px;
+    display: inline-block;
+}
+
+.colony-logo:hover {
+    color: var(--color-accent, #8c2030) !important;
+    background: none;
+    text-decoration: none;
+}
+
+/* Active nav link */
+nav a.active,
+nav a[aria-current] {
+    color: var(--color-accent, #8c2030) !important;
+    font-weight: 600;
 }
 
 .colony-header nav a.active {
-    color: #fff;
-    font-weight: 600;
-    background: rgba(255,255,255,0.18);
+    background: rgba(140,32,48,0.06);
     border-radius: 6px;
     border-bottom: none;
 }
 
-/* Dropdown summary: match the compact link style, suppress PicoCSS button-like defaults */
-.colony-header details.dropdown > summary {
-    font-size: 0.85rem;
-    color: rgba(255,255,255,0.85);
-    padding: 0 0.5rem;
-    line-height: 44px;
-    margin: 0;
-    /* PicoCSS styles summary as a button variant — undo that */
-    background: none;
-    border: none;
-    box-shadow: none;
+/* User dropdown — full PicoCSS override */
+.colony-user-dropdown > summary {
+    --pico-background-color: transparent !important;
+    --pico-border-color: transparent !important;
+    --pico-color: #4a4a58 !important;
+    background: none !important;
+    border: none !important;
+    box-shadow: none !important;
+    color: #4a4a58 !important;
+    font-size: 0.85rem !important;
+    font-weight: 400 !important;
+    padding: 0 0.5rem !important;
+    margin: 0 !important;
+    line-height: 40px !important;
+    cursor: pointer;
+    list-style: none;
 }
-
-.colony-header details.dropdown > summary:hover {
-    color: #fff;
+.colony-user-dropdown > summary:hover {
+    color: var(--color-text-primary, #1a1a1e) !important;
+    background: none !important;
 }
-
-/* Dropdown menu that opens below the summary */
-.colony-header details.dropdown > ul {
-    background: var(--color-anthracite);
-    border: 1px solid rgba(255,255,255,0.15);
-    border-radius: 4px;
+/* Remove all arrow indicators from PicoCSS details/summary */
+.colony-user-dropdown > summary::marker,
+.colony-user-dropdown > summary::-webkit-details-marker,
+.colony-user-dropdown > summary::before,
+.colony-user-dropdown > summary::after {
+    display: none !important;
+    content: none !important;
 }
-
-.colony-header details.dropdown > ul a,
-.colony-header details.dropdown > ul button {
-    font-size: 0.85rem;
-    color: rgba(255,255,255,0.85);
+.colony-user-dropdown > ul {
+    position: absolute !important;
+    right: 0.5rem !important;
+    left: auto !important;
+    top: 44px !important;
+    min-width: 160px !important;
+    background: #ffffff !important;
+    border: 1px solid var(--color-border, #e8e8ec) !important;
+    border-radius: 4px !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.10) !important;
+    padding: 0.25rem 0 !important;
+    margin: 0 !important;
+    list-style: none !important;
+    z-index: 200 !important;
+}
+.colony-user-dropdown > ul li {
+    padding: 0 !important;
+    margin: 0 !important;
+}
+.colony-user-dropdown > ul a,
+.colony-user-dropdown > ul button {
+    --pico-background-color: transparent !important;
+    --pico-border-color: transparent !important;
+    --pico-color: var(--color-text-primary, #1a1a1e) !important;
+    display: block !important;
+    width: 100% !important;
+    padding: 0.45rem 1rem !important;
+    font-size: 0.875rem !important;
+    font-weight: 400 !important;
+    color: var(--color-text-primary, #1a1a1e) !important;
+    background: none !important;
+    border: none !important;
+    box-shadow: none !important;
+    text-align: left !important;
+    text-decoration: none !important;
+    cursor: pointer;
+    margin: 0 !important;
+}
+.colony-user-dropdown > ul a:hover,
+.colony-user-dropdown > ul button:hover {
+    background: var(--color-surface, #f7f7f5) !important;
+    color: var(--color-text-primary, #1a1a1e) !important;
+    text-decoration: none !important;
 }
 
 /* ── Resource bar ────────────────────────────────────────────────────────── */
 
 .colony-resbar {
-    background: #f8f9fa;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid var(--color-border, #e8e8ec);
     padding: 5px 12px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
 }
 
-/* Flexbox wrapper used by the shared resourcebar partial — works without Bootstrap utilities */
-.res-bar-wrap {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    justify-content: center;
-    align-items: center;
+/* ── Sol-Button — override PicoCSS primary button defaults ──────────────── */
+button.btn-sol,
+.colony-header button.btn-sol {
+    --pico-background-color: var(--color-accent, #8c2030);
+    --pico-border-color: var(--color-accent, #8c2030);
+    --pico-color: #ffffff;
+    background: var(--color-accent, #8c2030) !important;
+    border: 1px solid var(--color-accent, #8c2030) !important;
+    color: #ffffff !important;
+    font-size: 0.8rem !important;
+    font-weight: 600 !important;
+    padding: 0.2rem 0.65rem !important;
+    border-radius: 4px !important;
+    box-shadow: none !important;
+    margin: 0 !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 0.3rem !important;
+    white-space: nowrap !important;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+button.btn-sol:hover,
+.colony-header button.btn-sol:hover {
+    opacity: 0.88;
 }
 
-.res-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 8px 2px 6px;
-    border-radius: 20px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    border: 1px solid var(--color-border);
-    background: #fff;
-    color: var(--color-anthracite);
-    white-space: nowrap;
-    cursor: default;
-    transition: filter 0.15s;
+/* Dropdown: plain text items, no PicoCSS button styles */
+.colony-header details.dropdown > ul button,
+.colony-header details.dropdown > ul a {
+    background: none !important;
+    border: none !important;
+    box-shadow: none !important;
+    color: var(--color-text-primary, #1a1a1e) !important;
+    font-size: 0.875rem !important;
+    padding: 0.4rem 0.75rem !important;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    display: block;
+    text-decoration: none;
 }
-.res-chip:hover { filter: brightness(0.94); }
-
-.res-chip--primary {
-    font-size: 0.85rem;
-    padding: 3px 10px 3px 8px;
-    border-width: 2px;
-    border-color: #aaa;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.10);
+.colony-header details.dropdown > ul button:hover,
+.colony-header details.dropdown > ul a:hover {
+    background: var(--color-surface, #f7f7f5) !important;
+    color: var(--color-text-primary, #1a1a1e) !important;
 }
 
-.res-abbr {
-    font-size: 0.65rem;
-    font-weight: 700;
-    opacity: 0.55;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.res-amount { font-variant-numeric: tabular-nums; }
-
-/* Vertical rule separating primary from secondary resources */
-.res-divider {
-    display: inline-block;
-    width: 1px;
-    height: 22px;
-    background: #ccc;
-    border-radius: 1px;
-    margin: 0 2px;
-    align-self: center;
-}
-
-.res-chip--empty {
-    opacity: 0.45;
-    border-style: dashed;
-}
-
-/* Per-resource accent colours */
-.res-Cr  { background: #fff8dc; border-color: #e6c84a; }
-.res-Sup { background: #f0f0f0; border-color: #aaa; }
-.res-Rg  { background: #fdf0e0; border-color: #d4924a; }
-.res-Co  { background: #dceeff; border-color: #5599dd; }
-.res-Or  { background: #e8f5e0; border-color: #5a9a3a; }
-.res-Tr  { background: #fce7f3; border-color: #d166a0; }
-.res-Sol { background: #ede9fe; border-color: #7c65cc; }
+/* Resource chip styles live in resources.css (imported at top of file) */
 
 /* ── Hex page layout ─────────────────────────────────────────────────────── */
 
@@ -244,44 +287,7 @@ body {
     flex-shrink: 0;
 }
 
-.ap-chips {
-    display: flex;
-    gap: 0.4rem;
-    margin-left: auto;
-}
-
-.ap-chip {
-    font-size: 0.72rem;
-    font-weight: 600;
-    padding: 0.2rem 0.55rem;
-    border-radius: 999px;
-    white-space: nowrap;
-}
-
-.ap-chip--nav {
-    background: #dbeafe;
-    color: #1e40af;
-}
-
-.ap-chip--build {
-    background: #dcfce7;
-    color: #166534;
-}
-
-.ap-chip--trust-pos {
-    background: #dcfce7;
-    color: #166534;
-}
-
-.ap-chip--trust-neu {
-    background: #f3f4f6;
-    color: #374151;
-}
-
-.ap-chip--trust-neg {
-    background: #fee2e2;
-    color: #991b1b;
-}
+/* AP chip styles live in resources.css (imported at top of file) */
 
 .hex-canvas-header h2 {
     margin: 0;
@@ -708,6 +714,21 @@ body {
     font-weight: 500;
 }
 
+.building-list-meta {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.building-list-supply {
+    font-size: 0.72rem;
+    color: var(--color-text-secondary, #6b6b7a);
+    background: var(--color-surface, #f7f7f5);
+    border: 1px solid var(--color-border, #e8e8ec);
+    border-radius: 10px;
+    padding: 0 0.4rem;
+}
+
 /* ── Signal chip ─────────────────────────────────────────────────────────── */
 
 .chip--signal {
@@ -1025,4 +1046,99 @@ dialog[x-ref="discoveryDialog"] {
         justify-content: flex-start;
         padding: 1rem;
     }
+}
+
+/* ── Sol Button Overlay & Dialog (colony layout) ───────────────────────── */
+.sol-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(26, 26, 30, 0.55);
+    backdrop-filter: blur(2px);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.sol-overlay--loading { background: rgba(26, 26, 30, 0.75); }
+.sol-dialog {
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    padding: 2rem 2.5rem;
+    max-width: 420px;
+    width: 90%;
+}
+.sol-dialog__title {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-size: 1.1rem;
+    color: var(--color-text-primary, #1a1a1e);
+    margin: 0 0 1rem;
+}
+.sol-dialog__body {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary, #6b6b7a);
+    line-height: 1.5;
+    margin: 0 0 0.5rem;
+}
+.sol-dialog__actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    margin-top: 1.5rem;
+}
+.sol-btn {
+    font-size: 0.875rem;
+    font-weight: 600;
+    padding: 0.45rem 1.1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: opacity 0.15s;
+}
+.sol-btn--ghost {
+    background: transparent;
+    border-color: var(--color-border, #e8e8ec);
+    color: var(--color-text-secondary, #6b6b7a);
+}
+.sol-btn--ghost:hover { opacity: 0.75; }
+.sol-btn--primary {
+    background: var(--color-accent, #8c2030);
+    border-color: var(--color-accent, #8c2030);
+    color: #ffffff;
+}
+.sol-btn--primary:hover { opacity: 0.88; }
+.sol-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    color: #ffffff;
+}
+.sol-loading__text {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-size: 1.1rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    margin: 0;
+    opacity: 0.95;
+}
+.sol-loading__sub {
+    font-size: 0.8rem;
+    opacity: 0.55;
+    margin: 0;
+    letter-spacing: 0.05em;
+}
+.sol-spinner {
+    width: 48px;
+    height: 48px;
+    border: 3px solid rgba(255,255,255,0.2);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    animation: sol-spin 0.9s linear infinite;
+}
+@keyframes sol-spin {
+    to { transform: rotate(360deg); }
 }

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -1017,6 +1017,77 @@ dialog[x-ref="discoveryDialog"] {
 .merchant-toast--info  { background: #14532d; }
 .merchant-toast--error { background: #7f1d1d; }
 
+/* ── Desktop / Mobile nav toggle ────────────────────────────────────────── */
+
+.nav-mobile { display: none; }
+
+@media (max-width: 599px) {
+    .nav-desktop { display: none !important; }
+    .nav-mobile  { display: flex !important; align-items: center; }
+
+    /* Sol-Button on mobile: hidden by default, visible only on colony.view */
+    .sol-btn-wrap { display: none; }
+    body.page-colony .sol-btn-wrap { display: flex; }
+}
+
+/* Hamburger toggle button */
+.nav-burger {
+    --pico-background-color: transparent !important;
+    --pico-border-color: transparent !important;
+    background: none !important;
+    border: none !important;
+    box-shadow: none !important;
+    color: #4a4a58 !important;
+    font-size: 1.3rem !important;
+    padding: 0 0.25rem !important;
+    margin: 0 !important;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    line-height: 1;
+}
+.nav-burger:hover { color: var(--color-text-primary, #1a1a1e) !important; }
+
+/* Flyout menu panel */
+.nav-flyout {
+    position: absolute;
+    top: 48px;
+    right: 0.5rem;
+    min-width: 180px;
+    background: #ffffff;
+    border: 1px solid var(--color-border, #e8e8ec);
+    border-radius: 6px;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.12);
+    z-index: 500;
+    padding: 0.25rem 0;
+    display: flex;
+    flex-direction: column;
+}
+.nav-flyout-item {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.6rem 1rem;
+    font-size: 0.875rem;
+    color: var(--color-text-primary, #1a1a1e);
+    text-decoration: none;
+    background: none;
+    border: none;
+    width: 100%;
+    cursor: pointer;
+    text-align: left;
+    font-family: inherit;
+    line-height: 1.4;
+}
+.nav-flyout-item:hover { background: var(--color-surface, #f7f7f5); text-decoration: none; color: var(--color-text-primary, #1a1a1e); }
+.nav-flyout-item.active { color: var(--color-accent, #8c2030); font-weight: 600; }
+.nav-flyout-item--btn { /* no extra overrides needed — font-family set above */ }
+.nav-flyout-divider {
+    height: 1px;
+    background: var(--color-border, #e8e8ec);
+    margin: 0.25rem 0;
+}
+
 /* ── Responsive ──────────────────────────────────────────────────────────── */
 
 /* Stack grid + sidebar at 900px and below */

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -1,4 +1,47 @@
 /* ── Messages ────────────────────────────────────────────────────────── */
+
+/* Mobile tab header: hidden on desktop, shown below 600px */
+.msg-mobile-header {
+    display: none;
+}
+
+@media (max-width: 599px) {
+    .msg-tabs-bar { display: none; }
+    .msg-mobile-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.5rem 0 0.75rem;
+        margin-bottom: 0.5rem;
+    }
+    .msg-mobile-title {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--color-text-primary, #1a1a1e);
+    }
+}
+
+/* Swipe position dots */
+.swipe-dots {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+.swipe-dot {
+    display: block;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-border, #e8e8ec);
+    border: 1px solid var(--color-border, #e8e8ec);
+    transition: background 0.15s;
+}
+.swipe-dot--active {
+    background: var(--color-accent, #8c2030);
+    border-color: var(--color-accent, #8c2030);
+}
+.swipe-dot:hover { background: var(--color-text-secondary, #6b6b7a); }
+
 .msg-tabs-bar {
     margin-bottom: 1.5rem;
     border-bottom: 1px solid var(--color-border, #e8e8ec);

--- a/public/css/messages.css
+++ b/public/css/messages.css
@@ -1,0 +1,155 @@
+/* ── Messages ────────────────────────────────────────────────────────── */
+.msg-tabs-bar {
+    margin-bottom: 1.5rem;
+    border-bottom: 1px solid var(--color-border, #e8e8ec);
+}
+.msg-tabs {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    flex-wrap: wrap;
+}
+.msg-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.6rem 1rem;
+    font-size: 0.875rem;
+    color: var(--color-text-secondary, #6b6b7a);
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    background: transparent;
+    transition: color 0.15s;
+    white-space: nowrap;
+    cursor: pointer;
+}
+.msg-tab:hover { color: var(--color-text-primary, #1a1a1e); text-decoration: none; }
+.msg-tab--active {
+    color: var(--color-accent, #8c2030);
+    border-bottom-color: var(--color-accent, #8c2030);
+    font-weight: 600;
+}
+.msg-tab--action { margin-left: auto; }
+.msg-tab[disabled] { opacity: 0.4; cursor: not-allowed; }
+
+.msg-list { max-width: 60rem; }
+.msg-empty {
+    color: var(--color-text-secondary, #6b6b7a);
+    font-style: italic;
+    padding: 2rem 0;
+}
+.msg-item { border-bottom: 1px solid var(--color-border, #e8e8ec); }
+.msg-item:first-child { border-top: 1px solid var(--color-border, #e8e8ec); }
+.msg-item--unread .msg-subject { font-weight: 600; }
+
+.msg-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.85rem 0.25rem;
+    cursor: pointer;
+    user-select: none;
+}
+.msg-header:hover { background: var(--color-surface, #f7f7f5); }
+.msg-meta {
+    font-size: 0.78rem;
+    color: var(--color-text-secondary, #6b6b7a);
+    white-space: nowrap;
+    min-width: 4rem;
+}
+.msg-sender { font-size: 0.875rem; white-space: nowrap; min-width: 7rem; }
+.msg-subject { font-size: 0.875rem; flex: 1; color: var(--color-text-primary, #1a1a1e); }
+.msg-unread-dot {
+    width: 7px; height: 7px;
+    border-radius: 50%;
+    background: var(--color-accent, #8c2030);
+    flex-shrink: 0;
+}
+.msg-chevron {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary, #6b6b7a);
+    margin-left: auto;
+    flex-shrink: 0;
+    transition: transform 0.2s;
+}
+.msg-chevron--open { transform: rotate(180deg); }
+
+.msg-body { padding: 0.75rem 0.25rem 1.25rem; }
+.msg-text {
+    font-size: 0.9rem;
+    color: var(--color-text-primary, #1a1a1e);
+    line-height: 1.6;
+    margin-bottom: 0.75rem;
+    white-space: pre-line;
+}
+.msg-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+.msg-action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.25rem 0.65rem;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: var(--color-text-secondary, #6b6b7a);
+    background: transparent;
+    border: 1px solid var(--color-border, #e8e8ec);
+    border-radius: 4px;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background 0.12s, color 0.12s;
+}
+.msg-action-btn:hover { background: var(--color-surface, #f7f7f5); color: var(--color-text-primary, #1a1a1e); text-decoration: none; }
+.msg-action-btn--danger:hover { background: #fdf0f2; border-color: var(--color-accent, #8c2030); color: var(--color-accent, #8c2030); }
+.msg-action-btn--primary {
+    background: var(--color-accent, #8c2030);
+    border-color: var(--color-accent, #8c2030);
+    color: #ffffff;
+    font-weight: 600;
+}
+.msg-action-btn--primary:hover { opacity: 0.88; }
+
+.msg-topic-badge {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 3px;
+    background: var(--color-surface, #f7f7f5);
+    border: 1px solid var(--color-border, #e8e8ec);
+    color: var(--color-text-secondary, #6b6b7a);
+    white-space: nowrap;
+}
+
+.msg-compose { max-width: 38rem; }
+.msg-form { display: flex; flex-direction: column; gap: 1rem; }
+.msg-form-field { display: flex; flex-direction: column; gap: 0.3rem; }
+.msg-form-field label { font-size: 0.85rem; font-weight: 500; color: var(--color-text-secondary, #6b6b7a); }
+.msg-form-field input, .msg-form-field select, .msg-form-field textarea {
+    padding: 0.45rem 0.65rem;
+    font-size: 0.9rem;
+    border: 1px solid var(--color-border, #e8e8ec);
+    border-radius: 4px;
+    background: #ffffff;
+    color: var(--color-text-primary, #1a1a1e);
+    font-family: inherit;
+    transition: border-color 0.15s;
+}
+.msg-form-field input:focus, .msg-form-field select:focus, .msg-form-field textarea:focus {
+    outline: none;
+    border-color: var(--color-accent, #8c2030);
+}
+.msg-form-actions { display: flex; gap: 0.75rem; align-items: center; padding-top: 0.25rem; }
+.msg-error-list {
+    background: #fdf0f2;
+    border: 1px solid var(--color-accent, #8c2030);
+    border-radius: 4px;
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    color: var(--color-accent, #8c2030);
+}
+.msg-error-list ul { margin: 0; padding-left: 1.25rem; }
+.msg-error-list li { margin: 0; }

--- a/public/css/resources.css
+++ b/public/css/resources.css
@@ -1,0 +1,222 @@
+/* ── resources.css ─────────────────────────────────────────────────────────
+ * Shared resource chip, resource bar, AP chip, and popup styles.
+ * Imported by style.css (Bootstrap layout) and colony.css (Alpine/Pico layout).
+ * Do NOT add layout-specific rules here (e.g. fixed positioning, grid areas).
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/* ── Resource bar wrapper ───────────────────────────────────────────────── */
+
+/* Inline centering helper used by the shared resourcebar partial */
+.resource-bar { text-align: center; }
+
+/* Flexbox wrapper used by the shared resourcebar partial */
+.res-bar-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+}
+
+/* ── Base chip ──────────────────────────────────────────────────────────── */
+
+.res-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px 3px 8px;
+    border-radius: 20px;
+    font-size: 0.70rem;
+    font-weight: 700;
+    border: 1px solid rgba(0,0,0,0.12);
+    background: #fff;
+    color: #333;
+    white-space: nowrap;
+    cursor: default;
+    transition: filter 0.15s;
+}
+.res-chip:hover { filter: brightness(0.94); }
+
+/* No size difference between primary and secondary chips */
+.res-chip--primary { }
+
+/* ── Chip internals ─────────────────────────────────────────────────────── */
+
+.res-abbr {
+    font-size: 0.70rem;
+    font-weight: 700;
+    opacity: 0.65;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.res-amount { font-variant-numeric: tabular-nums; }
+
+/* Vertical rule separating primary from secondary resources */
+.res-divider {
+    display: inline-block;
+    width: 1px;
+    height: 22px;
+    background: #ccc;
+    border-radius: 1px;
+    margin: 0 2px;
+    align-self: center;
+}
+
+/* Chip internal separator (legacy) */
+.res-chip-sep {
+    opacity: 0.35;
+    font-weight: 400;
+    padding: 0 1px;
+    font-size: 0.75rem;
+}
+
+/* ── Chip state modifiers ───────────────────────────────────────────────── */
+
+/* Empty / zero resource */
+.res-chip--empty {
+    opacity: 0.45;
+    border-style: dashed;
+}
+
+/* Sol chip: borderless, transparent */
+.res-chip--sol {
+    background: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none !important;
+}
+
+/* Warning / danger state */
+.res-chip--warning { background: #fef9e7 !important; border-color: #d4a017 !important; color: #7a5500; }
+.res-chip--danger  { background: #fdf0f2 !important; border-color: var(--color-accent, #8c2030) !important; color: var(--color-accent, #8c2030); }
+
+/* Chip that triggers a hover popup */
+.res-chip--has-popup { position: relative; }
+
+/* ── Per-resource accent colours ────────────────────────────────────────── */
+
+.res-Cr  { background: #fff8dc; border-color: #e6c84a; }
+.res-Sup { background: #f0f0f0; border-color: #aaa; }
+.res-Rg  { background: #fdf0e0; border-color: #d4924a; }
+.res-Co  { background: #dceeff; border-color: #5599dd; }
+.res-Or  { background: #e8f5e0; border-color: #5a9a3a; }
+.res-Tr  { background: #fce7f3; border-color: #d166a0; }
+.res-Sol { background: #ede9fe; border-color: #7c65cc; }
+
+/* Nexus debt chip (standalone fallback) */
+.res-NX  { background: #fdf4f5; border-color: #c9a0a7; }
+
+/* ── Hover popup ────────────────────────────────────────────────────────── */
+
+.res-popup {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: #ffffff;
+    border: 1px solid var(--color-border, #e8e8ec);
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.10);
+    padding: 0.5rem 0.75rem;
+    min-width: 180px;
+    z-index: 300;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+.res-popup-header {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--color-text-primary, #1a1a1e);
+    letter-spacing: 0.02em;
+    margin-bottom: 0.2rem;
+}
+
+.res-popup-body {
+    font-size: 0.78rem;
+    color: var(--color-text-secondary, #6b6b7a);
+    line-height: 1.4;
+}
+
+.res-popup-extra {
+    margin-top: 0.4rem;
+    padding-top: 0.4rem;
+    border-top: 1px solid var(--color-border, #e8e8ec);
+}
+
+/* Nexus breakdown row inside popup */
+.res-popup-nx-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.78rem;
+    color: var(--color-text-secondary, #6b6b7a);
+}
+.res-popup-nx-row .res-popup-label {
+    font-size: 0.72rem;
+    opacity: 0.7;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+.res-popup-nx-row.res-chip--warning { color: #7a5500; }
+.res-popup-nx-row.res-chip--danger  { color: var(--color-accent, #8c2030); }
+
+/* Legacy generic row (kept for fallback) */
+.res-popup-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    font-size: 0.8rem;
+    color: var(--color-text-primary, #1a1a1e);
+}
+
+.res-popup-label {
+    opacity: 0.6;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+/* ── AP chips (colony canvas header) ────────────────────────────────────── */
+
+.ap-chips {
+    display: flex;
+    gap: 0.4rem;
+    margin-left: auto;
+}
+
+.ap-chip {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+
+.ap-chip--nav {
+    background: #dbeafe;
+    color: #1e40af;
+}
+
+.ap-chip--build {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.ap-chip--trust-pos {
+    background: #dcfce7;
+    color: #166534;
+}
+
+.ap-chip--trust-neu {
+    background: #f3f4f6;
+    color: #374151;
+}
+
+.ap-chip--trust-neg {
+    background: #fee2e2;
+    color: #991b1b;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,8 +1,22 @@
 @CHARSET "UTF-8";
 
+@import url("https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400&display=swap");
+@import url("resources.css");
 @import url("techtree.css");
 @import url("galaxy.css");
 @import url("fleets.css");
+
+/* ── Design Tokens ─────────────────────────────────────────────────────── */
+:root {
+    --color-bg:              #ffffff;
+    --color-surface:         #f7f7f5;
+    --color-text-primary:    #1a1a1e;
+    --color-text-secondary:  #6b6b7a;
+    --color-accent:          #8c2030;
+    --color-border:          #e8e8ec;
+    --color-navbar-bg:       #ffffff;
+    --color-navbar-border:   #e8e8ec;
+}
 
 body {padding-top: 96px;padding-bottom: 40px;}
 hr {border-color: #ccc}
@@ -12,23 +26,106 @@ hr {border-color: #ccc}
 a {color: #000; white-space: nowrap;}
 a:hover {color: #000; text-decoration: underline;}
 
-/* Navbar-Links vom globalen a-Stil ausnehmen */
-.navbar a,
-.navbar .nav-link,
-.navbar .dropdown-item {
-    color: rgba(255,255,255,0.85);
-    white-space: nowrap;
-}
-.navbar a:hover,
-.navbar .nav-link:hover {
-    color: #fff;
-    text-decoration: none;
-}
-.navbar .dropdown-item:hover {
-    color: #000;
+/* ── Navbar (helle Variante) ───────────────────────────────────────────── */
+.navbar-nouron {
+    background: var(--color-navbar-bg) !important;
+    border-bottom: 1px solid var(--color-navbar-border);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
 }
 
-/* Laminas navigation helper: <li><a> ohne nav-link-Klasse */
+.navbar-brand-nouron {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-weight: 400;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: var(--color-text-primary) !important;
+    font-size: 0.9rem;
+    text-decoration: none;
+}
+.navbar-brand-nouron:hover {
+    color: var(--color-accent) !important;
+    text-decoration: none;
+}
+
+.navbar-nouron .nav-link {
+    color: #4a4a58 !important;
+    font-size: 0.875rem;
+    white-space: nowrap;
+}
+.navbar-nouron .nav-link:hover {
+    color: var(--color-text-primary) !important;
+    text-decoration: none;
+}
+.navbar-nouron .nav-link.active {
+    color: var(--color-accent) !important;
+    font-weight: 600;
+}
+.navbar-nouron .dropdown-toggle {
+    color: #4a4a58 !important;
+}
+.navbar-nouron .dropdown-menu {
+    border: 1px solid var(--color-border);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+}
+.navbar-nouron .dropdown-item {
+    color: var(--color-text-primary);
+    font-size: 0.875rem;
+}
+.navbar-nouron .dropdown-item:hover {
+    color: var(--color-text-primary);
+    background: var(--color-surface);
+}
+.navbar-nouron .navbar-toggler {
+    border-color: var(--color-border);
+}
+
+/* Sol-Button (accent red, light navbar) */
+.btn-sol {
+    background: var(--color-accent);
+    border: 1px solid var(--color-accent);
+    color: #ffffff;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: opacity 0.15s;
+}
+.btn-sol:hover { opacity: 0.88; }
+
+/* Nexus credit badge (for light navbar) */
+.nexus-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    color: var(--color-text-primary);
+    white-space: nowrap;
+}
+.nexus-badge--warning {
+    background: #fef9e7;
+    border-color: #d4a017;
+    color: #7a5500;
+}
+.nexus-badge--danger {
+    background: #fdf0f2;
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+/* Subnav light */
+.subnav-light {
+    background: var(--color-navbar-bg);
+    border-bottom: 1px solid var(--color-border);
+}
+
+/* Navbar nav list — legacy Laminas helper: <li><a> without nav-link class */
 .navbar-nav li {
     list-style: none;
 }
@@ -43,83 +140,10 @@ a:hover {color: #000; text-decoration: underline;}
     top: 64px;
     left: 0; right: 0;
     z-index: 1029;
-    background: #f8f9fa;
-    border-bottom: 1px solid #dee2e6;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
     padding: 5px 12px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-}
-.resource-bar { text-align: center; }
-
-.res-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 2px 9px 2px 7px;
-    border-radius: 20px;
-    font-size: 0.78rem;
-    font-weight: 600;
-    border: 1px solid rgba(0,0,0,0.10);
-    cursor: default;
-    white-space: nowrap;
-    background: #fff;
-    color: #333;
-    transition: filter 0.15s;
-}
-.res-chip:hover { filter: brightness(0.94); }
-.res-abbr {
-    font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    opacity: 0.65;
-    text-transform: uppercase;
-}
-.res-amount { font-variant-numeric: tabular-nums; }
-
-/* Primary resource chips — Credits and Supply: larger, bolder, always visible */
-.res-chip--primary {
-    font-size: 0.88rem;
-    padding: 3px 12px 3px 10px;
-    border-width: 2px;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.12);
-}
-.res-chip--primary .res-abbr {
-    font-size: 0.75rem;
-    opacity: 0.80;
-}
-
-/* Vertical rule separating primary from secondary resources */
-.res-divider {
-    display: inline-block;
-    width: 1px;
-    height: 22px;
-    background: #ccc;
-    border-radius: 1px;
-    margin: 0 2px;
-    align-self: center;
-}
-
-/* Per-resource accent colours */
-.res-Cr   { background: #fff8dc; border-color: #e6c84a; }
-.res-Sup  { background: #f0f0f0; border-color: #aaa; }
-.res-W    { background: #dceeff; border-color: #5599dd; }
-.res-E    { background: #efefef; border-color: #999; }
-.res-S    { background: #f5e8d8; border-color: #c87f3a; }
-.res-ENrg { background: #dcfce7; border-color: #3db86e; }
-.res-LNrg { background: #ede9fe; border-color: #7c65cc; }
-.res-ANrg { background: #fefce8; border-color: #ca9b11; }
-.res-Tr   { background: #fce7f3; border-color: #d166a0; }
-.res-Rg   { background: #fdf0e0; border-color: #d4924a; }
-.res-Co   { background: #dceeff; border-color: #5599dd; }
-.res-Or   { background: #e8f5e0; border-color: #5a9a3a; }
-.res-Sol  { background: #ede9fe; border-color: #7c65cc; }
-
-/* Flexbox wrapper used by the shared resourcebar partial — works without Bootstrap utilities as fallback */
-.res-bar-wrap {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    justify-content: center;
-    align-items: center;
 }
 
 body .nav-list > .active > a, .nav-list > .active > a:hover {background-color: #333;}
@@ -240,4 +264,107 @@ a.technology.personell.notexists { border-left-color: #cccccc; }
 }
 .fade-cycling {
     animation: inbox-pulse 2s ease-in-out var(--fade-delay, 0s) infinite;
+}
+
+/* ── Sol Button Overlay & Dialog ───────────────────────────────────────── */
+.sol-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(26, 26, 30, 0.55);
+    backdrop-filter: blur(2px);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.sol-overlay--loading {
+    background: rgba(26, 26, 30, 0.75);
+}
+
+/* Confirm dialog */
+.sol-dialog {
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+    padding: 2rem 2.5rem;
+    max-width: 420px;
+    width: 90%;
+}
+.sol-dialog__title {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    font-size: 1.1rem;
+    color: var(--color-text-primary, #1a1a1e);
+    margin: 0 0 1rem;
+}
+.sol-dialog__body {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary, #6b6b7a);
+    line-height: 1.5;
+    margin: 0 0 0.5rem;
+}
+.sol-dialog__actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    margin-top: 1.5rem;
+}
+.sol-btn {
+    font-size: 0.875rem;
+    font-weight: 600;
+    padding: 0.45rem 1.1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: opacity 0.15s;
+}
+.sol-btn--ghost {
+    background: transparent;
+    border-color: var(--color-border, #e8e8ec);
+    color: var(--color-text-secondary, #6b6b7a);
+}
+.sol-btn--ghost:hover { opacity: 0.75; }
+.sol-btn--primary {
+    background: var(--color-accent, #8c2030);
+    border-color: var(--color-accent, #8c2030);
+    color: #ffffff;
+}
+.sol-btn--primary:hover { opacity: 0.88; }
+
+/* Loading screen */
+.sol-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    color: #ffffff;
+}
+.sol-loading__text {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-size: 1.1rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    margin: 0;
+    opacity: 0.95;
+}
+.sol-loading__sub {
+    font-size: 0.8rem;
+    opacity: 0.55;
+    margin: 0;
+    letter-spacing: 0.05em;
+}
+
+/* Spinner */
+.sol-spinner {
+    width: 48px;
+    height: 48px;
+    border: 3px solid rgba(255,255,255,0.2);
+    border-top-color: #ffffff;
+    border-radius: 50%;
+    animation: sol-spin 0.9s linear infinite;
+}
+@keyframes sol-spin {
+    to { transform: rotate(360deg); }
 }

--- a/public/css/swipe.css
+++ b/public/css/swipe.css
@@ -1,0 +1,83 @@
+/* ── Swipe carousel (mobile) ───────────────────────────────────────────── */
+.swipe-container {
+    overflow: hidden;
+    width: 100%;
+    position: relative;
+    -webkit-overflow-scrolling: touch;
+}
+
+.swipe-track {
+    display: flex;
+    width: 100%;
+    transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+    will-change: transform;
+}
+
+.swipe-panel {
+    flex: 0 0 100%;
+    min-width: 0;
+}
+
+/* Dot indicators */
+.swipe-dots {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    padding: 0.6rem 0 0.25rem;
+}
+
+.swipe-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-border, #e8e8ec);
+    transition: background 0.2s, transform 0.2s;
+    cursor: pointer;
+    border: none;
+    padding: 0;
+}
+
+.swipe-dot--active {
+    background: var(--color-accent, #8c2030);
+    transform: scale(1.25);
+}
+
+/* ── Mobile nav: icon-only ─────────────────────────────────────────────── */
+@media (max-width: 767px) {
+    /* Colony layout nav */
+    .colony-header nav a .nav-label,
+    /* Bootstrap layout nav */
+    .navbar-nouron .nav-link .nav-label {
+        display: none;
+    }
+
+    /* Tighten colony nav spacing on small screens */
+    .colony-header nav > ul {
+        gap: 0;
+    }
+    .colony-header nav a {
+        padding: 0 0.5rem;
+    }
+    /* Tighten Bootstrap nav */
+    .navbar-nouron .nav-link {
+        padding-left: 0.4rem !important;
+        padding-right: 0.4rem !important;
+    }
+}
+
+/* ── Messages swipe hint (mobile only) ────────────────────────────────── */
+@media (max-width: 767px) {
+    .msg-swipe-hint {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.72rem;
+        color: var(--color-text-secondary, #6b6b7a);
+        padding: 0.25rem 0;
+        opacity: 0.6;
+    }
+}
+@media (min-width: 768px) {
+    .msg-swipe-hint { display: none; }
+}

--- a/public/js/swipe.js
+++ b/public/js/swipe.js
@@ -1,0 +1,58 @@
+/**
+ * Swipe utilities for Nouron mobile views.
+ * Two Alpine.js components:
+ *
+ * swipeNav({ prev, next })  — swipe left/right triggers URL navigation
+ * swipeCarousel(count, initial) — in-page panel carousel (future: Berater, Cantina, Hangar)
+ */
+
+function swipeNav({ prev = null, next = null } = {}) {
+    return {
+        _x0: 0,
+        _y0: 0,
+
+        touchStart(e) {
+            this._x0 = e.touches[0].clientX;
+            this._y0 = e.touches[0].clientY;
+        },
+
+        touchEnd(e) {
+            const dx = e.changedTouches[0].clientX - this._x0;
+            const dy = e.changedTouches[0].clientY - this._y0;
+            // Require dominant horizontal movement (>60px, less than 45° vertical)
+            if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx)) return;
+            if (dx < 0 && next) window.location.href = next;
+            if (dx > 0 && prev) window.location.href = prev;
+        }
+    };
+}
+
+function swipeCarousel(count = 1, initial = 0) {
+    return {
+        current: initial,
+        count,
+        _x0: 0,
+        _y0: 0,
+
+        get offset() {
+            return `translateX(-${this.current * 100}%)`;
+        },
+
+        touchStart(e) {
+            this._x0 = e.touches[0].clientX;
+            this._y0 = e.touches[0].clientY;
+        },
+
+        touchEnd(e) {
+            const dx = e.changedTouches[0].clientX - this._x0;
+            const dy = e.changedTouches[0].clientY - this._y0;
+            if (Math.abs(dx) < 60 || Math.abs(dy) > Math.abs(dx)) return;
+            if (dx < 0) this.next();
+            if (dx > 0) this.prev();
+        },
+
+        next() { if (this.current < this.count - 1) this.current++; },
+        prev() { if (this.current > 0) this.current--; },
+        goTo(i) { this.current = Math.max(0, Math.min(this.count - 1, i)); }
+    };
+}

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -51,11 +51,34 @@ window.__colonyViewData = {
                 <h2>{{ $colony->name }}</h2>
                 <small x-text="statusLine()"></small>
                 <div class="ap-chips">
-                    <span class="ap-chip ap-chip--nav" x-text="`Nav ${apNav} AP`"></span>
-                    <span class="ap-chip ap-chip--build" x-text="`Bau ${apConstruction} AP`"></span>
-                    <span class="ap-chip"
+                    <span class="ap-chip ap-chip--nav" x-data="{ open: false }"
+                          @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
+                          style="position:relative;cursor:default">
+                        <span x-text="`Nav ${apNav} AP`"></span>
+                        @include('partials.res-popup', [
+                            'popup_title' => __('resources.popup_nav_ap_title'),
+                            'popup_desc'  => __('resources.popup_nav_ap_desc'),
+                        ])
+                    </span>
+                    <span class="ap-chip ap-chip--build" x-data="{ open: false }"
+                          @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
+                          style="position:relative;cursor:default">
+                        <span x-text="`Bau ${apConstruction} AP`"></span>
+                        @include('partials.res-popup', [
+                            'popup_title' => __('resources.popup_bau_ap_title'),
+                            'popup_desc'  => __('resources.popup_bau_ap_desc'),
+                        ])
+                    </span>
+                    <span class="ap-chip" x-data="{ open: false }"
                           :class="trust >= 20 ? 'ap-chip--trust-pos' : trust < 0 ? 'ap-chip--trust-neg' : 'ap-chip--trust-neu'"
-                          x-text="`Vertrauen ${trust}`"></span>
+                          @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
+                          style="position:relative;cursor:default">
+                        <span x-text="`Vertrauen ${trust}`"></span>
+                        @include('partials.res-popup', [
+                            'popup_title' => __('resources.popup_trust_title'),
+                            'popup_desc'  => __('resources.popup_trust_desc'),
+                        ])
+                    </span>
                 </div>
                 {{-- Merchant notification — links to Bar when merchant is present --}}
                 <a href="{{ route('colony.bar') }}"
@@ -125,7 +148,10 @@ window.__colonyViewData = {
                                     :class="{ 'building-list-item--selected': pendingBuilding?.building_id === b.building_id }"
                                     @click="selectPendingBuilding(b)">
                                     <span class="building-list-name" x-text="b.label"></span>
-                                    <span class="building-list-ap" x-text="`${b.ap_for_levelup} AP`"></span>
+                                    <span class="building-list-meta">
+                                        <span class="building-list-ap" x-text="`${b.ap_for_levelup} AP`"></span>
+                                        <span class="building-list-supply" x-show="b.supply_cost > 0" x-text="`${b.supply_cost} SUP`"></span>
+                                    </span>
                                 </li>
                             </template>
                         </ul>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,15 +14,16 @@
 <body>
 
 @auth
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+<nav class="navbar navbar-expand-lg navbar-nouron fixed-top">
     <div class="container-fluid">
-        <a class="navbar-brand" href="{{ route('galaxy.index') }}">Nouron</a>
+        <a class="navbar-brand navbar-brand-nouron" href="{{ route('galaxy.index') }}">Nouron</a>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarMain"
                 aria-controls="navbarMain" aria-expanded="false" aria-label="Navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarMain">
             <ul class="navbar-nav me-auto">
+                @if(($inActiveRun ?? false) && !request()->routeIs('lobby*'))
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('galaxy.*')) active @endif"
                        href="{{ route('galaxy.index') }}"><i class="bi bi-globe2"></i> Galaxis</a>
@@ -55,40 +56,15 @@
                     <a class="nav-link @if(request()->routeIs('messages.*')) active @endif"
                        href="{{ route('messages.inbox') }}"><i class="bi bi-envelope"></i> Nachrichten</a>
                 </li>
+                @endif
             </ul>
             <ul class="navbar-nav ms-auto">
                 @auth
-                {{-- Feature 3: Nexus debt badge — only shown when an active run exists. --}}
-                @if(isset($nexusDebt) && $nexusDebt !== null)
-                    @php
-                        // Colour thresholds: normal < 80%, warning >= 80%, danger >= 95%.
-                        $nexusDebtPct = $nexusDebtMax > 0 ? ($nexusDebt / $nexusDebtMax) * 100 : 0;
-                        $nexusBadgeClass = match(true) {
-                            $nexusDebtPct >= 95 => 'bg-danger text-white',
-                            $nexusDebtPct >= 80 => 'bg-warning text-dark',
-                            default             => 'bg-secondary text-white',
-                        };
-                    @endphp
-                    <li class="nav-item d-flex align-items-center px-2">
-                        <span
-                            class="badge {{ $nexusBadgeClass }}"
-                            title="{{ __('colony.nexus_debt_label') }}"
-                        >
-                            <i class="bi bi-bank"></i>
-                            {{ __('colony.nexus_debt_label') }}:
-                            {{ number_format($nexusDebt) }} / {{ number_format($nexusDebtMax) }} Cr
-                        </span>
-                    </li>
-                @endif
-                <li class="nav-item">
-                    <form method="POST" action="{{ route('sol.next') }}">
-                        @csrf
-                        <button type="submit" class="btn btn-sm btn-outline-light"
-                                onclick="this.disabled=true; this.form.submit();">
-                            <i class="bi bi-skip-forward-fill"></i> {{ __('colony.next_sol_button') }}
-                        </button>
-                    </form>
+                @if(($inActiveRun ?? false) && !request()->routeIs('lobby*'))
+                <li class="nav-item d-flex align-items-center">
+                    @include('partials.sol-button')
                 </li>
+                @endif
                 @endauth
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" data-bs-toggle="dropdown">
@@ -111,13 +87,15 @@
     </div>
 </nav>
 
-{{-- Resource bar --}}
-@if(!empty($resourceBarPossessions))
+{{-- Resource bar — hidden on lobby (no active run context needed there) --}}
+@if(!empty($resourceBarPossessions) && !request()->routeIs('lobby*'))
 <div id="resourcebar-container">
     @include('resources.resourcebar', [
-        'possessions' => $resourceBarPossessions,
-        'currentSol'  => $currentSol ?? null,
-        'solLimit'    => $solLimit ?? 100,
+        'possessions'  => $resourceBarPossessions,
+        'currentSol'   => $currentSol ?? null,
+        'solLimit'     => $solLimit ?? 100,
+        'nexusDebt'    => ($inActiveRun ?? false) ? ($nexusDebt ?? null) : null,
+        'nexusDebtMax' => $nexusDebtMax ?? 12000,
     ])
 </div>
 @endif
@@ -126,7 +104,7 @@
 
 {{-- Sub-navigation tabs (module-specific) --}}
 @hasSection('subnav')
-<div class="bg-dark border-bottom border-secondary">
+<div class="subnav-light">
     <div class="container-fluid">
         @yield('subnav')
     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="{{ asset('css/style.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/swipe.css') }}">
     @stack('styles')
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
@@ -26,35 +27,35 @@
                 @if(($inActiveRun ?? false) && !request()->routeIs('lobby*'))
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('galaxy.*')) active @endif"
-                       href="{{ route('galaxy.index') }}"><i class="bi bi-globe2"></i> Galaxis</a>
+                       href="{{ route('galaxy.index') }}"><i class="bi bi-globe2"></i><span class="nav-label"> Galaxis</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('fleet.*')) active @endif"
-                       href="{{ route('fleet.index') }}"><i class="bi bi-send"></i> Flotte</a>
+                       href="{{ route('fleet.index') }}"><i class="bi bi-send"></i><span class="nav-label"> Flotte</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('colony.*')) active @endif"
-                       href="{{ route('colony.view') }}"><i class="bi bi-globe2"></i> Kolonie</a>
+                       href="{{ route('colony.view') }}"><i class="bi bi-globe2"></i><span class="nav-label"> Kolonie</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('techtree.*')) active @endif"
-                       href="{{ route('techtree.index') }}"><i class="bi bi-building"></i> Techtree</a>
+                       href="{{ route('techtree.index') }}"><i class="bi bi-building"></i><span class="nav-label"> Techtree</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('advisors.*')) active @endif"
-                       href="{{ route('advisors.index') }}"><i class="bi bi-people"></i> Berater</a>
+                       href="{{ route('advisors.index') }}"><i class="bi bi-people"></i><span class="nav-label"> Berater</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('colony.bar*')) active @endif"
-                       href="{{ route('colony.bar') }}"><i class="bi bi-cup-hot"></i> Cantina</a>
+                       href="{{ route('colony.bar') }}"><i class="bi bi-cup-hot"></i><span class="nav-label"> Cantina</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('trade.*')) active @endif"
-                       href="{{ route('trade.resources') }}"><i class="bi bi-cart3"></i> Handel</a>
+                       href="{{ route('trade.resources') }}"><i class="bi bi-cart3"></i><span class="nav-label"> Handel</span></a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link @if(request()->routeIs('messages.*')) active @endif"
-                       href="{{ route('messages.inbox') }}"><i class="bi bi-envelope"></i> Nachrichten</a>
+                       href="{{ route('messages.inbox') }}"><i class="bi bi-envelope"></i><span class="nav-label"> Nachrichten</span></a>
                 </li>
                 @endif
             </ul>

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -10,6 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400&display=swap">
     <link rel="stylesheet" href="{{ asset('css/colony.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/swipe.css') }}">
     @stack('styles')
 </head>
 <body>
@@ -20,11 +21,11 @@
             <li><a href="{{ route('colony.view') }}" class="colony-logo">Nouron</a></li>
         </ul>
         <ul>
-            <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*') && !request()->routeIs('colony.bar*') && !request()->routeIs('colony.merchant*')])><i class="bi bi-hexagon"></i> Kolonie</a></li>
-            <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])><i class="bi bi-people"></i> Berater</a></li>
-            <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])><i class="bi bi-diagram-3"></i> Techtree</a></li>
-            <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])><i class="bi bi-cup-hot"></i> Cantina</a></li>
-            <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])><i class="bi bi-envelope"></i> Nachrichten</a></li>
+            <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*') && !request()->routeIs('colony.bar*') && !request()->routeIs('colony.merchant*')])><i class="bi bi-hexagon"></i><span class="nav-label"> Kolonie</span></a></li>
+            <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])><i class="bi bi-people"></i><span class="nav-label"> Berater</span></a></li>
+            <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])><i class="bi bi-diagram-3"></i><span class="nav-label"> Techtree</span></a></li>
+            <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])><i class="bi bi-cup-hot"></i><span class="nav-label"> Cantina</span></a></li>
+            <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])><i class="bi bi-envelope"></i><span class="nav-label"> Nachrichten</span></a></li>
         </ul>
         <ul>
             {{-- Sol-Button (only in an active run) --}}
@@ -70,6 +71,7 @@
 </main>
 
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+<script src="{{ asset('js/swipe.js') }}"></script>
 <script src="{{ asset('js/colony-hexgrid.js') }}"></script>
 @stack('scripts')
 </body>

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -7,6 +7,8 @@
     <title>@yield('title', 'Nouron')</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400&display=swap">
     <link rel="stylesheet" href="{{ asset('css/colony.css') }}">
     @stack('styles')
 </head>
@@ -15,25 +17,32 @@
 <header class="colony-header">
     <nav>
         <ul>
-            <li><strong><a href="{{ route('colony.view') }}">Nouron</a></strong></li>
+            <li><a href="{{ route('colony.view') }}" class="colony-logo">Nouron</a></li>
         </ul>
         <ul>
             <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*') && !request()->routeIs('colony.bar*') && !request()->routeIs('colony.merchant*')])><i class="bi bi-hexagon"></i> Kolonie</a></li>
             <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])><i class="bi bi-people"></i> Berater</a></li>
+            <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])><i class="bi bi-diagram-3"></i> Techtree</a></li>
             <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])><i class="bi bi-cup-hot"></i> Cantina</a></li>
             <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])><i class="bi bi-envelope"></i> Nachrichten</a></li>
         </ul>
         <ul>
+            {{-- Sol-Button (only in an active run) --}}
+            @auth
+            @if($inActiveRun ?? false)
+            <li>@include('partials.sol-button')</li>
+            @endif
+            @endauth
             <li>
-                <details class="dropdown">
+                <details class="dropdown colony-user-dropdown">
                     <summary>{{ Auth::user()->username }}</summary>
-                    <ul dir="rtl">
+                    <ul>
                         <li><a href="{{ route('user.show') }}">Profil</a></li>
                         <li><a href="{{ route('user.settings') }}">Einstellungen</a></li>
                         <li>
                             <form method="POST" action="{{ route('logout') }}" style="margin:0">
                                 @csrf
-                                <button type="submit" class="secondary outline">Abmelden</button>
+                                <button type="submit">Abmelden</button>
                             </form>
                         </li>
                     </ul>
@@ -46,9 +55,11 @@
     @if(!empty($resourceBarPossessions))
     <div class="colony-resbar">
         @include('resources.resourcebar', [
-            'possessions' => $resourceBarPossessions,
-            'currentSol'  => $currentSol ?? null,
-            'solLimit'    => $solLimit ?? 100,
+            'possessions'  => $resourceBarPossessions,
+            'currentSol'   => $currentSol ?? null,
+            'solLimit'     => $solLimit ?? 100,
+            'nexusDebt'    => ($inActiveRun ?? false) ? ($nexusDebt ?? null) : null,
+            'nexusDebtMax' => $nexusDebtMax ?? 12000,
         ])
     </div>
     @endif

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -13,28 +13,33 @@
     <link rel="stylesheet" href="{{ asset('css/swipe.css') }}">
     @stack('styles')
 </head>
-<body>
+<body class="@if(request()->routeIs('colony.view')) page-colony @endif">
 
 <header class="colony-header">
     <nav>
         <ul>
             <li><a href="{{ route('colony.view') }}" class="colony-logo">Nouron</a></li>
         </ul>
-        <ul>
+
+        {{-- Desktop nav (visible from 600px up) --}}
+        <ul class="nav-desktop">
             <li><a href="{{ route('colony.view') }}" @class(['active' => request()->routeIs('colony.*') && !request()->routeIs('colony.bar*') && !request()->routeIs('colony.merchant*')])><i class="bi bi-hexagon"></i><span class="nav-label"> Kolonie</span></a></li>
             <li><a href="{{ route('advisors.index') }}" @class(['active' => request()->routeIs('advisors.*')])><i class="bi bi-people"></i><span class="nav-label"> Berater</span></a></li>
             <li><a href="{{ route('techtree.index') }}" @class(['active' => request()->routeIs('techtree.*')])><i class="bi bi-diagram-3"></i><span class="nav-label"> Techtree</span></a></li>
             <li><a href="{{ route('colony.bar') }}" @class(['active' => request()->routeIs('colony.bar*')])><i class="bi bi-cup-hot"></i><span class="nav-label"> Cantina</span></a></li>
             <li><a href="{{ route('messages.inbox') }}" @class(['active' => request()->routeIs('messages.*')])><i class="bi bi-envelope"></i><span class="nav-label"> Nachrichten</span></a></li>
         </ul>
+
         <ul>
-            {{-- Sol-Button (only in an active run) --}}
+            {{-- Sol-Button: always visible on desktop; mobile only on colony.view (via .sol-btn-wrap) --}}
             @auth
             @if($inActiveRun ?? false)
-            <li>@include('partials.sol-button')</li>
+            <li class="sol-btn-wrap">@include('partials.sol-button')</li>
             @endif
             @endauth
-            <li>
+
+            {{-- Desktop: user dropdown --}}
+            <li class="nav-desktop">
                 <details class="dropdown colony-user-dropdown">
                     <summary>{{ Auth::user()->username }}</summary>
                     <ul>
@@ -48,6 +53,39 @@
                         </li>
                     </ul>
                 </details>
+            </li>
+
+            {{-- Mobile: hamburger button + flyout menu --}}
+            <li class="nav-mobile" x-data="{ open: false }">
+                <button class="nav-burger" @click="open = !open" :aria-expanded="open.toString()" type="button" aria-label="Menü">
+                    <i class="bi bi-list"></i>
+                </button>
+                <div class="nav-flyout" x-show="open" @click.outside="open = false" x-cloak>
+                    <a href="{{ route('colony.view') }}" @class(['nav-flyout-item', 'active' => request()->routeIs('colony.*') && !request()->routeIs('colony.bar*') && !request()->routeIs('colony.merchant*')])>
+                        <i class="bi bi-hexagon"></i> Kolonie
+                    </a>
+                    <a href="{{ route('advisors.index') }}" @class(['nav-flyout-item', 'active' => request()->routeIs('advisors.*')])>
+                        <i class="bi bi-people"></i> Berater
+                    </a>
+                    <a href="{{ route('techtree.index') }}" @class(['nav-flyout-item', 'active' => request()->routeIs('techtree.*')])>
+                        <i class="bi bi-diagram-3"></i> Techtree
+                    </a>
+                    <a href="{{ route('colony.bar') }}" @class(['nav-flyout-item', 'active' => request()->routeIs('colony.bar*')])>
+                        <i class="bi bi-cup-hot"></i> Cantina
+                    </a>
+                    <a href="{{ route('messages.inbox') }}" @class(['nav-flyout-item', 'active' => request()->routeIs('messages.*')])>
+                        <i class="bi bi-envelope"></i> Nachrichten
+                    </a>
+                    <div class="nav-flyout-divider"></div>
+                    <a href="{{ route('user.show') }}" class="nav-flyout-item"><i class="bi bi-person"></i> Profil</a>
+                    <a href="{{ route('user.settings') }}" class="nav-flyout-item"><i class="bi bi-gear"></i> Einstellungen</a>
+                    <form method="POST" action="{{ route('logout') }}" style="margin:0">
+                        @csrf
+                        <button type="submit" class="nav-flyout-item nav-flyout-item--btn">
+                            <i class="bi bi-power"></i> Abmelden
+                        </button>
+                    </form>
+                </div>
             </li>
         </ul>
     </nav>

--- a/resources/views/lobby/index.blade.php
+++ b/resources/views/lobby/index.blade.php
@@ -31,10 +31,12 @@
         margin-top: 0.75rem;
     }
 
-    /* PicoCSS <article> cards */
+    /* PicoCSS <article> cards — force light background regardless of system color scheme */
     .lobby-run-card {
         margin: 0;
         padding: 1.25rem;
+        background: #ffffff;
+        color: #333;
     }
 
     .lobby-run-card header {
@@ -46,11 +48,13 @@
         margin-bottom: 0.5rem;
         background: none;
         border: none;
+        color: inherit;
     }
 
     .lobby-run-card header h3 {
         margin: 0;
         font-size: 1.1rem;
+        color: #1a1a2e;
     }
 
     .lobby-run-card footer {
@@ -253,7 +257,7 @@
     - No Bootstrap grid classes used inside — PicoCSS article/grid only.
     - Alpine.js is already loaded globally by layouts/app.blade.php.
 --}}
-<div class="lobby-scope" style="max-width: 56rem; margin: 0 auto; padding: 1rem 0 3rem;">
+<div class="lobby-scope" data-theme="light" style="max-width: 56rem; margin: 0 auto; padding: 2rem 0 3rem;">
 
     {{-- ── Page header ──────────────────────────────────────────────────────── --}}
     <hgroup style="margin-bottom: 1.75rem;">
@@ -269,11 +273,12 @@
         <div class="lobby-run-grid">
             @foreach($active as $run)
                 @php
-                    $tickLimit  = $run->settings['tick_limit'] ?? 100;
-                    $solPct     = $tickLimit > 0
+                    $tickLimit   = $run->settings['tick_limit'] ?? 100;
+                    $displayTick = min($run->current_tick, $tickLimit);
+                    $solPct      = $tickLimit > 0
                         ? min(100, round(($run->current_tick / $tickLimit) * 100))
                         : 0;
-                    $colonyName = $run->colony->name ?? __('lobby.colony_unnamed');
+                    $colonyName  = $run->colony->name ?? __('lobby.colony_unnamed');
                 @endphp
                 <article class="lobby-run-card">
                     <header>
@@ -282,12 +287,12 @@
 
                     <p class="lobby-sol-progress">
                         {{ __('lobby.sol_progress', [
-                            'current' => $run->current_tick,
+                            'current' => $displayTick,
                             'limit'   => $tickLimit,
                         ]) }}
                     </p>
                     <progress
-                        value="{{ $run->current_tick }}"
+                        value="{{ $displayTick }}"
                         max="{{ $tickLimit }}"
                         title="{{ $solPct }}%"
                     ></progress>

--- a/resources/views/messages/archive.blade.php
+++ b/resources/views/messages/archive.blade.php
@@ -3,10 +3,7 @@
 @section('title', 'Archiv — Nouron')
 
 @section('content')
-<div style="padding: 1.5rem 1.5rem 3rem;"
-     x-data="swipeNav({ prev: '{{ route('messages.outbox') }}', next: '{{ route('messages.events') }}' })"
-     @touchstart.passive="touchStart($event)"
-     @touchend.passive="touchEnd($event)">
+<div style="padding: 1.5rem 1.5rem 3rem;">
 @include('messages.partials.tabs')
 <div class="msg-list">
     @if($messages->isEmpty())

--- a/resources/views/messages/archive.blade.php
+++ b/resources/views/messages/archive.blade.php
@@ -1,49 +1,41 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 
 @section('title', 'Archiv — Nouron')
 
 @section('content')
+<div style="padding: 1.5rem 1.5rem 3rem;"
+     x-data="swipeNav({ prev: '{{ route('messages.outbox') }}', next: '{{ route('messages.events') }}' })"
+     @touchstart.passive="touchStart($event)"
+     @touchend.passive="touchEnd($event)">
 @include('messages.partials.tabs')
-
-<div class="row">
-    <div class="accordion col-12" id="archive-accordion">
-        @if($messages->isEmpty())
-            <p class="text-muted fst-italic">Keine archivierten Nachrichten.</p>
-        @endif
-        @foreach($messages as $message)
-        <div id="message-{{ $message->id }}" class="accordion-item">
-            <h2 class="accordion-header">
-                <button class="accordion-button collapsed" type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-message-{{ $message->id }}">
-                    <span class="me-2"><i class="bi bi-clock"></i> {{ $message->tick }}</span>
-                    <strong class="me-2">{{ $message->sender }}:</strong>
-                    {{ $message->subject }}
-                </button>
-            </h2>
-            <div id="collapse-message-{{ $message->id }}" class="accordion-collapse collapse">
-                <div class="accordion-body">
-                    <p>{{ $message->text }}</p>
-                    <div class="d-flex gap-2 flex-wrap mt-2 message-options"
-                         id="message-{{ $message->id }}-options">
-                        <form method="POST" action="{{ route('messages.remove', $message->id) }}" class="d-inline">
-                            @csrf
-                            <button type="submit" class="btn btn-sm btn-outline-danger"
-                                    title="Löschen">
-                                <i class="bi bi-x-lg"></i> löschen
-                            </button>
-                        </form>
-                    </div>
-                </div>
+<div class="msg-list">
+    @if($messages->isEmpty())
+        <p class="msg-empty">Keine archivierten Nachrichten.</p>
+    @endif
+    @foreach($messages as $message)
+    <div id="message-{{ $message->id }}" class="msg-item" x-data="{ open: false }">
+        <div class="msg-header"
+             @click="open = !open"
+             :aria-expanded="open"
+             role="button">
+            <span class="msg-meta">Sol {{ $message->tick }}</span>
+            <span class="msg-sender"><strong>{{ $message->sender }}</strong></span>
+            <span class="msg-subject">{{ $message->subject }}</span>
+            <i class="bi bi-chevron-down msg-chevron" :class="{ 'msg-chevron--open': open }"></i>
+        </div>
+        <div class="msg-body" x-show="open" x-cloak>
+            <p class="msg-text">{{ $message->text }}</p>
+            <div class="msg-actions">
+                <form method="POST" action="{{ route('messages.remove', $message->id) }}" style="display:inline">
+                    @csrf
+                    <button type="submit" class="msg-action-btn msg-action-btn--danger" title="Löschen">
+                        <i class="bi bi-x-lg"></i> löschen
+                    </button>
+                </form>
             </div>
         </div>
-        @endforeach
     </div>
-
-    <ul class="pagination mt-3">
-        <li class="page-item"><a class="page-link" href="#">&laquo;</a></li>
-        <li class="page-item"><a class="page-link" href="#">1</a></li>
-        <li class="page-item"><a class="page-link" href="#">&raquo;</a></li>
-    </ul>
+    @endforeach
+</div>
 </div>
 @endsection

--- a/resources/views/messages/compose.blade.php
+++ b/resources/views/messages/compose.blade.php
@@ -1,76 +1,68 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 
 @section('title', 'Neue Nachricht — Nouron')
 
 @section('content')
 @include('messages.partials.tabs')
 
-<div class="row">
-    <div class="col-12 col-md-8 col-lg-6">
-        <ul class="nav nav-tabs mb-3" id="compose-tabs">
-            <li class="nav-item">
-                <button class="nav-link active" data-bs-toggle="tab"
-                        data-bs-target="#msg-to-user" type="button">
-                    ... an Spieler
-                </button>
-            </li>
-            <li class="nav-item">
-                <button class="nav-link disabled" type="button">... an Fraktion</button>
-            </li>
-            <li class="nav-item">
-                <button class="nav-link disabled" type="button">... an INNN</button>
-            </li>
-            <li class="nav-item">
-                <button class="nav-link disabled" type="button">... an Support</button>
-            </li>
-        </ul>
-
-        <div class="tab-content">
-            <div class="tab-pane fade show active" id="msg-to-user">
-                @if($errors->any())
-                    <div class="alert alert-danger">
-                        <ul class="mb-0">
-                            @foreach($errors->all() as $error)
-                                <li>{{ $error }}</li>
-                            @endforeach
-                        </ul>
-                    </div>
-                @endif
-
-                <form method="POST" action="{{ route('messages.send') }}">
-                    @csrf
-                    <div class="mb-3">
-                        <label for="recipient_id" class="form-label">Empfanger-ID</label>
-                        <input type="number" class="form-control" id="recipient_id"
-                               name="recipient_id" value="{{ old('recipient_id') }}"
-                               min="0" required>
-                    </div>
-                    <div class="mb-3">
-                        <label for="attitude" class="form-label">Haltung</label>
-                        <select class="form-select" id="attitude" name="attitude">
-                            <option value="mood_factual" @selected(old('attitude', 'mood_factual') === 'mood_factual')>Sachlich</option>
-                            <option value="mood_friendly" @selected(old('attitude') === 'mood_friendly')>Freundlich</option>
-                            <option value="mood_hostile"  @selected(old('attitude') === 'mood_hostile')>Feindlich</option>
-                        </select>
-                    </div>
-                    <div class="mb-3">
-                        <label for="subject" class="form-label">Betreff</label>
-                        <input type="text" class="form-control" id="subject"
-                               name="subject" value="{{ old('subject') }}"
-                               maxlength="255" required>
-                    </div>
-                    <div class="mb-3">
-                        <label for="text" class="form-label">Nachricht</label>
-                        <textarea class="form-control" id="text" name="text"
-                                  rows="8" required>{{ old('text') }}</textarea>
-                    </div>
-                    <button type="submit" class="btn btn-primary">
-                        <i class="bi bi-send"></i> Senden
-                    </button>
-                    <a href="{{ route('messages.inbox') }}" class="btn btn-secondary ms-2">Abbrechen</a>
-                </form>
-            </div>
-        </div>
+<div style="padding: 1.5rem 1.5rem 3rem;">
+<div class="msg-compose">
+    <div class="msg-compose-tabs">
+        <button class="msg-tab msg-tab--active" type="button">
+            <i class="bi bi-person"></i> an Spieler
+        </button>
+        <button class="msg-tab" type="button" disabled title="Nicht verfügbar">
+            <i class="bi bi-people"></i> an Fraktion
+        </button>
+        <button class="msg-tab" type="button" disabled title="Nicht verfügbar">
+            <i class="bi bi-newspaper"></i> an INNN
+        </button>
+        <button class="msg-tab" type="button" disabled title="Nicht verfügbar">
+            <i class="bi bi-headset"></i> an Support
+        </button>
     </div>
+
+    @if($errors->any())
+        <div class="msg-error-list">
+            <ul>
+                @foreach($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    <form method="POST" action="{{ route('messages.send') }}" class="msg-form">
+        @csrf
+        <div class="msg-form-field">
+            <label for="recipient_id">Empfanger-ID</label>
+            <input type="number" id="recipient_id" name="recipient_id"
+                   value="{{ old('recipient_id') }}" min="0" required>
+        </div>
+        <div class="msg-form-field">
+            <label for="attitude">Haltung</label>
+            <select id="attitude" name="attitude">
+                <option value="mood_factual" @selected(old('attitude', 'mood_factual') === 'mood_factual')>Sachlich</option>
+                <option value="mood_friendly" @selected(old('attitude') === 'mood_friendly')>Freundlich</option>
+                <option value="mood_hostile"  @selected(old('attitude') === 'mood_hostile')>Feindlich</option>
+            </select>
+        </div>
+        <div class="msg-form-field">
+            <label for="subject">Betreff</label>
+            <input type="text" id="subject" name="subject"
+                   value="{{ old('subject') }}" maxlength="255" required>
+        </div>
+        <div class="msg-form-field">
+            <label for="text">Nachricht</label>
+            <textarea id="text" name="text" rows="8" required>{{ old('text') }}</textarea>
+        </div>
+        <div class="msg-form-actions">
+            <button type="submit" class="msg-action-btn msg-action-btn--primary">
+                <i class="bi bi-send"></i> Senden
+            </button>
+            <a href="{{ route('messages.inbox') }}" class="msg-action-btn">Abbrechen</a>
+        </div>
+    </form>
+</div>
 </div>
 @endsection

--- a/resources/views/messages/events.blade.php
+++ b/resources/views/messages/events.blade.php
@@ -2,10 +2,7 @@
 @section('title', 'Ereignisse — Nouron')
 
 @section('content')
-<div style="padding: 1.5rem 1.5rem 3rem;"
-     x-data="swipeNav({ prev: '{{ route('messages.archive') }}', next: '{{ route('messages.news') }}' })"
-     @touchstart.passive="touchStart($event)"
-     @touchend.passive="touchEnd($event)">
+<div style="padding: 1.5rem 1.5rem 3rem;">
 @include('messages.partials.tabs')
 <div class="msg-list">
     @if($events->isEmpty())

--- a/resources/views/messages/events.blade.php
+++ b/resources/views/messages/events.blade.php
@@ -1,117 +1,117 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 @section('title', 'Ereignisse — Nouron')
 
 @section('content')
+<div style="padding: 1.5rem 1.5rem 3rem;"
+     x-data="swipeNav({ prev: '{{ route('messages.archive') }}', next: '{{ route('messages.news') }}' })"
+     @touchstart.passive="touchStart($event)"
+     @touchend.passive="touchEnd($event)">
 @include('messages.partials.tabs')
+<div class="msg-list">
+    @if($events->isEmpty())
+        <p class="msg-empty">Keine Ereignisse vorhanden.</p>
+    @else
+        @foreach($events as $event)
+        @php
+            $params = [];
+            if ($event->parameters) {
+                $raw = @unserialize($event->parameters);
+                if (is_array($raw)) {
+                    $params = $raw;
+                }
+            }
 
-<div class="row justify-content-center">
-    <div class="col-12 col-md-10 col-xl-8">
-        @if($events->isEmpty())
-            <p class="text-muted fst-italic">Keine Ereignisse vorhanden.</p>
-        @else
-            <div class="list-group">
-                @foreach($events as $event)
-                @php
-                    $params = [];
-                    if ($event->parameters) {
-                        $raw = @unserialize($event->parameters);
-                        if (is_array($raw)) {
-                            $params = $raw;
+            $resolved = [];
+            foreach ($params as $key => $value) {
+                switch ($key) {
+                    case 'tech_id':
+                        // tech_id can refer to a building, research, or ship — try all three
+                        $entity = \App\Models\Building::find((int) $value)
+                            ?? \App\Models\Research::find((int) $value)
+                            ?? \App\Models\Ship::find((int) $value);
+                        $resolved['tech'] = $entity
+                            ? '<strong>' . e(__('techtree.' . $entity->name)) . '</strong>'
+                            : '<strong>Technologie #' . (int) $value . '</strong>';
+                        break;
+
+                    case 'research_id':
+                        $res = \App\Models\Research::find((int) $value);
+                        $resolved['research'] = $res
+                            ? '<strong>' . e(__('techtree.' . $res->name)) . '</strong>'
+                            : '<strong>Forschung #' . (int) $value . '</strong>';
+                        break;
+
+                    case 'colony_id':
+                        $col = (int) $value > 0 ? \App\Models\Colony::find((int) $value) : null;
+                        $resolved['colony'] = $col
+                            ? '<strong>' . e($col->name) . '</strong>'
+                            : '<strong>unbekannte Kolonie</strong>';
+                        break;
+
+                    case 'fleet_id':
+                        $fleet = \App\Models\Fleet::find((int) $value);
+                        $resolved['fleet'] = $fleet
+                            ? '<strong>' . e($fleet->fleet) . '</strong>'
+                            : '<strong>Flotte #' . (int) $value . '</strong>';
+                        break;
+
+                    case 'attacker_id':
+                        $attacker = (int) $value > 0 ? \App\Models\User::find((int) $value) : null;
+                        $resolved['attacker'] = $attacker
+                            ? '<strong>' . e($attacker->username) . '</strong>'
+                            : '<strong>unbekannter Angreifer</strong>';
+                        break;
+
+                    case 'defender_id':
+                        $defender = (int) $value > 0 ? \App\Models\User::find((int) $value) : null;
+                        $resolved['defender'] = $defender
+                            ? '<strong>' . e($defender->username) . '</strong>'
+                            : '<strong>unbekannter Verteidiger</strong>';
+                        break;
+
+                    case 'coords':
+                        if (is_array($value) && count($value) >= 2) {
+                            $resolved['coords'] = '<strong>' . (int) $value[0] . '/' . (int) $value[1] . '</strong>';
                         }
-                    }
+                        break;
+                }
+            }
 
-                    $resolved = [];
-                    foreach ($params as $key => $value) {
-                        switch ($key) {
-                            case 'tech_id':
-                                // tech_id can refer to a building, research, or ship — try all three
-                                $entity = \App\Models\Building::find((int) $value)
-                                    ?? \App\Models\Research::find((int) $value)
-                                    ?? \App\Models\Ship::find((int) $value);
-                                $resolved['tech'] = $entity
-                                    ? '<strong>' . e(__('techtree.' . $entity->name)) . '</strong>'
-                                    : '<strong>Technologie #' . (int) $value . '</strong>';
-                                break;
+            // Fill missing placeholders so raw ":placeholder" never leaks into the output
+            $resolved += [
+                'tech'      => '<em class="text-muted">unbekannt</em>',
+                'research'  => '<em class="text-muted">unbekannt</em>',
+                'colony'    => '<em class="text-muted">unbekannte Kolonie</em>',
+                'fleet'     => '<em class="text-muted">unbekannte Flotte</em>',
+                'attacker'  => '<em class="text-muted">unbekannt</em>',
+                'defender'  => '<em class="text-muted">unbekannt</em>',
+                'coords'    => '<em class="text-muted">?/?</em>',
+            ];
 
-                            case 'research_id':
-                                $res = \App\Models\Research::find((int) $value);
-                                $resolved['research'] = $res
-                                    ? '<strong>' . e(__('techtree.' . $res->name)) . '</strong>'
-                                    : '<strong>Forschung #' . (int) $value . '</strong>';
-                                break;
+            $langKey = 'events.' . str_replace('.', '_', $event->event);
+            $text = __($langKey, $resolved);
+            if ($text === $langKey) {
+                $text = __('events.unknown', ['event' => e($event->event)]);
+            }
 
-                            case 'colony_id':
-                                $col = (int) $value > 0 ? \App\Models\Colony::find((int) $value) : null;
-                                $resolved['colony'] = $col
-                                    ? '<strong>' . e($col->name) . '</strong>'
-                                    : '<strong>unbekannte Kolonie</strong>';
-                                break;
-
-                            case 'fleet_id':
-                                $fleet = \App\Models\Fleet::find((int) $value);
-                                $resolved['fleet'] = $fleet
-                                    ? '<strong>' . e($fleet->fleet) . '</strong>'
-                                    : '<strong>Flotte #' . (int) $value . '</strong>';
-                                break;
-
-                            case 'attacker_id':
-                                $attacker = (int) $value > 0 ? \App\Models\User::find((int) $value) : null;
-                                $resolved['attacker'] = $attacker
-                                    ? '<strong>' . e($attacker->username) . '</strong>'
-                                    : '<strong>unbekannter Angreifer</strong>';
-                                break;
-
-                            case 'defender_id':
-                                $defender = (int) $value > 0 ? \App\Models\User::find((int) $value) : null;
-                                $resolved['defender'] = $defender
-                                    ? '<strong>' . e($defender->username) . '</strong>'
-                                    : '<strong>unbekannter Verteidiger</strong>';
-                                break;
-
-                            case 'coords':
-                                if (is_array($value) && count($value) >= 2) {
-                                    $resolved['coords'] = '<strong>' . (int) $value[0] . '/' . (int) $value[1] . '</strong>';
-                                }
-                                break;
-                        }
-                    }
-
-                    // Fill missing placeholders so raw ":placeholder" never leaks into the output
-                    $resolved += [
-                        'tech'      => '<em class="text-muted">unbekannt</em>',
-                        'research'  => '<em class="text-muted">unbekannt</em>',
-                        'colony'    => '<em class="text-muted">unbekannte Kolonie</em>',
-                        'fleet'     => '<em class="text-muted">unbekannte Flotte</em>',
-                        'attacker'  => '<em class="text-muted">unbekannt</em>',
-                        'defender'  => '<em class="text-muted">unbekannt</em>',
-                        'coords'    => '<em class="text-muted">?/?</em>',
-                    ];
-
-                    $langKey = 'events.' . str_replace('.', '_', $event->event);
-                    $text = __($langKey, $resolved);
-                    if ($text === $langKey) {
-                        $text = __('events.unknown', ['event' => e($event->event)]);
-                    }
-
-                    // Icon per area
-                    $icon = match($event->area) {
-                        'techtree' => 'bi-tools',
-                        'galaxy'   => 'bi-rocket-takeoff',
-                        'trade'    => 'bi-bag',
-                        'nexus'    => 'bi-broadcast-pin',
-                        default    => 'bi-info-circle',
-                    };
-                @endphp
-                <div class="list-group-item d-flex align-items-start gap-2">
-                    <i class="bi {{ $icon }} mt-1 text-muted flex-shrink-0"></i>
-                    <div>
-                        <span class="text-muted small me-2">Tick {{ $event->tick }}</span>
-                        {!! $text !!}
-                    </div>
-                </div>
-                @endforeach
+            // Icon per area
+            $icon = match($event->area) {
+                'techtree' => 'bi-tools',
+                'galaxy'   => 'bi-rocket-takeoff',
+                'trade'    => 'bi-bag',
+                'nexus'    => 'bi-broadcast-pin',
+                default    => 'bi-info-circle',
+            };
+        @endphp
+        <div class="msg-item">
+            <div class="msg-header" style="cursor: default;">
+                <span class="msg-meta">Sol {{ $event->tick }}</span>
+                <i class="bi {{ $icon }}" style="color: var(--color-text-secondary); flex-shrink: 0;"></i>
+                <span class="msg-subject">{!! $text !!}</span>
             </div>
-        @endif
-    </div>
+        </div>
+        @endforeach
+    @endif
+</div>
 </div>
 @endsection

--- a/resources/views/messages/inbox.blade.php
+++ b/resources/views/messages/inbox.blade.php
@@ -3,10 +3,7 @@
 @section('title', 'Posteingang — Nouron')
 
 @section('content')
-<div style="padding: 1.5rem 1.5rem 3rem;"
-     x-data="swipeNav({ next: '{{ route('messages.outbox') }}' })"
-     @touchstart.passive="touchStart($event)"
-     @touchend.passive="touchEnd($event)">
+<div style="padding: 1.5rem 1.5rem 3rem;">
 @include('messages.partials.tabs')
 
 <div class="msg-list">

--- a/resources/views/messages/inbox.blade.php
+++ b/resources/views/messages/inbox.blade.php
@@ -1,62 +1,56 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 
 @section('title', 'Posteingang — Nouron')
 
 @section('content')
+<div style="padding: 1.5rem 1.5rem 3rem;"
+     x-data="swipeNav({ next: '{{ route('messages.outbox') }}' })"
+     @touchstart.passive="touchStart($event)"
+     @touchend.passive="touchEnd($event)">
 @include('messages.partials.tabs')
 
-<div class="row">
-    <div class="accordion col-12" id="inbox-accordion">
-        @if($messages->isEmpty())
-            <p class="text-muted fst-italic">Keine Nachrichten im Eingang.</p>
-        @endif
-        @foreach($messages as $message)
-        <div id="message-{{ $message->id }}" class="accordion-item">
-            <h2 class="accordion-header">
-                <button class="accordion-button collapsed" type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-message-{{ $message->id }}"
-                        aria-expanded="false">
-                    <i class="bi bi-clock me-1"></i> {{ $message->tick }}
-                    &nbsp;<strong>{{ $message->sender }}:</strong>&nbsp;
-                    @if(!$message->is_read)
-                        <i class="bi bi-envelope-fill text-primary me-1"></i>
-                    @endif
-                    {{ $message->subject }}
-                </button>
-            </h2>
-            <div id="collapse-message-{{ $message->id }}" class="accordion-collapse collapse">
-                <div class="accordion-body">
-                    <p>{{ $message->text }}</p>
-                    <div class="d-flex gap-2 flex-wrap mt-2 message-options"
-                         id="message-{{ $message->id }}-options">
-                        @if(!$message->is_read)
-                            <button class="btn btn-sm btn-outline-secondary js-react"
-                                    data-id="{{ $message->id }}"
-                                    title="Als gelesen markieren">
-                                <i class="bi bi-hand-thumbs-up"></i>
-                            </button>
-                        @endif
-                        <form method="POST" action="{{ route('messages.archive.message', $message->id) }}" class="d-inline">
-                            @csrf
-                            <button type="submit" class="btn btn-sm btn-outline-secondary"
-                                    title="Archivieren">
-                                <i class="bi bi-archive"></i> archivieren
-                            </button>
-                        </form>
-                        <form method="POST" action="{{ route('messages.remove', $message->id) }}" class="d-inline">
-                            @csrf
-                            <button type="submit" class="btn btn-sm btn-outline-danger"
-                                    title="Löschen">
-                                <i class="bi bi-x-lg"></i> löschen
-                            </button>
-                        </form>
-                    </div>
-                </div>
+<div class="msg-list">
+    @if($messages->isEmpty())
+        <p class="msg-empty">Keine Nachrichten im Eingang.</p>
+    @endif
+    @foreach($messages as $message)
+    <div id="message-{{ $message->id }}"
+         class="msg-item @if(!$message->is_read) msg-item--unread @endif"
+         x-data="{ open: false }">
+        <div class="msg-header" @click="open = !open" :aria-expanded="open">
+            <span class="msg-meta">Sol {{ $message->tick }}</span>
+            <span class="msg-sender"><strong>{{ $message->sender }}</strong></span>
+            <span class="msg-subject">{{ $message->subject }}</span>
+            @if(!$message->is_read)
+                <span class="msg-unread-dot" title="Ungelesen"></span>
+            @endif
+            <i class="bi bi-chevron-down msg-chevron" :class="{ 'msg-chevron--open': open }"></i>
+        </div>
+        <div class="msg-body" x-show="open" x-cloak>
+            <p class="msg-text">{{ $message->text }}</p>
+            <div class="msg-actions">
+                @if(!$message->is_read)
+                    <button class="msg-action-btn js-react" data-id="{{ $message->id }}" title="Als gelesen markieren">
+                        <i class="bi bi-check2"></i> gelesen
+                    </button>
+                @endif
+                <form method="POST" action="{{ route('messages.archive.message', $message->id) }}" style="display:inline;margin:0">
+                    @csrf
+                    <button type="submit" class="msg-action-btn" title="Archivieren">
+                        <i class="bi bi-archive"></i> archivieren
+                    </button>
+                </form>
+                <form method="POST" action="{{ route('messages.remove', $message->id) }}" style="display:inline;margin:0">
+                    @csrf
+                    <button type="submit" class="msg-action-btn msg-action-btn--danger" title="Löschen">
+                        <i class="bi bi-x-lg"></i> löschen
+                    </button>
+                </form>
             </div>
         </div>
-        @endforeach
     </div>
+    @endforeach
+</div>
 </div>
 @endsection
 
@@ -73,9 +67,7 @@ document.querySelectorAll('.js-react').forEach(function (btn) {
             },
             body: JSON.stringify({ id: id })
         }).then(function (r) { return r.json(); }).then(function (data) {
-            if (data.result) {
-                btn.remove();
-            }
+            if (data.result) { btn.remove(); }
         });
     });
 });

--- a/resources/views/messages/news.blade.php
+++ b/resources/views/messages/news.blade.php
@@ -1,18 +1,14 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 @section('title', 'INNN — Nouron')
 
 @section('content')
+<div style="padding: 1.5rem 1.5rem 3rem;"
+     x-data="swipeNav({ prev: '{{ route('messages.events') }}' })"
+     @touchstart.passive="touchStart($event)"
+     @touchend.passive="touchEnd($event)">
 @include('messages.partials.tabs')
 
 @php
-$topicBadge = [
-    'economy'   => 'bg-success',
-    'politics'  => 'bg-primary',
-    'diplomacy' => 'bg-info text-dark',
-    'culture'   => 'bg-warning text-dark',
-    'sports'    => 'bg-danger',
-    'misc'      => 'bg-secondary',
-];
 $topicLabel = [
     'economy'   => 'Wirtschaft',
     'politics'  => 'Politik',
@@ -23,28 +19,29 @@ $topicLabel = [
 ];
 @endphp
 
-<div class="row">
-    <div class="col-12">
-        @if($news->isEmpty())
-            <p class="text-muted fst-italic">Keine Nachrichten vorhanden.</p>
-        @else
-            <div class="list-group">
-                @foreach($news as $item)
-                <div class="list-group-item list-group-item-action">
-                    <div class="d-flex w-100 justify-content-between align-items-start mb-1">
-                        <h6 class="mb-0 fw-bold">{{ $item->headline }}</h6>
-                        <div class="d-flex gap-2 align-items-center ms-3 flex-shrink-0">
-                            <span class="badge {{ $topicBadge[$item->topic] ?? 'bg-secondary' }}">
-                                {{ $topicLabel[$item->topic] ?? $item->topic }}
-                            </span>
-                            <span class="text-muted small">Tick {{ $item->tick }}</span>
-                        </div>
-                    </div>
-                    <p class="mb-0 text-muted small">{{ $item->text }}</p>
-                </div>
-                @endforeach
+<div class="msg-list">
+    @if($news->isEmpty())
+        <p class="msg-empty">Keine Nachrichten vorhanden.</p>
+    @else
+        @foreach($news as $item)
+        <div class="msg-item" x-data="{ open: false }">
+            <div class="msg-header"
+                 @click="open = !open"
+                 :aria-expanded="open"
+                 role="button">
+                <span class="msg-meta">Sol {{ $item->tick }}</span>
+                <span class="msg-sender">
+                    <span class="msg-topic-badge">{{ $topicLabel[$item->topic] ?? $item->topic }}</span>
+                </span>
+                <span class="msg-subject">{{ $item->headline }}</span>
+                <i class="bi bi-chevron-down msg-chevron" :class="{ 'msg-chevron--open': open }"></i>
             </div>
-        @endif
-    </div>
+            <div class="msg-body" x-show="open" x-cloak>
+                <p class="msg-text">{{ $item->text }}</p>
+            </div>
+        </div>
+        @endforeach
+    @endif
 </div>
+</div>{{-- swipeNav wrapper --}}
 @endsection

--- a/resources/views/messages/news.blade.php
+++ b/resources/views/messages/news.blade.php
@@ -2,10 +2,7 @@
 @section('title', 'INNN — Nouron')
 
 @section('content')
-<div style="padding: 1.5rem 1.5rem 3rem;"
-     x-data="swipeNav({ prev: '{{ route('messages.events') }}' })"
-     @touchstart.passive="touchStart($event)"
-     @touchend.passive="touchEnd($event)">
+<div style="padding: 1.5rem 1.5rem 3rem;">
 @include('messages.partials.tabs')
 
 @php
@@ -43,5 +40,5 @@ $topicLabel = [
         @endforeach
     @endif
 </div>
-</div>{{-- swipeNav wrapper --}}
+</div>
 @endsection

--- a/resources/views/messages/outbox.blade.php
+++ b/resources/views/messages/outbox.blade.php
@@ -1,59 +1,35 @@
-@extends('layouts.app')
+@extends('layouts.colony')
 
 @section('title', 'Postausgang — Nouron')
 
 @section('content')
+<div style="padding: 1.5rem 1.5rem 3rem;"
+     x-data="swipeNav({ prev: '{{ route('messages.inbox') }}', next: '{{ route('messages.archive') }}' })"
+     @touchstart.passive="touchStart($event)"
+     @touchend.passive="touchEnd($event)">
 @include('messages.partials.tabs')
-
-<div class="row">
-    <div class="accordion col-12" id="outbox-accordion">
-        @if($messages->isEmpty())
-            <p class="text-muted fst-italic">Keine Nachrichten im Ausgang.</p>
-        @endif
-        @foreach($messages as $message)
-        <div class="accordion-item">
-            <h2 class="accordion-header">
-                <button class="accordion-button collapsed" type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#collapse-message-{{ $message->id }}">
-                    <i class="bi bi-clock me-1"></i> {{ $message->tick }}
-                    &nbsp;<strong>an {{ $message->recipient }}:</strong>&nbsp;
-                    {{ $message->subject }}
-                </button>
-            </h2>
-            <div id="collapse-message-{{ $message->id }}" class="accordion-collapse collapse">
-                <div class="accordion-body">
-                    <p>{{ $message->text }}</p>
-                    <div class="d-flex gap-2 flex-wrap mt-2">
-                        <span class="text-muted small">Gesendet in Tick {{ $message->tick }}</span>
-                    </div>
-                    {{-- Outbox action buttons are disabled (sender cannot react to own messages) --}}
-                    <div class="d-flex gap-2 flex-wrap mt-2">
-                        <a href="#" class="btn btn-sm btn-outline-secondary disabled"
-                           title="positiv reagieren">
-                            <i class="bi bi-hand-thumbs-up"></i>
-                        </a>
-                        <a href="#" class="btn btn-sm btn-outline-secondary disabled"
-                           title="positiv reagieren + antworten">
-                            <i class="bi bi-hand-thumbs-up"></i> + <i class="bi bi-envelope"></i>
-                        </a>
-                        <a href="#" class="btn btn-sm btn-outline-secondary disabled"
-                           title="antworten">
-                            <i class="bi bi-envelope"></i>
-                        </a>
-                        <a href="#" class="btn btn-sm btn-outline-secondary disabled"
-                           title="negativ reagieren">
-                            <i class="bi bi-hand-thumbs-down"></i>
-                        </a>
-                        <a href="#" class="btn btn-sm btn-outline-secondary disabled"
-                           title="negativ reagieren + antworten">
-                            <i class="bi bi-hand-thumbs-down"></i> + <i class="bi bi-envelope"></i>
-                        </a>
-                    </div>
-                </div>
-            </div>
+<div class="msg-list">
+    @if($messages->isEmpty())
+        <p class="msg-empty">Keine Nachrichten im Ausgang.</p>
+    @endif
+    @foreach($messages as $message)
+    <div class="msg-item" x-data="{ open: false }">
+        <div class="msg-header"
+             @click="open = !open"
+             :aria-expanded="open"
+             role="button">
+            <span class="msg-meta">Sol {{ $message->tick }}</span>
+            <span class="msg-sender"><strong>an {{ $message->recipient }}</strong></span>
+            <span class="msg-subject">{{ $message->subject }}</span>
+            <i class="bi bi-chevron-down msg-chevron" :class="{ 'msg-chevron--open': open }"></i>
         </div>
-        @endforeach
+        <div class="msg-body" x-show="open" x-cloak>
+            <p class="msg-text">{{ $message->text }}</p>
+            <p class="msg-meta">Gesendet in Sol {{ $message->tick }}</p>
+        </div>
     </div>
+    @endforeach
+</div>
 </div>
 @endsection
+

--- a/resources/views/messages/outbox.blade.php
+++ b/resources/views/messages/outbox.blade.php
@@ -3,10 +3,7 @@
 @section('title', 'Postausgang — Nouron')
 
 @section('content')
-<div style="padding: 1.5rem 1.5rem 3rem;"
-     x-data="swipeNav({ prev: '{{ route('messages.inbox') }}', next: '{{ route('messages.archive') }}' })"
-     @touchstart.passive="touchStart($event)"
-     @touchend.passive="touchEnd($event)">
+<div style="padding: 1.5rem 1.5rem 3rem;">
 @include('messages.partials.tabs')
 <div class="msg-list">
     @if($messages->isEmpty())

--- a/resources/views/messages/partials/tabs.blade.php
+++ b/resources/views/messages/partials/tabs.blade.php
@@ -1,31 +1,73 @@
 @push('styles')
 <link rel="stylesheet" href="{{ asset('css/messages.css') }}">
 @endpush
+
+{{-- Desktop: full tab bar --}}
 <div class="msg-tabs-bar">
     <nav class="msg-tabs">
         <a class="msg-tab @if(request()->routeIs('messages.inbox')) msg-tab--active @endif"
-           href="{{ route('messages.inbox') }}">
-            <i class="bi bi-inbox"></i> Eingang
-        </a>
+           href="{{ route('messages.inbox') }}"><i class="bi bi-inbox"></i><span class="nav-label"> Eingang</span></a>
         <a class="msg-tab @if(request()->routeIs('messages.outbox')) msg-tab--active @endif"
-           href="{{ route('messages.outbox') }}">
-            <i class="bi bi-send"></i> Ausgang
-        </a>
+           href="{{ route('messages.outbox') }}"><i class="bi bi-send"></i><span class="nav-label"> Ausgang</span></a>
         <a class="msg-tab @if(request()->routeIs('messages.archive')) msg-tab--active @endif"
-           href="{{ route('messages.archive') }}">
-            <i class="bi bi-archive"></i> Archiv
-        </a>
+           href="{{ route('messages.archive') }}"><i class="bi bi-archive"></i><span class="nav-label"> Archiv</span></a>
         <a class="msg-tab @if(request()->routeIs('messages.events')) msg-tab--active @endif"
-           href="{{ route('messages.events') }}">
-            <i class="bi bi-lightning-charge"></i> Ereignisse
-        </a>
+           href="{{ route('messages.events') }}"><i class="bi bi-lightning-charge"></i><span class="nav-label"> Ereignisse</span></a>
         <a class="msg-tab @if(request()->routeIs('messages.news')) msg-tab--active @endif"
-           href="{{ route('messages.news') }}">
-            <i class="bi bi-newspaper"></i> INNN
-        </a>
+           href="{{ route('messages.news') }}"><i class="bi bi-newspaper"></i><span class="nav-label"> INNN</span></a>
         <a class="msg-tab msg-tab--action @if(request()->routeIs('messages.compose')) msg-tab--active @endif"
-           href="{{ route('messages.compose') }}">
-            <i class="bi bi-pencil-square"></i> Neue Nachricht
-        </a>
+           href="{{ route('messages.compose') }}"><i class="bi bi-pencil-square"></i><span class="nav-label"> Neue Nachricht</span></a>
     </nav>
 </div>
+
+{{-- Mobile: current tab name + dot indicators --}}
+@php
+$tabOrder = ['messages.inbox', 'messages.outbox', 'messages.archive', 'messages.events', 'messages.news'];
+$tabNames = ['Eingang', 'Ausgang', 'Archiv', 'Ereignisse', 'INNN'];
+$tabUrls  = [
+    route('messages.inbox'),
+    route('messages.outbox'),
+    route('messages.archive'),
+    route('messages.events'),
+    route('messages.news'),
+];
+$currentIdx = 0;
+foreach ($tabOrder as $i => $routeName) {
+    if (request()->routeIs($routeName)) { $currentIdx = $i; break; }
+}
+$prevUrl = $currentIdx > 0 ? $tabUrls[$currentIdx - 1] : null;
+$nextUrl = $currentIdx < count($tabUrls) - 1 ? $tabUrls[$currentIdx + 1] : null;
+@endphp
+
+<div class="msg-mobile-header">
+    <span class="msg-mobile-title">{{ $tabNames[$currentIdx] }}</span>
+    <div class="swipe-dots">
+        @foreach($tabNames as $i => $name)
+        <a href="{{ $tabUrls[$i] }}"
+           class="swipe-dot @if($i === $currentIdx) swipe-dot--active @endif"
+           title="{{ $name }}"></a>
+        @endforeach
+    </div>
+</div>
+
+@push('scripts')
+<script>
+(function () {
+    var prev = @json($prevUrl);
+    var next = @json($nextUrl);
+    if (!prev && !next) return;
+    var sx = 0, sy = 0;
+    window.addEventListener('touchstart', function (e) {
+        sx = e.touches[0].clientX;
+        sy = e.touches[0].clientY;
+    }, { passive: true });
+    window.addEventListener('touchend', function (e) {
+        var dx = e.changedTouches[0].clientX - sx;
+        var dy = e.changedTouches[0].clientY - sy;
+        if (Math.abs(dx) < 45 || Math.abs(dy) > Math.abs(dx)) return;
+        if (dx < 0 && next) { window.location.href = next; }
+        else if (dx > 0 && prev) { window.location.href = prev; }
+    }, { passive: true });
+}());
+</script>
+@endpush

--- a/resources/views/messages/partials/tabs.blade.php
+++ b/resources/views/messages/partials/tabs.blade.php
@@ -1,42 +1,31 @@
-<div class="row mb-3">
-    <div class="col-12">
-        <ul class="nav nav-tabs">
-            <li class="nav-item">
-                <a class="nav-link @if(request()->routeIs('messages.inbox')) active @endif"
-                   href="{{ route('messages.inbox') }}">
-                    <i class="bi bi-inbox"></i> Eingang
-                </a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link @if(request()->routeIs('messages.outbox')) active @endif"
-                   href="{{ route('messages.outbox') }}">
-                    <i class="bi bi-send"></i> Ausgang
-                </a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link @if(request()->routeIs('messages.archive')) active @endif"
-                   href="{{ route('messages.archive') }}">
-                    <i class="bi bi-archive"></i> Archiv
-                </a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link @if(request()->routeIs('messages.events')) active @endif"
-                   href="{{ route('messages.events') }}">
-                    <i class="bi bi-lightning-charge"></i> Ereignisse
-                </a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link @if(request()->routeIs('messages.news')) active @endif"
-                   href="{{ route('messages.news') }}">
-                    <i class="bi bi-newspaper"></i> INNN
-                </a>
-            </li>
-            <li class="nav-item ms-auto">
-                <a class="nav-link @if(request()->routeIs('messages.compose')) active @endif"
-                   href="{{ route('messages.compose') }}">
-                    <i class="bi bi-pencil-square"></i> Neue Nachricht
-                </a>
-            </li>
-        </ul>
-    </div>
+@push('styles')
+<link rel="stylesheet" href="{{ asset('css/messages.css') }}">
+@endpush
+<div class="msg-tabs-bar">
+    <nav class="msg-tabs">
+        <a class="msg-tab @if(request()->routeIs('messages.inbox')) msg-tab--active @endif"
+           href="{{ route('messages.inbox') }}">
+            <i class="bi bi-inbox"></i> Eingang
+        </a>
+        <a class="msg-tab @if(request()->routeIs('messages.outbox')) msg-tab--active @endif"
+           href="{{ route('messages.outbox') }}">
+            <i class="bi bi-send"></i> Ausgang
+        </a>
+        <a class="msg-tab @if(request()->routeIs('messages.archive')) msg-tab--active @endif"
+           href="{{ route('messages.archive') }}">
+            <i class="bi bi-archive"></i> Archiv
+        </a>
+        <a class="msg-tab @if(request()->routeIs('messages.events')) msg-tab--active @endif"
+           href="{{ route('messages.events') }}">
+            <i class="bi bi-lightning-charge"></i> Ereignisse
+        </a>
+        <a class="msg-tab @if(request()->routeIs('messages.news')) msg-tab--active @endif"
+           href="{{ route('messages.news') }}">
+            <i class="bi bi-newspaper"></i> INNN
+        </a>
+        <a class="msg-tab msg-tab--action @if(request()->routeIs('messages.compose')) msg-tab--active @endif"
+           href="{{ route('messages.compose') }}">
+            <i class="bi bi-pencil-square"></i> Neue Nachricht
+        </a>
+    </nav>
 </div>

--- a/resources/views/partials/res-popup.blade.php
+++ b/resources/views/partials/res-popup.blade.php
@@ -1,0 +1,14 @@
+{{--
+    Reusable chip popup.
+    Variables:
+      $popup_title  — bold heading (string)
+      $popup_desc   — one-sentence description (string)
+      $popup_extra  — optional extra HTML rows (raw, server-controlled only)
+--}}
+<div class="res-popup" x-show="$data.open ?? open" x-cloak>
+    <div class="res-popup-header">{{ $popup_title }}</div>
+    <div class="res-popup-body">{{ $popup_desc }}</div>
+    @if(!empty($popup_extra ?? null))
+        <div class="res-popup-extra">{!! $popup_extra !!}</div>
+    @endif
+</div>

--- a/resources/views/partials/sol-button.blade.php
+++ b/resources/views/partials/sol-button.blade.php
@@ -1,0 +1,103 @@
+{{--
+    Sol-Button partial — Alpine.js component.
+    Checks remaining AP before ending the Sol.
+    Shows confirm dialog if AP unspent, then shows loading overlay (min 5s).
+--}}
+<div
+    x-data="{
+        confirmOpen: false,
+        loading: false,
+        apData: null,
+
+        get hasAp() {
+            return this.apData && this.apData.total > 0;
+        },
+
+        get apSummary() {
+            if (!this.apData) return '';
+            const parts = [];
+            if (this.apData.construction > 0) parts.push(this.apData.construction + ' Bau-AP');
+            if (this.apData.research > 0)     parts.push(this.apData.research + ' Forschungs-AP');
+            if (this.apData.navigation > 0)   parts.push(this.apData.navigation + ' Nav-AP');
+            return parts.join(', ');
+        },
+
+        async handleClick() {
+            const resp = await fetch('{{ route('sol.remaining-ap') }}', {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            this.apData = await resp.json();
+
+            if (this.hasAp) {
+                this.confirmOpen = true;
+            } else {
+                await this.submitSol();
+            }
+        },
+
+        async submitSol() {
+            this.confirmOpen = false;
+            this.loading = true;
+
+            const minDuration = 5000;
+            const form = document.getElementById('sol-next-form');
+            const formData = new FormData(form);
+
+            try {
+                await Promise.all([
+                    fetch(form.action, {
+                        method: 'POST',
+                        body: formData,
+                        credentials: 'same-origin',
+                    }),
+                    new Promise(resolve => setTimeout(resolve, minDuration)),
+                ]);
+                // Always navigate to colony view — redirect()->back() is unreliable via fetch
+                window.location.href = '{{ route('colony.view') }}';
+            } catch (e) {
+                this.loading = false;
+                alert('Fehler beim Beenden des Sol. Bitte Seite neu laden.');
+            }
+        }
+    }"
+    style="display:inline-flex;align-items:center;"
+>
+    {{-- Sol form (hidden, submitted via fetch) --}}
+    <form id="sol-next-form" method="POST" action="{{ route('sol.next') }}" style="display:none;">
+        @csrf
+    </form>
+
+    {{-- Trigger button --}}
+    <button type="button" class="btn-sol" @click="handleClick">
+        <i class="bi bi-skip-forward-fill"></i> {{ __('colony.next_sol_button') }}
+    </button>
+
+    {{-- Confirm dialog overlay --}}
+    <div x-show="confirmOpen" x-cloak class="sol-overlay">
+        <div class="sol-dialog">
+            <h3 class="sol-dialog__title">Sol beenden?</h3>
+            <p class="sol-dialog__body">
+                Du hast noch nicht alle AP ausgegeben:
+                <strong x-text="apSummary"></strong>.
+            </p>
+            <p class="sol-dialog__body">Ungenutzte AP verfallen am Sol-Ende.</p>
+            <div class="sol-dialog__actions">
+                <button type="button" class="sol-btn sol-btn--ghost" @click="confirmOpen = false">
+                    Weiterspielen
+                </button>
+                <button type="button" class="sol-btn sol-btn--primary" @click="submitSol">
+                    Sol trotzdem beenden
+                </button>
+            </div>
+        </div>
+    </div>
+
+    {{-- Loading overlay --}}
+    <div x-show="loading" x-cloak class="sol-overlay sol-overlay--loading">
+        <div class="sol-loading">
+            <div class="sol-spinner"></div>
+            <p class="sol-loading__text">Sol wird berechnet …</p>
+            <p class="sol-loading__sub">Ereignisse, Produktion, Verfall</p>
+        </div>
+    </div>
+</div>

--- a/resources/views/resources/resourcebar.blade.php
+++ b/resources/views/resources/resourcebar.blade.php
@@ -1,10 +1,11 @@
-{{-- Resource bar partial (no layout) — replaces resources/json/reloadresourcebar.phtml --}}
-{{-- Server-side data dependency: $possessions — keyed by resource_id, each entry has: amount, abbreviation, name --}}
-{{-- Optional: $currentSol (int), $solLimit (int) — inject Sol chip before primary resources --}}
+{{-- Resource bar partial --}}
+{{-- $possessions: keyed by resource_id — amount, abbreviation, name --}}
+{{-- Optional: $currentSol, $solLimit, $nexusDebt, $nexusDebtMax --}}
 @auth
 @php
-    $primaryIds   = [1, 2, 12]; // Credits (Cr), Supply (Sup), Trust (M) — always shown
-    $activeResIds = [1, 2, 3, 4, 5, 12]; // whitelist — ENrg/LNrg/ANrg (6/8/10) excluded
+    // Trust (12) removed — shown in colony header as "Vertrauen", not duplicated here
+    $primaryIds   = [1, 2];           // Credits (Cr), Supply (Sup)
+    $activeResIds = [1, 2, 3, 4, 5]; // whitelist — Trust/ENrg/LNrg/ANrg excluded
     $primary      = [];
     $secondary    = [];
 
@@ -20,45 +21,99 @@
 
     ksort($primary);
 
-    $solDisplay = $currentSol ?? null; // composer already caps at solLimit
+    $solDisplay   = $currentSol ?? null;
+    $crResource   = $primary[1] ?? null;
+    $hasNexus     = isset($nexusDebt) && $nexusDebt !== null;
+    $nexusPct     = $hasNexus && ($nexusDebtMax ?? 12000) > 0
+        ? ($nexusDebt / ($nexusDebtMax ?? 12000)) * 100 : 0;
+    $nexusChipMod = match(true) {
+        $nexusPct >= 95 => 'res-chip--danger',
+        $nexusPct >= 80 => 'res-chip--warning',
+        default         => '',
+    };
+
+    // Popup extra for CR chip (NX info row)
+    $crPopupExtra = $hasNexus
+        ? '<div class="res-popup-nx-row ' . $nexusChipMod . '">'
+            . '<span class="res-popup-label">' . __('resources.popup_nx_title') . '</span>'
+            . '<span>' . number_format($nexusDebt, 0, ',', '.') . ' / ' . number_format($nexusDebtMax ?? 12000, 0, ',', '.') . ' Cr</span>'
+          . '</div>'
+        : null;
 @endphp
 <div class="res-bar-wrap d-flex flex-wrap gap-2 justify-content-center align-items-center resource-bar">
 
-    {{-- Sol chip: only shown when run-local Sol is meaningful (≤ solLimit) --}}
+    {{-- Sol chip: no border, no max --}}
     @if($solDisplay !== null)
-        <span class="res-chip res-chip--primary res-chip--sol res-Sol">
+        <span class="res-chip res-chip--sol" x-data="{ open: false }"
+              @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
+              style="position:relative;cursor:default">
             <span class="res-abbr">Sol</span>
-            <span class="res-amount">{{ $solDisplay }} / {{ $solLimit ?? 100 }}</span>
+            <span class="res-amount">{{ $solDisplay }}</span>
+            @include('partials.res-popup', [
+                'popup_title' => __('resources.popup_sol_title'),
+                'popup_desc'  => __('resources.popup_sol_desc'),
+            ])
         </span>
         <span class="res-divider" aria-hidden="true"></span>
     @endif
 
-    {{-- Primary resources: always visible, regardless of amount --}}
-    @foreach($primary as $resId => $resource)
-        <span class="res-chip res-chip--primary res-{{ $resource['abbreviation'] ?? 'x' }}"
-              data-bs-toggle="tooltip" data-bs-placement="bottom"
-              title="{{ __('resources.' . ($resource['name'] ?? '')) }}">
-            <span class="res-abbr">{{ $resource['abbreviation'] ?? '' }}</span>
-            <span class="res-amount">{{ number_format($resource['amount'] ?? 0, 0, ',', '.') }}</span>
+    {{-- Credits chip — NX shown in popup --}}
+    @if($crResource !== null)
+        <span class="res-chip res-Cr {{ $nexusChipMod }}" x-data="{ open: false }"
+              @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
+              style="position:relative;cursor:default">
+            <span class="res-abbr">CR</span>
+            <span class="res-amount">{{ number_format($crResource['amount'] ?? 0, 0, ',', '.') }}</span>
+            @include('partials.res-popup', [
+                'popup_title' => __('resources.popup_cr_title'),
+                'popup_desc'  => __('resources.popup_cr_desc'),
+                'popup_extra' => $crPopupExtra,
+            ])
         </span>
-    @endforeach
+    @endif
 
-    {{-- Visual separator between primary and secondary resources --}}
-    @if(count($secondary) > 0)
-        <span class="res-divider" aria-hidden="true"></span>
+    {{-- Supply chip --}}
+    @if(isset($primary[2]))
+        <span class="res-chip res-Sup" x-data="{ open: false }"
+              @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
+              style="position:relative;cursor:default">
+            <span class="res-abbr">SUP</span>
+            <span class="res-amount">{{ number_format($primary[2]['amount'] ?? 0, 0, ',', '.') }}</span>
+            @include('partials.res-popup', [
+                'popup_title' => __('resources.popup_sup_title'),
+                'popup_desc'  => __('resources.popup_sup_desc'),
+            ])
+        </span>
     @endif
 
     {{-- Secondary (tradeable) resources: only shown when amount > 0 --}}
-    @foreach($secondary as $resId => $resource)
-        @if(($resource['amount'] ?? 0) > 0)
-            <span class="res-chip res-{{ $resource['abbreviation'] ?? 'x' }}"
-                  data-bs-toggle="tooltip" data-bs-placement="bottom"
-                  title="{{ __('resources.' . ($resource['name'] ?? '')) }}">
-                <span class="res-abbr">{{ $resource['abbreviation'] ?? '' }}</span>
-                <span class="res-amount">{{ number_format($resource['amount'], 0, ',', '.') }}</span>
-            </span>
+    @if(count($secondary) > 0)
+        @php
+            $anySecondary = collect($secondary)->contains(fn($r) => ($r['amount'] ?? 0) > 0);
+            $popupKeyMap  = ['W' => 'w', 'O' => 'o', 'Rg' => 'rg'];
+        @endphp
+        @if($anySecondary)
+            <span class="res-divider" aria-hidden="true"></span>
+            @foreach($secondary as $resId => $resource)
+                @if(($resource['amount'] ?? 0) > 0)
+                    @php
+                        $abbr    = $resource['abbreviation'] ?? 'x';
+                        $langKey = 'popup_' . strtolower($abbr);
+                    @endphp
+                    <span class="res-chip res-{{ $abbr }}" x-data="{ open: false }"
+                          @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
+                          style="position:relative;cursor:default">
+                        <span class="res-abbr">{{ $abbr }}</span>
+                        <span class="res-amount">{{ number_format($resource['amount'], 0, ',', '.') }}</span>
+                        @include('partials.res-popup', [
+                            'popup_title' => __('resources.' . $langKey . '_title'),
+                            'popup_desc'  => __('resources.' . $langKey . '_desc'),
+                        ])
+                    </span>
+                @endif
+            @endforeach
         @endif
-    @endforeach
+    @endif
 
 </div>
 @endauth

--- a/resources/views/techtree/partials/techlevelup_bar.blade.php
+++ b/resources/views/techtree/partials/techlevelup_bar.blade.php
@@ -19,12 +19,10 @@
 <div class="progress ap_spend" style="height:20px;">
     @for($n = 1; $n <= $apTotal; $n++)
     @if($n <= $apSpend)
-        {{-- Already-invested segment — not interactive --}}
         <span class="progress-bar bg-success"
               style="width:{{ $widthPct }}%;"
               title="{{ $n }} / {{ $apTotal }} AP investiert">&nbsp;</span>
     @else
-        {{-- Remaining segment — clicking invests (n - ap_spend) AP in one go --}}
         @php $investAp = $n - $apSpend; @endphp
         <a id="{{ $type }}-{{ $techId }}|add-{{ $investAp }}"
            class="progress-bar bg-info{{ $apAvailable <= 0 ? ' disabled' : '' }}"
@@ -35,3 +33,14 @@
     @endif
     @endfor
 </div>
+@if($apAvailable <= 0 && $apSpend < $apTotal)
+    @php
+        $apHintKey = match($type) {
+            'research' => 'techtree.hint_no_research_ap',
+            default    => 'techtree.hint_no_construction_ap',
+        };
+    @endphp
+    <p class="text-muted small mt-1 mb-0">
+        <i class="bi bi-info-circle"></i> {{ __($apHintKey) }}
+    </p>
+@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -155,7 +155,8 @@ Route::middleware('auth')->prefix('advisors')->name('advisors.')->group(function
 
 // ── Sol (player-triggered tick advancement) ───────────────────────────────────
 
-Route::middleware('auth')->post('/sol/next', [SolController::class, 'next'])->name('sol.next');
+Route::middleware('auth')->post('/sol/next',        [SolController::class, 'next'])->name('sol.next');
+Route::middleware('auth')->get('/sol/remaining-ap', [SolController::class, 'remainingAp'])->name('sol.remaining-ap');
 
 // ── Techtree (Schritt 10) ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Zusammenfassung

- Design Guide erstellt (`docs/design-guide.md`) — verbindliche Referenz für Farben, Typo, Spacing, Komponenten
- Navbar auf helles Design migriert (beide Layouts), Libre Baskerville Logo
- Lobby-Fixes: dunkle Karte, Sol-Anzeige, Nav/Ressourcenleiste kontextbewusst
- Sol-Flow: AP-Check → Confirm-Dialog → 5s Ladescreen (`partials/sol-button.blade.php`)
- Ressourcen-Chip-Popups: wiederverwendbares Partial, alle Chips mit Beschreibungstext
- Supply-Kosten im Bau-Dialog sichtbar
- Techtree: Navlink in Colony-Layout, AP-Hinweis bei 0 AP, Hint-Route 404 gefixt
- Testdata Springfield: valider Sol-5-Stand (war Supply-Overflow 70>>26)
- `game:validate-colony` Artisan Command (Supply, Tick-Sanity, CC-Level)
- Messages-Screen auf `layouts.colony` migriert, Bootstrap-Accordion → Alpine
- `messages.css` als eigene Datei, `resources.css` nur für Ressourcen-Chips
- Swipe-Infrastruktur: `swipe.js` + `swipe.css` (swipeNav + swipeCarousel)
- Mobile: Hamburger-Menü < 600px, Sol-Button nur auf colony.view, Messages-Dots + Swipe
- CSS-Refactor: Design-Tokens in `:root`, `resources.css` extrahiert

## Kein Breaking Change

Alle bestehenden Screens funktionieren weiterhin. Nur visuelle + UX-Verbesserungen.

## Test plan

- [ ] Lobby: Sol-Anzeige korrekt, Nav ausgeblendet, Ressourcenleiste ausgeblendet
- [ ] Colony View: helle Navbar, Sol-Button Confirm-Dialog + 5s Ladescreen
- [ ] Berater / Techtree / Cantina: Navbar korrekt, Chip-Popups auf Hover
- [ ] Messages: Tabs auf Desktop, Dots + Swipe auf Mobile
- [ ] Mobile < 600px: Hamburger öffnet Flyout, Sol-Button nur auf Colony-View
- [ ] `php artisan game:validate-colony 1` → alle Checks grün
- [ ] `php artisan db:seed --class=TestSeeder` → sauberer Sol-5-Stand