### PR TITLE
fix(techtree): instanced building prerequisite check uses MAX(level)

### DIFF
--- a/app/Services/Techtree/AbstractTechnologyService.php
+++ b/app/Services/Techtree/AbstractTechnologyService.php
@@ -109,16 +109,16 @@ abstract class AbstractTechnologyService
             return true;
         }
 
-        $colonyBuilding = DB::table('colony_buildings')
+        $maxLevel = DB::table('colony_buildings')
             ->where('colony_id', $colonyId)
             ->where('building_id', $entity->required_building_id)
-            ->first();
+            ->max('level');
 
-        if (!$colonyBuilding) {
+        if ($maxLevel === null) {
             return false;
         }
 
-        return $colonyBuilding->level >= $entity->required_building_level;
+        return (int) $maxLevel >= (int) $entity->required_building_level;
     }
 
     /**

--- a/app/Services/Techtree/TechtreeColonyService.php
+++ b/app/Services/Techtree/TechtreeColonyService.php
@@ -85,6 +85,7 @@ class TechtreeColonyService
 
         $colonyEntities = DB::table($colonyTable)
             ->where('colony_id', $colonyId)
+            ->orderBy('level')  // for instanced buildings: highest-level instance wins keyBy
             ->get()
             ->keyBy($idKey)
             ->map(fn($e) => (array) $e)


### PR DESCRIPTION
## Problem

Instanzierte Gebäude (z.B. Wohnhabitat) können mehrere colony_buildings-Zeilen haben. `keyBy('building_id')` in TechtreeColonyService behielt einen zufälligen Eintrag — oft die level=0 In-progress-Instanz. `computeStatus` sah dann level=0 als Voraussetzung und setzte abhängige Gebäude (Cantina) auf \`locked\` — obwohl Wohnhabitat Lv1 gebaut war.

## Fix

- `TechtreeColonyService`: \`orderBy('level')\` ASC vor \`keyBy\` → höchste Level-Instanz überschreibt
- `AbstractTechnologyService::checkRequiredBuildingsByEntityId`: \`MAX(level)\` statt \`->first()\`

## Test plan

- [x] 23 Techtree-Tests grün
- [x] Playtest: zweites Wohnhabitat in progress → Cantina bleibt \`available\`