### PR TITLE
refactor: Moral → Trust/Vertrauen (vollständige Umbenennung)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-06-05
+
+- **Moral → Trust/Vertrauen**: Vollständige Umbenennung — `MoralService` → `TrustService`, `game.moral.*` → `game.trust.*`, `moral_per_lv` → `trust_per_lv`, DB-Tabelle `moral_events` → `trust_events`, Resource-Slug `res_moral` → `res_trust`, `lang/de/moral.php` → `trust.php`. CLAUDE.md aktualisiert. 759 Tests grün.
+- **GDD §2**: Tick-Phasen auf 5 Konzeptphasen komprimiert (Fleet / Decay / Supply & Ressourcen / Vertrauen / Beratung & Events). Detail-Reihenfolge in `GameTick.php`-Docblock als kanonische Quelle.
+- **GDD §13**: Burnout-Implementierungshinweis korrigiert — probabilistische Prüfung Phase 4+; `unavailable_until_tick` existiert bereits in DB.
+- **GDD §5**: Harvester-Produktionsrate — feste Rate `×10/level` dokumentiert (Phase 3); tile-abhängige Mechanik auf Phase 4+ verschoben.
+- **GDD §4a**: `terrain_fog` / `terrain_locked` als UI-Render-States dokumentiert (kein `tile_type` in DB — abgeleitet aus `is_explored` + `is_colony_zone`).
+- **Characters**: `informationsagent` → `information_broker` (Slug-Konsistenz; alle anderen Slugs englisch).
+
 ## 2026-06-04
 
 - **Docs-Review**: Vollständiger Audit aller `docs/`-Dateien. 21 Findings, 15 direkt behoben:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 **Spielkonzept:** Singleplayer Roguelike Mini-4X (FTL/Catan-Stil). Kleine, ressourcenarme Kolonie am Leben erhalten. Kein Imperiumsaufbau, keine Rassen, keine organisierten Kriege. Runs haben konkretes Ziel + klares Ende.
 
-**Abgeschlossen:** ZF2 → Laminas → Laravel Migration, Techtree-Redesign, Tick-System, AP-System, Berater-System, Flottenoperationen, Decay-System, Moralsystem, Supply-System, INNN-Nachrichten, Hex-Grid Kolonieansicht, Systemkarte, Reisender Händler, jQuery-Migration (vollständig), Berater-Screen (Alpine.js + PicoCSS), Onboarding-System (Triggers + Hints-Bar), Run-System, Lobby/Runs-Übersicht, Debug-Statusleiste (Admin), Fleet Command Overlay (Systemkarte), Kommandanten-Zuweisung (Fleet, PR #139), Ressourcen-DB-Cleanup (ENrg/LNrg/ANrg entfernt).
+**Abgeschlossen:** ZF2 → Laminas → Laravel Migration, Techtree-Redesign, Tick-System, AP-System, Berater-System, Flottenoperationen, Decay-System, Trust-System (Vertrauen), Supply-System, INNN-Nachrichten, Hex-Grid Kolonieansicht, Systemkarte, Reisender Händler, jQuery-Migration (vollständig), Berater-Screen (Alpine.js + PicoCSS), Onboarding-System (Triggers + Hints-Bar), Run-System, Lobby/Runs-Übersicht, Debug-Statusleiste (Admin), Fleet Command Overlay (Systemkarte), Kommandanten-Zuweisung (Fleet, PR #139), Ressourcen-DB-Cleanup (ENrg/LNrg/ANrg entfernt).
 
 **Laufend (Phase 3):** UI-Migration Bootstrap 5 → Alpine.js + PicoCSS. Ausstehend: GDD-Cleanup (Balance-TODOs nach Playtest), Onboarding-Wizard (Triggers + Hints implementiert, kein dedizierter New-Player-Flow), Cantina-Redesign (Bar-Hintergrund + NPC-Charaktere geplant).
 
@@ -30,7 +30,7 @@
 ```
 app/
   Http/Controllers/   -- Route Handler (Techtree, Colony, Fleet, INNN, ...)
-  Services/           -- Game Logic (TickService, MoralService, AdvisorService, ...)
+  Services/           -- Game Logic (TickService, TrustService, AdvisorService, ...)
   Models/             -- Eloquent Models
   Console/Commands/   -- game:tick, game:sync-techs
 config/
@@ -54,7 +54,8 @@ Schichtung: `Controller → Service → Eloquent Model → SQLite`
 - Legacy-Screens: noch Bootstrap 5 — werden schrittweise auf Alpine.js + PicoCSS migriert (jQuery vollständig entfernt)
 - `TestSeeder` führt `data/sql/testdata.sqlite.sql` aus (regex-filtered: nur INSERT/UPDATE Statements)
 - Techtree-Koordinaten phase-lokal (Zeile/Spalte innerhalb Phase), nicht global
-- Moral-Events: Keys `encounter_won`, `encounter_lost`, `colony_threatened` (nicht `combat_*`)
+- Trust-Events (`game.trust.*`): Keys `encounter_won`, `encounter_lost`, `colony_threatened` (nicht `combat_*`)
+- `moral` in Code, Config und DB ist vollständig zu `trust` umbenannt; deutscher UI-Label ist `Vertrauen` (via `__('resources.res_trust')`)
 
 ## Grafik-Assets
 

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -17,7 +17,7 @@ use App\Models\UserResource;
 use App\Services\BarService;
 use App\Services\EventService;
 use App\Services\MerchantService;
-use App\Services\MoralService;
+use App\Services\TrustService;
 use App\Services\OnboardingTriggerService;
 use App\Services\ResourcesService;
 use App\Services\TickService;
@@ -40,7 +40,7 @@ use Illuminate\Support\Facades\DB;
  *  6. Research decay      — decrement colony_researches.status_points; level-down at ≤ 0
  *  7. Supply cap          — SET user_resources.supply = CC_flat + housing_level × 8 (cap model)
  *  8. Resource generation — produce colony resources per industry building level (moral multiplier applied)
- *  8b. Moral calculation  — recalculate colony moral and store in colony_resources (resource_id=12)
+ *  8b. Trust calculation  — recalculate colony trust and store in colony_resources (resource_id=12)
  *  8c. Passive Credits    — Nexus subsidy (30 Cr) + colony tax per housing level (20 Cr/level) added to user Credits
  *  8d. Advisor upkeep     — deduct Credits per active advisor by rank (10/50/160 Cr); clamped to ≥ 0
  *  9. Advisor ticks       — increment active_ticks, check rank promotions
@@ -60,7 +60,7 @@ class GameTick extends Command
     public function __construct(
         private readonly TickService               $tickService,
         private readonly EventService              $eventService,
-        private readonly MoralService              $moralService,
+        private readonly TrustService              $trustService,
         private readonly ResourcesService          $resourcesService,
         private readonly OnboardingTriggerService  $onboardingTriggerService,
         private readonly BarService                $barService,
@@ -126,8 +126,8 @@ class GameTick extends Command
             $n = $this->generateResources($tick);
             $this->line("  Colonies with resources:  {$n}");
 
-            $n = $this->calculateMoral($tick);
-            $this->line("  Colonies moral updated:   {$n}");
+            $n = $this->calculateTrust($tick);
+            $this->line("  Colonies trust updated:   {$n}");
 
             $n = $this->generatePassiveCredits($tick);
             $this->line("  Users passive credits:    {$n}");
@@ -415,7 +415,7 @@ class GameTick extends Command
 
             $initiatorColonyId = $this->getColonyIdByUserId($initiator->user_id);
             if ($initiatorColonyId) {
-                $this->moralService->fireEvent(
+                $this->trustService->fireEvent(
                     $initiatorColonyId,
                     $initiatorPower >= $encounteredPower ? 'encounter_won' : 'encounter_lost',
                     $tick
@@ -438,8 +438,8 @@ class GameTick extends Command
 
                 $encounteredColonyId = $this->getColonyIdByUserId($encFleet->user_id);
                 if ($encounteredColonyId) {
-                    $this->moralService->fireEvent($encounteredColonyId, 'colony_threatened', $tick);
-                    $this->moralService->fireEvent(
+                    $this->trustService->fireEvent($encounteredColonyId, 'colony_threatened', $tick);
+                    $this->trustService->fireEvent(
                         $encounteredColonyId,
                         $encounteredPower >= $initiatorPower ? 'encounter_won' : 'encounter_lost',
                         $tick
@@ -776,10 +776,10 @@ class GameTick extends Command
         $colonies = Colony::all();
 
         foreach ($colonies as $colony) {
-            // Apply moral production multiplier based on the colony's CURRENT moral
-            // (stored from the previous tick's moral calculation — no circular dependency).
-            $moral      = $this->moralService->getMoral($colony->id);
-            $multiplier = $this->moralService->getProductionMultiplier($moral);
+            // Apply trust production multiplier based on the colony's CURRENT trust
+            // (stored from the previous tick's trust calculation — no circular dependency).
+            $trust      = $this->trustService->getTrust($colony->id);
+            $multiplier = $this->trustService->getProductionMultiplier($trust);
 
             foreach ($productionConfig as $buildingId => $outputs) {
                 $building = DB::table('colony_buildings')
@@ -803,9 +803,9 @@ class GameTick extends Command
         return $colonies->count();
     }
 
-    // ── 8b. Moral calculation ─────────────────────────────────────────────────
+    // ── 8b. Trust calculation ─────────────────────────────────────────────────
 
-    private function calculateMoral(int $tick): int
+    private function calculateTrust(int $tick): int
     {
         $colonies = Colony::all();
 
@@ -821,7 +821,7 @@ class GameTick extends Command
                     ->value('amount') ?? 0);
             }
 
-            $this->moralService->calculateAndStore($colony, $tick);
+            $this->trustService->calculateAndStore($colony, $tick);
 
             if ($userId !== null && $trustBefore !== null && $trustBefore >= 0) {
                 $trustAfter = (int) (DB::table('colony_resources')

--- a/app/Console/Commands/GameTickDryRun.php
+++ b/app/Console/Commands/GameTickDryRun.php
@@ -2,7 +2,7 @@
 
 namespace App\Console\Commands;
 
-use App\Services\MoralService;
+use App\Services\TrustService;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
@@ -18,7 +18,7 @@ class GameTickDryRun extends Command
     protected $signature   = 'game:tick-dry-run {--colony= : Limit output to a single colony ID}';
     protected $description = 'Simulate one game tick and show a resource/decay diff (no DB writes)';
 
-    public function __construct(private readonly MoralService $moralService)
+    public function __construct(private readonly TrustService $trustService)
     {
         parent::__construct();
     }
@@ -140,8 +140,8 @@ class GameTickDryRun extends Command
             ->pluck('amount', 'resource_id');
 
         $production = config('game.production', []);
-        $moral      = $this->moralService->getMoral($cid);
-        $multiplier = $this->moralService->getProductionMultiplier($moral);
+        $moral      = $this->trustService->getTrust($cid);
+        $multiplier = $this->trustService->getProductionMultiplier($moral);
 
         $resNames = [3 => 'Regolith', 4 => 'Werkstoffe', 5 => 'Organika'];
         $this->line('  Resources:');
@@ -161,10 +161,10 @@ class GameTickDryRun extends Command
             $this->line(sprintf('    %-14s %6d → %6d  (%s)', $rname . ':', $cur, $new, $yieldStr));
         }
 
-        $moralColor = $moral >= 0 ? 'green' : 'red';
+        $trustColor = $moral >= 0 ? 'green' : 'red';
         $this->line(sprintf(
-            '    Moral:        <fg=%s>%d</> (production ×%.2f)',
-            $moralColor, $moral, $multiplier
+            '    Trust:        <fg=%s>%d</> (production ×%.2f)',
+            $trustColor, $moral, $multiplier
         ));
 
         // ── Building decay ────────────────────────────────────────────────

--- a/app/Http/Controllers/LobbyController.php
+++ b/app/Http/Controllers/LobbyController.php
@@ -129,7 +129,7 @@ class LobbyController extends Controller
                 ['resource_id' => 3,  'colony_id' => $colonyId, 'amount' => 200], // regolith
                 ['resource_id' => 4,  'colony_id' => $colonyId, 'amount' => 0],   // werkstoffe
                 ['resource_id' => 5,  'colony_id' => $colonyId, 'amount' => 0],   // organika
-                ['resource_id' => 12, 'colony_id' => $colonyId, 'amount' => 0],   // moral/trust
+                ['resource_id' => 12, 'colony_id' => $colonyId, 'amount' => 0],   // trust
             ]);
 
             // Reset user-level resources (credits + supply).

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * Eloquent model for the `resources` table — resource type definitions.
- * (9 types: credits, supply, water, ferum, silicates, ena, lho, aku, moral)
+ * (9 types: credits, supply, water, ferum, silicates, ena, lho, aku, trust)
  */
 class Resource extends Model
 {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,7 +7,7 @@ use App\Services\EventService;
 use App\Services\GalaxyService;
 use App\Services\MerchantService;
 use App\Services\MessageService;
-use App\Services\MoralService;
+use App\Services\TrustService;
 use App\Services\ResourcesService;
 use App\Services\Techtree\BuildingService;
 use App\Services\Techtree\PersonellService;
@@ -55,12 +55,12 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(GalaxyService::class, GalaxyService::class);
         $this->app->bind(MessageService::class, MessageService::class);
         $this->app->bind(ResourcesService::class, ResourcesService::class);
-        $this->app->bind(MoralService::class, fn($app) => new MoralService(
+        $this->app->bind(TrustService::class, fn($app) => new TrustService(
             $app->make(TickService::class),
         ));
         $this->app->bind(TradeGateway::class, fn($app) => new TradeGateway(
             $app->make(ColonyService::class),
-            $app->make(MoralService::class),
+            $app->make(TrustService::class),
             $app->make(PersonellService::class),
         ));
         $this->app->bind(FleetService::class, FleetService::class);
@@ -68,7 +68,7 @@ class AppServiceProvider extends ServiceProvider
         // Techtree services
         $this->app->bind(PersonellService::class, fn($app) => new PersonellService(
             $app->make(TickService::class),
-            $app->make(MoralService::class),
+            $app->make(TrustService::class),
             $app->make(ResourcesService::class),
         ));
         $this->app->bind(BuildingService::class, fn($app) => new BuildingService(

--- a/app/Services/OnboardingHintService.php
+++ b/app/Services/OnboardingHintService.php
@@ -235,7 +235,7 @@ class OnboardingHintService
     }
 
     /**
-     * Hint 5: Colony moral/trust (resource_id=12) is below the trust threshold AND
+     * Hint 5: Colony trust (resource_id=12) is below the trust threshold AND
      *         current tick >= hint_trust_min_ticks threshold.
      */
     private function checkHint5(int $colonyId, int $currentTick): bool

--- a/app/Services/OnboardingService.php
+++ b/app/Services/OnboardingService.php
@@ -77,7 +77,7 @@ class OnboardingService
             ['resource_id' => 3,  'colony_id' => $colonyId, 'amount' => 200],  // regolith
             ['resource_id' => 4,  'colony_id' => $colonyId, 'amount' => 0],    // werkstoffe — produced by harvester
             ['resource_id' => 5,  'colony_id' => $colonyId, 'amount' => 0],    // organika  — produced by bioFacility
-            ['resource_id' => 12, 'colony_id' => $colonyId, 'amount' => 0],    // moral
+            ['resource_id' => 12, 'colony_id' => $colonyId, 'amount' => 0],    // trust
         ];
 
         DB::table('colony_resources')->insert($colonyResources);

--- a/app/Services/ResourcesService.php
+++ b/app/Services/ResourcesService.php
@@ -16,7 +16,7 @@ use RuntimeException;
  * ResourcesService — Laravel port of Resources\Service\ResourcesService.
  *
  * Manages the 9 resource types (credits, supply, water, ferum, silicates,
- * ena, lho, aku, moral). Credits and supply are stored in user_resources
+ * ena, lho, aku, trust). Credits and supply are stored in user_resources
  * (user-level); the remaining 7 are stored in colony_resources.
  */
 class ResourcesService

--- a/app/Services/RunProgressService.php
+++ b/app/Services/RunProgressService.php
@@ -188,7 +188,7 @@ class RunProgressService
     /**
      * Evaluate and persist progress for every open objective of the given run.
      *
-     * Called once per tick, after resource generation and moral recalculation.
+     * Called once per tick, after resource generation and trust recalculation.
      */
     public function updateObjectiveProgress(Run $run): void
     {

--- a/app/Services/Techtree/PersonellService.php
+++ b/app/Services/Techtree/PersonellService.php
@@ -4,7 +4,7 @@ namespace App\Services\Techtree;
 
 use App\Models\Advisor;
 use App\Services\Concerns\ValidatesId;
-use App\Services\MoralService;
+use App\Services\TrustService;
 use App\Services\ResourcesService;
 use App\Services\TickService;
 use Illuminate\Support\Collection;
@@ -45,7 +45,7 @@ class PersonellService
 
     public function __construct(
         private readonly TickService      $tickService,
-        private readonly MoralService     $moralService,
+        private readonly TrustService     $trustService,
         private readonly ResourcesService $resourcesService,
     ) {}
 
@@ -64,9 +64,9 @@ class PersonellService
             ->get()
             ->sum(fn(Advisor $a) => $a->getApPerTick());
 
-        // Apply moral AP multiplier for colony-scoped types.
-        $moral      = $this->moralService->getMoral($scopeId);
-        $multiplier = $this->moralService->getApMultiplier($moral);
+        // Apply trust AP multiplier for colony-scoped types.
+        $trust      = $this->trustService->getTrust($scopeId);
+        $multiplier = $this->trustService->getApMultiplier($trust);
         return (int) round($baseAp * $multiplier);
     }
 

--- a/app/Services/TradeGateway.php
+++ b/app/Services/TradeGateway.php
@@ -3,7 +3,7 @@
 namespace App\Services;
 
 use App\Models\TradeResourceView;
-use App\Services\MoralService;
+use App\Services\TrustService;
 use App\Services\Techtree\PersonellService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -34,7 +34,7 @@ class TradeGateway
 {
     public function __construct(
         private readonly ColonyService    $colonyService,
-        private readonly MoralService     $moralService,
+        private readonly TrustService     $trustService,
         private readonly PersonellService $personellService,
     ) {}
 
@@ -355,9 +355,9 @@ class TradeGateway
                 $this->personellService->lockActionPoints('economy', $buyerColonyId, 1);
             }
 
-            // 7b. Fire moral events for both parties (scheduled for next tick).
-            $this->moralService->fireEvent($buyerColonyId,  'trade_success');
-            $this->moralService->fireEvent($sellerColonyId, 'trade_success');
+            // 7b. Fire trust events for both parties (scheduled for next tick).
+            $this->trustService->fireEvent($buyerColonyId,  'trade_success');
+            $this->trustService->fireEvent($sellerColonyId, 'trade_success');
 
             // 8. Delete the offer
             DB::table('trade_resources')

--- a/app/Services/TrustService.php
+++ b/app/Services/TrustService.php
@@ -7,13 +7,13 @@ use App\Services\TickService;
 use Illuminate\Support\Facades\DB;
 
 /**
- * MoralService — calculates and stores colony moral.
+ * TrustService — calculates and stores colony trust.
  *
- * Moral ranges from -100 to +100 (neutral = 0, start = 0).
+ * Trust ranges from -100 to +100 (neutral = 0, start = 0).
  * It is recalculated every tick from static factors (buildings, researches, ships)
- * and one-shot events (stored in moral_events for the current tick).
+ * and one-shot events (stored in trust_events for the current tick).
  *
- * Stored in colony_resources.amount WHERE resource_id = 12 (res_moral).
+ * Stored in colony_resources.amount WHERE resource_id = 12 (res_trust).
  *
  * Bands:
  *   +61 .. +100  Euphorisch
@@ -28,9 +28,9 @@ use Illuminate\Support\Facades\DB;
  *
  * See GDD §13 for full design documentation.
  */
-class MoralService
+class TrustService
 {
-    /** Fallback if config('game.moral.resource_id') is not set. */
+    /** Fallback if config('game.trust.resource_id') is not set. */
     public const RESOURCE_ID = 12;
 
     public function __construct(
@@ -40,40 +40,40 @@ class MoralService
     // ── Calculation ───────────────────────────────────────────────────────────
 
     /**
-     * Calculate moral for a colony and persist it in colony_resources.
+     * Calculate trust for a colony and persist it in colony_resources.
      * Called by GameTick step 8b (after resource generation).
      */
     public function calculateAndStore(Colony $colony, int $tick): int
     {
-        $moral = $this->calculateMoral($colony->id, $tick);
+        $trust = $this->calculateTrust($colony->id, $tick);
 
         DB::table('colony_resources')->updateOrInsert(
             ['colony_id' => $colony->id, 'resource_id' => $this->resourceId()],
-            ['amount' => $moral]
+            ['amount' => $trust]
         );
 
-        return $moral;
+        return $trust;
     }
 
     /**
-     * Calculate raw moral value for a colony at the given tick.
+     * Calculate raw trust value for a colony at the given tick.
      * Does NOT persist the result.
      */
-    public function calculateMoral(int $colonyId, int $tick): int
+    public function calculateTrust(int $colonyId, int $tick): int
     {
-        $moral = 0;
-        $moral += $this->buildingContribution($colonyId);
-        $moral += $this->researchContribution($colonyId);
-        $moral += $this->shipContribution($colonyId);
-        $moral += $this->eventContribution($colonyId, $tick);
+        $trust = 0;
+        $trust += $this->buildingContribution($colonyId);
+        $trust += $this->researchContribution($colonyId);
+        $trust += $this->shipContribution($colonyId);
+        $trust += $this->eventContribution($colonyId, $tick);
 
-        return max(-100, min(100, $moral));
+        return max(-100, min(100, $trust));
     }
 
     /**
-     * Read the current stored moral for a colony (-100..+100).
+     * Read the current stored trust for a colony (-100..+100).
      */
-    public function getMoral(int $colonyId): int
+    public function getTrust(int $colonyId): int
     {
         $row = DB::table('colony_resources')
             ->where('colony_id', $colonyId)
@@ -85,62 +85,62 @@ class MoralService
 
     private function resourceId(): int
     {
-        return (int) config('game.moral.resource_id', self::RESOURCE_ID);
+        return (int) config('game.trust.resource_id', self::RESOURCE_ID);
     }
 
     // ── Multipliers ───────────────────────────────────────────────────────────
 
     /**
-     * Return the production multiplier for the given moral value.
+     * Return the production multiplier for the given trust value.
      */
-    public function getProductionMultiplier(int $moral): float
+    public function getProductionMultiplier(int $trust): float
     {
-        return $this->lookupMultiplier($moral, 'production_multiplier');
+        return $this->lookupMultiplier($trust, 'production_multiplier');
     }
 
     /**
-     * Return the AP multiplier for the given moral value.
+     * Return the AP multiplier for the given trust value.
      */
-    public function getApMultiplier(int $moral): float
+    public function getApMultiplier(int $trust): float
     {
-        return $this->lookupMultiplier($moral, 'ap_multiplier');
+        return $this->lookupMultiplier($trust, 'ap_multiplier');
     }
 
     /**
-     * Return the display name of the moral band.
+     * Return the display name of the trust band.
      */
-    public function getBand(int $moral): string
+    public function getBand(int $trust): string
     {
-        if ($moral >= 61)  return __('moral.band_euphorisch');
-        if ($moral >= 21)  return __('moral.band_zufrieden');
-        if ($moral >= -20) return __('moral.band_stabil');
-        if ($moral >= -61) return __('moral.band_unruhig');
-        return __('moral.band_aufruhr');
+        if ($trust >= 61)  return __('trust.band_euphorisch');
+        if ($trust >= 21)  return __('trust.band_zufrieden');
+        if ($trust >= -20) return __('trust.band_stabil');
+        if ($trust >= -61) return __('trust.band_unruhig');
+        return __('trust.band_aufruhr');
     }
 
     // ── Events ────────────────────────────────────────────────────────────────
 
     /**
-     * Fire a moral event for a colony.
+     * Fire a trust event for a colony.
      *
-     * Events are one-shot: they contribute to exactly one tick's moral calculation.
+     * Events are one-shot: they contribute to exactly one tick's trust calculation.
      * For events fired outside the tick cycle (e.g. from controllers), use the
      * next tick so they are picked up at the next recalculation.
      *
      * @param  int    $colonyId
-     * @param  string $eventType  Key from config('game.moral.events')
+     * @param  string $eventType  Key from config('game.trust.events')
      * @param  int|null $tick     Defaults to current tick + 1 (for out-of-tick callers).
      *                            Pass current tick when called from within GameTick.
      */
     public function fireEvent(int $colonyId, string $eventType, ?int $tick = null): void
     {
-        if (!array_key_exists($eventType, config('game.moral.events', []))) {
+        if (!array_key_exists($eventType, config('game.trust.events', []))) {
             return; // unknown event type — silently ignore
         }
 
         $tick ??= $this->tickService->getTickCount() + 1;
 
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => $colonyId,
             'tick'       => $tick,
             'event_type' => $eventType,
@@ -151,8 +151,8 @@ class MoralService
 
     private function buildingContribution(int $colonyId): int
     {
-        // Build [id => moral_per_lv] map from config/buildings.php
-        $cfg = collect(config('buildings', []))->pluck('moral_per_lv', 'id')->filter()->toArray();
+        // Build [id => trust_per_lv] map from config/buildings.php
+        $cfg = collect(config('buildings', []))->pluck('trust_per_lv', 'id')->filter()->toArray();
         if (empty($cfg)) {
             return 0;
         }
@@ -172,8 +172,8 @@ class MoralService
 
     private function researchContribution(int $colonyId): int
     {
-        // Build [id => moral_per_lv] map from config/knowledge.php
-        $cfg = collect(config('knowledge', []))->pluck('moral_per_lv', 'id')->filter()->toArray();
+        // Build [id => trust_per_lv] map from config/knowledge.php
+        $cfg = collect(config('knowledge', []))->pluck('trust_per_lv', 'id')->filter()->toArray();
         if (empty($cfg)) {
             return 0;
         }
@@ -192,8 +192,8 @@ class MoralService
 
     private function shipContribution(int $colonyId): int
     {
-        // Build [id => moral_per_unit] map from config/ships.php
-        $cfg = collect(config('ships', []))->pluck('moral_per_unit', 'id')->filter()->toArray();
+        // Build [id => trust_per_unit] map from config/ships.php
+        $cfg = collect(config('ships', []))->pluck('trust_per_unit', 'id')->filter()->toArray();
         if (empty($cfg)) {
             return 0;
         }
@@ -208,7 +208,7 @@ class MoralService
             $sum += ($cfg[$s->ship_id] ?? 0) * $s->level;
         }
 
-        $cap = (int) config('game.moral.ships_cap', 30);
+        $cap = (int) config('game.trust.ships_cap', 30);
         return max(-$cap, min($cap, $sum));
     }
 
@@ -218,12 +218,12 @@ class MoralService
      */
     private function eventContribution(int $colonyId, int $tick): int
     {
-        $cfg = config('game.moral.events', []);
+        $cfg = config('game.trust.events', []);
         if (empty($cfg)) {
             return 0;
         }
 
-        $events = DB::table('moral_events')
+        $events = DB::table('trust_events')
             ->where('colony_id', $colonyId)
             ->where('tick', $tick)
             ->pluck('event_type');
@@ -240,10 +240,10 @@ class MoralService
         return array_sum($byType);
     }
 
-    private function lookupMultiplier(int $moral, string $configKey): float
+    private function lookupMultiplier(int $trust, string $configKey): float
     {
-        foreach (config("game.moral.{$configKey}", []) as $band) {
-            if ($moral >= $band['min'] && $moral <= $band['max']) {
+        foreach (config("game.trust.{$configKey}", []) as $band) {
+            if ($trust >= $band['min'] && $trust <= $band['max']) {
                 return (float) $band['factor'];
             }
         }

--- a/config/advisors.php
+++ b/config/advisors.php
@@ -7,7 +7,7 @@
  *   id           — DB primary key in `personell` table
  *   ap_type      — which action-point pool this advisor fills
  *                  'construction' | 'research' | 'navigation' | 'economy' | 'strategy'
- *   moral_per_unit — moral change per active advisor (minor effects)
+ *   trust_per_unit — trust change per active advisor (minor effects)
  *   credits      — hire cost in credits
  *
  * Advisors do NOT consume Supply — their cost runs through Credits only (see GDD §12).
@@ -22,35 +22,35 @@ return [
     'engineer' => [
         'id'             => 35,
         'ap_type'        => 'construction',
-        'moral_per_unit' => 0,
+        'trust_per_unit' => 0,
         'credits'        => 300,    // critical for early building — first hire
     ],
 
     'scientist' => [
         'id'             => 36,
         'ap_type'        => 'research',
-        'moral_per_unit' => 0,
+        'trust_per_unit' => 0,
         'credits'        => 400,
     ],
 
     'pilot' => [
         'id'             => 89,
         'ap_type'        => 'navigation',
-        'moral_per_unit' => 0,
+        'trust_per_unit' => 0,
         'credits'        => 500,    // fleet-focused, later priority
     ],
 
     'trader' => [
         'id'             => 92,
         'ap_type'        => 'economy',
-        'moral_per_unit' => 0,
+        'trust_per_unit' => 0,
         'credits'        => 350,
     ],
 
     'strategist' => [
         'id'             => 93,
         'ap_type'        => 'strategy',
-        'moral_per_unit' => 0,
+        'trust_per_unit' => 0,
         'credits'        => 600,    // military/strategy — typically late-game hire
     ],
 

--- a/config/buildings.php
+++ b/config/buildings.php
@@ -7,7 +7,7 @@
  *   id               — DB primary key in `buildings` table
  *   supply_cap       — flat supply cap granted (commandCenter) or per-unit cap (housingComplex)
  *   supply_cost      — supply consumed while the building exists at level > 0
- *   moral_per_lv     — moral change per building level (used by MoralService)
+ *   trust_per_lv     — trust change per building level (used by TrustService)
  *   decay_rate       — status_points lost per tick (also stored in DB, used by GameTick decay)
  *   max_status_points — status_points reset value after level-down (also stored in DB)
  *   max_level        — hard level cap (null = uncapped, practically limited by supply)
@@ -29,7 +29,7 @@ return [
         'id'                => 25,
         'supply_cap'        => 10,      // cap per level (CC Lv1 = 10, Lv5 = 50 — hard cap Lv5)
         'supply_cost'       => 0,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.33,    // 60 days
         'max_status_points' => 20,
         'max_level'         => 5,
@@ -39,7 +39,7 @@ return [
         'id'                => 28,
         'supply_cap'        => 8,       // per unit (instance), max 6 units → +48 cap
         'supply_cost'       => 0,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.44,    // 45 days
         'max_status_points' => 20,
         'max_level'         => 6,       // max 6 instances (instanced building)
@@ -50,7 +50,7 @@ return [
     'harvester' => [                    // ex industrieMine/oremine (ID 27) — produces Regolith (resource 3)
         'id'                => 27,
         'supply_cost'       => 2,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.95,    // 21 days
         'max_status_points' => 20,
         'max_level'         => null,
@@ -59,7 +59,7 @@ return [
     'bioFacility' => [                  // ex silicatemine (ID 41) — now produces Organika
         'id'                => 41,
         'supply_cost'       => 2,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.95,
         'max_status_points' => 20,
         'max_level'         => null,
@@ -68,7 +68,7 @@ return [
     'depot' => [
         'id'                => 30,
         'supply_cost'       => 3,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.67,    // 30 days
         'max_status_points' => 20,
         'max_level'         => null,
@@ -79,7 +79,7 @@ return [
     'sciencelab' => [
         'id'                => 31,
         'supply_cost'       => 8,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.95,    // 21 days
         'max_status_points' => 20,
         'max_level'         => null,
@@ -90,7 +90,7 @@ return [
     'hangar' => [                       // replaces civilianSpaceyard + militarySpaceyard
         'id'                => 44,      // ex civilianSpaceyard — 1 hangar = 1 ship slot
         'supply_cost'       => 12,      // limits fleet naturally: 3 hangars = 36 supply
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.67,    // 30 days
         'max_status_points' => 20,
         'max_level'         => null,    // repeatable, supply-limited
@@ -101,7 +101,7 @@ return [
     'infirmary' => [
         'id'                => 46,
         'supply_cost'       => 10,
-        'moral_per_lv'      => 3,
+        'trust_per_lv'      => 3,
         'decay_rate'        => 0.67,    // 30 days — core infrastructure, same tier as depot/hangar
         'max_status_points' => 20,
         'max_level'         => null,
@@ -110,7 +110,7 @@ return [
     'bar' => [
         'id'                => 52,
         'supply_cost'       => 4,
-        'moral_per_lv'      => 2,       // social hub — leisure in an otherwise bleak colony life
+        'trust_per_lv'      => 2,       // social hub — leisure in an otherwise bleak colony life
         'decay_rate'        => 1.0,     // 20 days — sturdy enough, but needs occasional maintenance
         'max_status_points' => 20,
         'max_level'         => null,
@@ -119,7 +119,7 @@ return [
     'monument' => [
         'id'                => 50,
         'supply_cost'       => 2,
-        'moral_per_lv'      => 2,
+        'trust_per_lv'      => 2,
         'decay_rate'        => 0.33,    // 60 days — monuments are built to last
         'max_status_points' => 20,
         'max_level'         => null,
@@ -128,7 +128,7 @@ return [
     'temple' => [
         'id'                => 32,
         'supply_cost'       => 4,
-        'moral_per_lv'      => 2,
+        'trust_per_lv'      => 2,
         'decay_rate'        => 2.0,     // 10 days — needs regular upkeep
         'max_status_points' => 20,
         'max_level'         => null,
@@ -144,7 +144,7 @@ return [
     'securityHub' => [
         'id'                  => 53,
         'supply_cost'         => 8,
-        'moral_per_lv'        => 0,
+        'trust_per_lv'        => 0,
         'decay_rate'          => 0.67,    // 30 days — provisional
         'max_status_points'   => 20,
         'max_level'           => 3,
@@ -160,7 +160,7 @@ return [
     'uplinkStation' => [
         'id'                => 54,
         'supply_cost'       => 6,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0.67,    // 30 days — provisional
         'max_status_points' => 20,
         'max_level'         => 3,
@@ -173,7 +173,7 @@ return [
     'tradingPost' => [
         'id'                   => 55,
         'supply_cost'          => 6,
-        'moral_per_lv'         => 0,
+        'trust_per_lv'         => 0,
         'decay_rate'           => 0.67,    // 30 days — provisional
         'max_status_points'    => 20,
         'max_level'            => 3,

--- a/config/characters.php
+++ b/config/characters.php
@@ -3,7 +3,7 @@
 return [
     'bartender'        => ['name' => 'Tomas',  'role' => 'Bartender'],
     'smuggler'         => ['name' => 'Dax',    'role' => 'Smuggler'],
-    'informationsagent'=> ['name' => 'Vesper', 'role' => 'Information Broker'],
+    'information_broker'=> ['name' => 'Vesper', 'role' => 'Information Broker'],
     'mechanic'         => ['name' => 'Sarka',  'role' => 'Exhausted Mechanic'],
     'corporate_rep'    => ['name' => 'Orin',   'role' => 'Corporate Representative'],
     'founder'          => ['name' => 'Aldra',  'role' => 'Former Colony Founder'],

--- a/config/game.php
+++ b/config/game.php
@@ -167,16 +167,16 @@ return [
         'ap_cost_threshold' => 1000,  // divisor: amount × price / threshold = AP cost
     ],
 
-    // Moral system — formula and multiplier bands (see GDD §13).
+    // Trust system — formula and multiplier bands (see GDD §13).
     // Formula: clamp(Σbuildings + Σresearches + clamp(Σships, -30, +30) + events, -100, +100)
-    // Per-entity moral_per_lv / moral_per_unit values live in config/buildings.php,
-    // config/techs.php and config/ships.php — MoralService reads from those files.
-    'moral' => [
-        // resource_id in colony_resources where the moral value is stored (res_moral).
+    // Per-entity trust_per_lv / trust_per_unit values live in config/buildings.php,
+    // config/techs.php and config/ships.php — TrustService reads from those files.
+    'trust' => [
+        // resource_id in colony_resources where the trust value is stored (res_moral).
         'resource_id' => 12,
-        // Hard cap for total ship moral contribution (before global clamp).
+        // Hard cap for total ship trust contribution (before global clamp).
         'ships_cap' => 30,
-        // Production multipliers by moral band (see GDD §13 "Effekte der Moral").
+        // Production multipliers by trust band (see GDD §13 "Effekte der Moral").
         'production_multiplier' => [
             ['min' =>  61, 'max' => 100, 'factor' => 1.20],
             ['min' =>  21, 'max' =>  60, 'factor' => 1.10],
@@ -184,7 +184,7 @@ return [
             ['min' => -60, 'max' => -21, 'factor' => 0.85],
             ['min' => -100,'max' => -61, 'factor' => 0.70],
         ],
-        // AP multipliers by moral band.
+        // AP multipliers by trust band.
         'ap_multiplier' => [
             ['min' =>  61, 'max' => 100, 'factor' => 1.10],
             ['min' =>  21, 'max' =>  60, 'factor' => 1.05],
@@ -192,7 +192,7 @@ return [
             ['min' => -60, 'max' => -21, 'factor' => 0.90],
             ['min' => -100,'max' => -61, 'factor' => 0.80],
         ],
-        // Event moral effects (one-shot, active for exactly 1 tick).
+        // Event trust effects (one-shot, active for exactly 1 tick).
         // Multiple events of the same key in one tick do NOT stack — strongest wins.
         'events' => [
             'building_level_up'     =>  1,

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -7,7 +7,7 @@
  *
  * Fields:
  *   id               — DB primary key in `researches` table
- *   moral_per_lv     — moral change per knowledge level (used by MoralService)
+ *   trust_per_lv     — trust change per knowledge level (used by TrustService)
  *   decay_rate       — always 0; knowledge never decays (GDD §10). GameTick skips Kenntnisse in decay loop.
  *   max_status_points — status_points reset value (kept for compatibility with colony_researches schema)
  *   credits          — base cost in credits to invest one level
@@ -28,7 +28,7 @@ return [
 
     'construction' => [
         'id'                => 90,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0,
         'max_status_points' => 20,
         'credits'           => 100,
@@ -37,7 +37,7 @@ return [
 
     'cartography' => [
         'id'                => 91,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0,
         'max_status_points' => 20,
         'credits'           => 100,
@@ -46,7 +46,7 @@ return [
 
     'geology' => [
         'id'                => 92,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0,
         'max_status_points' => 20,
         'credits'           => 100,
@@ -55,7 +55,7 @@ return [
 
     'agronomy' => [
         'id'                => 93,
-        'moral_per_lv'      => 1,       // see GDD §13
+        'trust_per_lv'      => 1,       // see GDD §13
         'decay_rate'        => 0,
         'max_status_points' => 20,
         'credits'           => 100,
@@ -64,7 +64,7 @@ return [
 
     'health' => [
         'id'                => 94,
-        'moral_per_lv'      => 2,       // see GDD §13
+        'trust_per_lv'      => 2,       // see GDD §13
         'decay_rate'        => 0,
         'max_status_points' => 20,
         'credits'           => 100,
@@ -73,7 +73,7 @@ return [
 
     'trade' => [
         'id'                => 95,
-        'moral_per_lv'      => 0,
+        'trust_per_lv'      => 0,
         'decay_rate'        => 0,
         'max_status_points' => 20,
         'credits'           => 100,
@@ -82,7 +82,7 @@ return [
 
     'defense' => [
         'id'                => 96,
-        'moral_per_lv'      => -1,      // see GDD §13 — vigilance dampens morale slightly
+        'trust_per_lv'      => -1,      // see GDD §13 — vigilance dampens morale slightly
         'decay_rate'        => 0,
         'max_status_points' => 20,
         'credits'           => 100,

--- a/config/ships.php
+++ b/config/ships.php
@@ -7,7 +7,7 @@
  *   id               — DB primary key in `ships` table
  *   moving_speed     — tiles per tick (fleet moves at slowest ship's speed)
  *   supply_cost      — supply consumed per ship unit (0 for unmanned craft)
- *   moral_per_unit   — moral change per ship in colony fleet (used by MoralService)
+ *   trust_per_unit   — trust change per ship in colony fleet (used by TrustService)
  *
  * Ships do NOT decay. They are either intact or destroyed (combat, mission hazards).
  * Maintenance pressure comes from the Hangar building decaying, not from the ships themselves.
@@ -24,7 +24,7 @@ return [
         'id'             => 85,
         'moving_speed'   => 5,          // fastest unit in the game
         'supply_cost'    => 0,          // unmanned — no crew, no supply upkeep
-        'moral_per_unit' => 0,
+        'trust_per_unit' => 0,
     ],
 
     // ── Military ──────────────────────────────────────────────────────────────
@@ -33,7 +33,7 @@ return [
         'id'             => 37,         // ex fighter1
         'moving_speed'   => 4,
         'supply_cost'    => 14,         // high — limits fleet size organically
-        'moral_per_unit' => -1,
+        'trust_per_unit' => -1,
     ],
 
     // ── Transport ─────────────────────────────────────────────────────────────
@@ -42,7 +42,7 @@ return [
         'id'             => 47,         // ex smallTransporter
         'moving_speed'   => 3,
         'supply_cost'    => 6,
-        'moral_per_unit' => 1,
+        'trust_per_unit' => 1,
     ],
 
 ];

--- a/data/cantina_hotspots.json
+++ b/data/cantina_hotspots.json
@@ -110,7 +110,7 @@
             "top": 52
         },
         "characters": [
-            "informationsagent",
+            "information_broker",
             "smuggler",
             "stranger"
         ]

--- a/data/sql/data.sqlite.sql
+++ b/data/sql/data.sqlite.sql
@@ -412,7 +412,7 @@ INSERT INTO "resources" VALUES(2,'res_supply','Sup','Event',0,200,'resicon-suppl
 INSERT INTO "resources" VALUES(3,'res_water','W','Level',1,500,'resicon-water');
 INSERT INTO "resources" VALUES(4,'res_ferum','E','Level',1,500,'resicon-iron');
 INSERT INTO "resources" VALUES(5,'res_silicates','S','Level',1,500,'resicon-silicates');
-INSERT INTO "resources" VALUES(12,'res_moral','M','Event',0,0,'resicon-moral');
+INSERT INTO "resources" VALUES(12,'res_trust','M','Event',0,0,'resicon-moral');
 INSERT INTO "ships" VALUES(29,'military','techs_frigate1',NULL,NULL,NULL,NULL,0,10,5,15,10,500);
 INSERT INTO "ships" VALUES(37,'military','techs_fighter1',NULL,NULL,NULL,NULL,0,8,5,15,10,500);
 INSERT INTO "ships" VALUES(47,'economy','techs_smallTransporter',NULL,NULL,NULL,NULL,0,7,4,15,10,500);

--- a/data/sql/schema.sqlite.sql
+++ b/data/sql/schema.sqlite.sql
@@ -344,7 +344,7 @@ CREATE TABLE advisors (
   unavailable_until_tick  INTEGER DEFAULT NULL
 );
 CREATE UNIQUE INDEX advisors_colony_personell_unique ON advisors (colony_id, personell_id) WHERE colony_id IS NOT NULL;
-CREATE TABLE moral_events (
+CREATE TABLE trust_events (
   id          INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
   colony_id   INTEGER NOT NULL REFERENCES glx_colonies(id),
   tick        INTEGER NOT NULL,

--- a/data/sql/testdata.sqlite.sql
+++ b/data/sql/testdata.sqlite.sql
@@ -3,7 +3,7 @@ INSERT INTO "resources" VALUES(2,'res_supply','Sup','Event',0,200,'resicon-suppl
 INSERT INTO "resources" VALUES(3,'res_regolith','Rg','Level',1,200,'resicon-regolith');
 INSERT INTO "resources" VALUES(4,'res_werkstoffe','Co','Level',1,0,'resicon-iron');
 INSERT INTO "resources" VALUES(5,'res_organika','Or','Level',1,0,'resicon-silicates');
-INSERT INTO "resources" VALUES(12,'res_moral','Tr','Event',0,0,'resicon-moral');
+INSERT INTO "resources" VALUES(12,'res_trust','Tr','Event',0,0,'resicon-moral');
 INSERT INTO "glx_system_types" VALUES(1,'stellar_class_A',8,'stellars/s_white.png','stellars/s_white_quarter.png');
 INSERT INTO "glx_system_types" VALUES(2,'stellar_class_O',12,'stellars/s_blue.png','stellars/s_blue_quarter.png');
 INSERT INTO "glx_system_types" VALUES(3,'stellar_class_B',11,'stellars/s_cyan.png','stellars/s_cyan_quarter.png');

--- a/database/migrations/2026_06_05_000000_rename_moral_to_trust.php
+++ b/database/migrations/2026_06_05_000000_rename_moral_to_trust.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Renames the moral_events table to trust_events and updates the
+     * resource abbreviation slug from res_moral to res_trust.
+     */
+    public function up(): void
+    {
+        Schema::rename('moral_events', 'trust_events');
+
+        DB::table('resources')
+            ->where('name', 'res_moral')
+            ->update(['name' => 'res_trust']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::rename('trust_events', 'moral_events');
+
+        DB::table('resources')
+            ->where('name', 'res_trust')
+            ->update(['name' => 'res_moral']);
+    }
+};

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -562,12 +562,12 @@ produzierte Menge = Gebäude-Level × Rate
 
 | Gebäude | building_id | Ressource | resource_id | Rate |
 |---------|-------------|-----------|-------------|------|
-| Harvester | 27 | Regolith | 3 | tile-abhängig |
+| Harvester | 27 | Regolith | 3 | 10 pro Level |
 | Agrardom | 41 | Organika | 5 | 10 pro Level |
 
 > **Designentscheidung:** Der Harvester produziert Regolith (lokaler Rohstoff), nicht Werkstoffe. Werkstoffe sind veredelte Industriegüter die nicht vor Ort herstellbar sind — sie kommen ausschließlich über Handel, KI-Händler und Events (§3).
 
-> **Harvester-Produktion:** Die produzierte Menge hängt vom Tile-Typ ab (z.B. "Reicher Erzknoten" = +50% Bonus). Quellen versiegen graduell — ein sichtbarer Erschöpfungs-Counter auf dem Tile zeigt den verbleibenden Vorrat.
+> **Harvester-Produktion (Phase 4+):** Geplant ist eine tile-abhängige Rate mit Tile-Boni (z.B. "Reicher Erzknoten" = +50%) und gradueller Erschöpfung. Aktuell (Phase 3): feste Rate `×10/level` identisch zum Agrardom — nach erstem Playtest evaluieren ob Tile-Varianz den Aufwand rechtfertigt.
 
 ### Konfiguration
 
@@ -575,8 +575,8 @@ produzierte Menge = Gebäude-Level × Rate
 
 ```php
 'production' => [
-    27 => [3 => 'tile'],   // harvester      → Regolith  tile-abhängig
-    41 => [5 => 10],       // bioFacility    → Organika  × 10/level
+    27 => [3 => 10],   // harvester   → Regolith  × 10/level
+    41 => [5 => 10],   // bioFacility → Organika  × 10/level
 ],
 ```
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -876,7 +876,7 @@ Erfahrenere Berater erholen sich schneller — und haben schon durch den `rank_d
 
 > **Designabsicht:** Burnout ist ein seltenes, aber echtes Risiko, das den Spieler dazu bringt, einen Backup-Plan für den Ausfall eines Beraters zu haben. Experten sind robuster, aber teurer — das macht Rang-Aufstieg strategisch wertvoller als nur "mehr AP pro Sol".
 
-> **Implementierungshinweis:** Die Burnout-Prüfung erfolgt in Tick-Schritt 7 (Advisor Ticks), nach dem AP-Bonus-Update. Die Zufallsziehung passiert einmal pro Berater pro Tick. Alle Konfigurations-Parameter stehen in `config/game.php → advisors.burnout`.
+> **Implementierungsstand:** Die Burnout-Wahrscheinlichkeits-Formel ist noch nicht implementiert. `unavailable_until_tick` existiert in der DB und wird gecheckt; die probabilistische Prüfung folgt nach dem ersten Playtest (Phase 4+).
 
 ---
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -187,18 +187,17 @@ php artisan game:tick --tick=N  # erzwingt Tick-Nummer N (nur für Tests)
 - Konfiguration: `config/game.php → tick`
 - Alle Schritte eines Ticks laufen in einer einzigen DB-Transaktion (atomar)
 
-### Reihenfolge der Tick-Schritte
+### Reihenfolge der Tick-Phasen
 
-| Schritt | Beschreibung |
-|---------|-------------|
-| 1 | Fleet Move Orders — Flotten bewegen sich zu Zielkoordinaten |
-| 2 | Fleet Trade Orders — Ressourcentransfer Flotte ↔ Kolonie |
-| 3 | Fleet Encounter Orders — Zwischenfälle aufgelöst; Schiffs-Verschleiß (`wear_per_order`) abgezogen |
-| 4 | Building Decay — Gebäude verlieren `decay_rate` SP; Level-Down bei SP ≤ 0 (§7) |
-| 5 | Supply Cap — `user_resources.supply` neu berechnen und setzen (Formel: siehe §6) |
-| 6 | Resource Generation — Rohstoffproduktion pro Kolonie und Produktionsgebäude |
-| 6b | Vertrauen Calculation — Vertrauen neu berechnen, `colony_resources` (res_id=12) aktualisieren (§14) |
-| 7 | Advisor Ticks — `active_ticks` erhöhen, Rang-Aufstieg prüfen, Burnout-Wahrscheinlichkeit würfeln (§7, §13) |
+| Phase | Beschreibung |
+|-------|-------------|
+| 1. Fleet | Flottenbewegung, Ressourcentransfer, Zwischenfälle |
+| 2. Decay | Gebäude-, Schiffs- und Kenntnisverfall (SP-Abzug; Level-Down bei SP ≤ 0) |
+| 3. Supply & Ressourcen | Supply-Cap neu berechnen (§6), dann Rohstoffproduktion (Vertrauens-Multiplikator angewendet) |
+| 4. Vertrauen | Vertrauenswert neu berechnen, `colony_resources` aktualisieren (§14) |
+| 5. Beratung & Events | Advisor-Ticks, Bar-Angebote, Händler-Spawn, Run-Checks (Phasen, Objectives, Fail State) |
+
+> Die genaue Schritt-Reihenfolge innerhalb jeder Phase ist in `app/Console/Commands/GameTick.php` (Docblock) kanonisch festgehalten.
 
 ---
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -470,6 +470,8 @@ Tile-Typen definieren die **Mechanik** eines Tiles — nicht sein Aussehen. Die 
 | `terrain_hazard` | Gefahr — Korvette/Sonde nötig zur Neutralisierung. Wird danach zu `terrain_empty` |
 | `terrain_impassable` | Nicht begehbar, nicht bebaubar (Klippen, Abgründe, Lavaströme — je nach Planetentyp) |
 
+> **UI-Render-States (kein DB-Typ):** `terrain_fog` und `terrain_locked` sind keine `tile_type`-Werte in der DB — sie sind visuelle Zustände die das Hex-Grid aus `is_explored` + `is_colony_zone` ableitet. `terrain_fog` = unerkundetes Kolonie-Zone-Tile; `terrain_locked` = unerkundetes Exploration-Zone-Tile. Beschreibung in `docs/lore/tiles.md`.
+
 **Ressource-Tiles (für Harvester):**
 
 | Typ-Key | Ressource | Qualität |

--- a/docs/characters/information_broker.md
+++ b/docs/characters/information_broker.md
@@ -1,5 +1,5 @@
 ---
-slug: informationsagent
+slug: information_broker
 status: draft
 ---
 
@@ -29,5 +29,5 @@ A middle-aged woman with dark, closely cropped hair and a calm, expressionless f
 - **Frequency:** rare
 
 ## Artwork
-- **File:** public/img/characters/informationsagent.webp
-- **Prompt:** .prompts/images/characters/informationsagent.prompt.md
+- **File:** public/img/characters/information_broker.webp
+- **Prompt:** .prompts/images/characters/information_broker.prompt.md

--- a/lang/de/events.php
+++ b/lang/de/events.php
@@ -17,7 +17,7 @@ return [
     // TODO: trigger when a building first drops a status level in the player's session
     'onboarding_decay'            => 'Struktur :tech auf Kolonie :colony zeigt Verfallsschäden — Reparatur-AP einplanen.',
 
-    // TODO: trigger when colony moral first drops below threshold
+    // TODO: trigger when colony trust first drops below threshold
     'onboarding_trust'            => 'Vertrauen der Kolonisten auf :colony gesunken — Ursache prüfen.',
 
     // Merchant events

--- a/lang/de/nexusdb.php
+++ b/lang/de/nexusdb.php
@@ -27,8 +27,8 @@ return [
     'speed_unit'      => 'Felder/Sol',
     'supply_cost_ship'=> 'Versorgungskosten',
     'supply_unmanned' => 'Unbemannt',
-    'moral_effect'    => 'Moraleffekt',
-    'moral_neutral'   => 'Neutral',
+    'trust_effect'    => 'Vertrauenseffekt',
+    'trust_neutral'   => 'Neutral',
 
     // Knowledge tab — card field labels
     'knowledge_max_level'    => 'Max. Stufe',

--- a/lang/de/resources.php
+++ b/lang/de/resources.php
@@ -7,7 +7,7 @@ return [
     'res_regolith'   => 'Regolith',
     'res_werkstoffe' => 'Werkstoffe',
     'res_organika'   => 'Organika',
-    'res_moral'      => 'Vertrauen',
+    'res_trust'      => 'Vertrauen',
 
     // Chip popup descriptions
     'popup_sol_title' => 'Sol',

--- a/lang/de/trust.php
+++ b/lang/de/trust.php
@@ -1,14 +1,14 @@
 <?php
 
 return [
-    // Moral bands (displayed in colony overview and tooltips)
+    // Trust bands (displayed in colony overview and tooltips)
     'band_euphorisch' => 'Euphorisch',
     'band_zufrieden'  => 'Zufrieden',
     'band_stabil'     => 'Stabil',
     'band_unruhig'    => 'Unruhig',
     'band_aufruhr'    => 'Aufruhr',
 
-    // Moral event descriptions (shown in INNN event log)
+    // Trust event descriptions (shown in INNN event log)
     'event_building_level_up'   => 'Ein Gebäude wurde ausgebaut – die Bevölkerung ist erfreut.',
     'event_building_level_down' => 'Ein Gebäude ist verfallen – die Bevölkerung ist unzufrieden.',
     'event_research_level_up'   => 'Ein Forschungsdurchbruch hebt die Stimmung.',

--- a/lang/en/resources.php
+++ b/lang/en/resources.php
@@ -6,5 +6,5 @@ return [
     'res_regolith'   => 'Regolith',
     'res_werkstoffe' => 'Compounds',
     'res_organika'   => 'Organics',
-    'res_moral'      => 'Morale',
+    'res_trust'      => 'Trust',
 ];

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -207,7 +207,7 @@ body .nav-list > .active > a, .nav-list > .active > a:hover {background-color: #
 
 .resicon-credits {background-color: gold;}
 .resicon-supply {background-color: #ddd;}
-.resicon-moral {background-color: #fff; }
+.resicon-trust {background-color: #fff; }
 .resicon-iron {background-color: #ccc;}
 .resicon-water {background-color: #66f;}
 .resicon-silicates {background-color: #CD853F;}

--- a/resources/views/nexusdb/index.blade.php
+++ b/resources/views/nexusdb/index.blade.php
@@ -142,12 +142,12 @@
         font-variant-numeric: tabular-nums;
     }
 
-    /* ── Moral effect badges ─────────────────────────────────────────────── */
-    .nexusdb-moral-pos {
+    /* ── Trust effect badges ─────────────────────────────────────────────── */
+    .nexusdb-trust-pos {
         color: var(--pico-ins-color, #2d8a4e);
     }
 
-    .nexusdb-moral-neg {
+    .nexusdb-trust-neg {
         color: var(--pico-del-color, #c0392b);
     }
 
@@ -264,14 +264,14 @@
                             </td>
                         </tr>
                         <tr>
-                            <td>{{ __('nexusdb.moral_effect') }}</td>
+                            <td>{{ __('nexusdb.trust_effect') }}</td>
                             <td>
-                                @if($data['moral_per_unit'] === 0)
-                                    <span>{{ __('nexusdb.moral_neutral') }}</span>
-                                @elseif($data['moral_per_unit'] > 0)
-                                    <span class="nexusdb-moral-pos">+{{ $data['moral_per_unit'] }}</span>
+                                @if($data['trust_per_unit'] === 0)
+                                    <span>{{ __('nexusdb.trust_neutral') }}</span>
+                                @elseif($data['trust_per_unit'] > 0)
+                                    <span class="nexusdb-trust-pos">+{{ $data['trust_per_unit'] }}</span>
                                 @else
-                                    <span class="nexusdb-moral-neg">{{ $data['moral_per_unit'] }}</span>
+                                    <span class="nexusdb-trust-neg">{{ $data['trust_per_unit'] }}</span>
                                 @endif
                             </td>
                         </tr>

--- a/resources/views/partials/debug-bar.blade.php
+++ b/resources/views/partials/debug-bar.blade.php
@@ -8,7 +8,7 @@
     $cfgSupply = config('game.supply');
     $cfgCredit = config('game.credits');
     $cfgFleet  = config('game.fleet.order_costs');
-    $cfgMoral  = config('game.moral.events');
+    $cfgTrust  = config('game.trust.events');
     $cfgTick   = config('game.tick');
 @endphp
 
@@ -93,10 +93,10 @@
             @endforeach
         </div>
 
-        {{-- Moral Events --}}
+        {{-- Trust Events --}}
         <div>
-            <div style="color:#ff0;margin-bottom:4px;">Moral Events</div>
-            @foreach($cfgMoral as $event => $val)
+            <div style="color:#ff0;margin-bottom:4px;">Trust Events</div>
+            @foreach($cfgTrust as $event => $val)
                 <div>
                     <span style="color:#666;">{{ $event }}:</span>
                     <span style="color:{{ $val >= 0 ? '#4c4' : '#f55' }};">{{ $val >= 0 ? '+' : '' }}{{ $val }}</span>

--- a/tests/Feature/GameTick/GameTickMoralTest.php
+++ b/tests/Feature/GameTick/GameTickMoralTest.php
@@ -9,36 +9,36 @@ use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 /**
- * GameTick step 8b — Moral (Trust) recalculation.
+ * GameTick step 8b — Trust recalculation.
  *
- * Moral is stored in colony_resources.amount WHERE resource_id=12.
+ * Trust is stored in colony_resources.amount WHERE resource_id=12.
  * It is recalculated each tick from:
- *   - Building contributions (building config moral_per_lv × level)
- *   - Research contributions (knowledge config moral_per_lv × level)
+ *   - Building contributions (building config trust_per_lv × level)
+ *   - Research contributions (knowledge config trust_per_lv × level)
  *   - Ship contributions (capped at ±30)
- *   - One-shot events from moral_events (only strongest per type)
+ *   - One-shot events from trust_events (only strongest per type)
  *
  * Formula: clamp(Σbuildings + Σresearches + clamp(Σships, -30, +30) + events, -100, +100)
  *
  * Covered scenarios:
  *  Happy path:
- *  - Moral calculated and stored after tick (building contribution)
- *  - Moral event increases moral by configured amount
- *  - Moral event decreases moral by configured amount
+ *  - Trust calculated and stored after tick (building contribution)
+ *  - Trust event increases trust by configured amount
+ *  - Trust event decreases trust by configured amount
  *
  *  Edge cases:
- *  - Moral clamped at +100 maximum
- *  - Moral clamped at -100 minimum
- *  - Moral events are one-shot (not repeated on subsequent ticks)
+ *  - Trust clamped at +100 maximum
+ *  - Trust clamped at -100 minimum
+ *  - Trust events are one-shot (not repeated on subsequent ticks)
  *  - Duplicate events of the same type do not stack (strongest wins)
  *
  *  Adversarial:
  *  - Unknown event type is silently ignored (no crash, no effect)
- *  - Moral with zero buildings/events = 0 (neutral)
+ *  - Trust with zero buildings/events = 0 (neutral)
  *
  * Fixture summary (TestSeeder):
  *   Colony 1 (Springfield), user_id=3
- *   colony_resources resource_id=12: amount=0 (moral starts at 0)
+ *   colony_resources resource_id=12: amount=0 (trust starts at 0)
  *
  * Uses tick numbers 11300–11349.
  */
@@ -54,42 +54,42 @@ class GameTickMoralTest extends TestCase
         parent::setUp();
         $this->app->make(TestSeeder::class)->run();
 
-        // Start with clean moral state
+        // Start with clean trust state
         DB::table('colony_resources')->updateOrInsert(
             ['colony_id' => self::COLONY_ID, 'resource_id' => self::MORAL_RES_ID],
             ['amount' => 0]
         );
 
-        // Clear all pending moral events
-        DB::table('moral_events')->where('colony_id', self::COLONY_ID)->delete();
+        // Clear all pending trust events
+        DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
 
         // Zero all supply costs so no over-cap multiplier fires during decay
         DB::table('buildings')->update(['supply_cost' => 0]);
         DB::table('researches')->update(['supply_cost' => 0]);
         DB::table('ships')->update(['supply_cost' => 0]);
 
-        // Zero colony_ships for colony 1 so ship moral contribution = 0.
-        // Colony 1 has corvettes (moral_per_unit=-1) and other ships that would
+        // Zero colony_ships for colony 1 so ship trust contribution = 0.
+        // Colony 1 has corvettes (trust_per_unit=-1) and other ships that would
         // introduce a non-zero ship contribution and break isolation assertions.
         DB::table('colony_ships')->where('colony_id', self::COLONY_ID)->update(['level' => 0]);
 
-        // Zero all building levels for colony 1 that have moral_per_lv != 0.
+        // Zero all building levels for colony 1 that have trust_per_lv != 0.
         // Each test inserts exactly what it needs.
-        $moralBuildingIds = collect(config('buildings', []))
-            ->filter(fn($b) => ($b['moral_per_lv'] ?? 0) != 0)
+        $trustBuildingIds = collect(config('buildings', []))
+            ->filter(fn($b) => ($b['trust_per_lv'] ?? 0) != 0)
             ->pluck('id')
             ->toArray();
-        if (!empty($moralBuildingIds)) {
+        if (!empty($trustBuildingIds)) {
             DB::table('colony_buildings')
                 ->where('colony_id', self::COLONY_ID)
-                ->whereIn('building_id', $moralBuildingIds)
+                ->whereIn('building_id', $trustBuildingIds)
                 ->update(['level' => 0]);
         }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private function getMoral(): int
+    private function getTrust(): int
     {
         return (int) DB::table('colony_resources')
             ->where('colony_id', self::COLONY_ID)
@@ -97,7 +97,7 @@ class GameTickMoralTest extends TestCase
             ->value('amount');
     }
 
-    private function setMoral(int $value): void
+    private function setTrust(int $value): void
     {
         DB::table('colony_resources')->updateOrInsert(
             ['colony_id' => self::COLONY_ID, 'resource_id' => self::MORAL_RES_ID],
@@ -107,7 +107,7 @@ class GameTickMoralTest extends TestCase
 
     private function insertMoralEvent(string $eventType, int $tick): void
     {
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => self::COLONY_ID,
             'tick'       => $tick,
             'event_type' => $eventType,
@@ -117,69 +117,69 @@ class GameTickMoralTest extends TestCase
     // ── Happy path ─────────────────────────────────────────────────────────────
 
     /**
-     * After a tick the moral value is stored in colony_resources.
+     * After a tick the trust value is stored in colony_resources.
      *
-     * With no moral_per_lv buildings, no colony ships with moral_per_unit, and no
-     * events, expected moral = 0 (setUp has already zeroed these contributions).
+     * With no trust_per_lv buildings, no colony ships with trust_per_unit, and no
+     * events, expected trust = 0 (setUp has already zeroed these contributions).
      */
     public function test_moral_is_stored_after_tick(): void
     {
         Artisan::call('game:tick', ['--tick' => 11300]);
 
-        // Moral must have been SET (not left at default NULL)
-        $moral = $this->getMoral();
-        $this->assertIsInt($moral, 'Moral must be stored as integer in colony_resources after tick');
+        // Trust must have been SET (not left at default NULL)
+        $trust = $this->getTrust();
+        $this->assertIsInt($trust, 'Trust must be stored as integer in colony_resources after tick');
     }
 
     /**
-     * A 'building_level_up' moral event contributes +1 to moral.
+     * A 'building_level_up' trust event contributes +1 to trust.
      *
-     * Pre-condition: moral at 0, no building/ship moral contribution (zeroed in setUp)
+     * Pre-condition: trust at 0, no building/ship trust contribution (zeroed in setUp)
      * → result = event value = +1.
      */
     public function test_positive_moral_event_increases_moral(): void
     {
-        $eventEffect = (int) config('game.moral.events.building_level_up', 1);
+        $eventEffect = (int) config('game.trust.events.building_level_up', 1);
 
         $this->insertMoralEvent('building_level_up', 11301);
 
         Artisan::call('game:tick', ['--tick' => 11301]);
 
-        $moral = $this->getMoral();
+        $trust = $this->getTrust();
         // buildings+researches+ships = 0 (zeroed above); event = +1
-        $this->assertEquals($eventEffect, $moral,
-            "Moral after 'building_level_up' event must equal the configured effect (+{$eventEffect})");
+        $this->assertEquals($eventEffect, $trust,
+            "Trust after 'building_level_up' event must equal the configured effect (+{$eventEffect})");
     }
 
     /**
-     * A 'encounter_lost' moral event contributes -5 to moral.
-     * setUp has already zeroed building and ship moral contributions.
+     * A 'encounter_lost' trust event contributes -5 to trust.
+     * setUp has already zeroed building and ship trust contributions.
      */
     public function test_negative_moral_event_decreases_moral(): void
     {
-        $eventEffect = (int) config('game.moral.events.encounter_lost', -5);
+        $eventEffect = (int) config('game.trust.events.encounter_lost', -5);
 
         $this->insertMoralEvent('encounter_lost', 11302);
 
         Artisan::call('game:tick', ['--tick' => 11302]);
 
-        $moral = $this->getMoral();
-        $this->assertEquals($eventEffect, $moral,
-            "Moral after 'encounter_lost' event must equal the configured effect ({$eventEffect})");
+        $trust = $this->getTrust();
+        $this->assertEquals($eventEffect, $trust,
+            "Trust after 'encounter_lost' event must equal the configured effect ({$eventEffect})");
     }
 
     /**
-     * Infirmary (building_id=46) contributes moral_per_lv=3 per level.
-     * Colony 1 infirmary level=1 → moral contribution = +3.
-     * setUp has already zeroed all other moral-contributing buildings and ships.
+     * Infirmary (building_id=46) contributes trust_per_lv=3 per level.
+     * Colony 1 infirmary level=1 → trust contribution = +3.
+     * setUp has already zeroed all other trust-contributing buildings and ships.
      */
     public function test_building_with_moral_per_lv_contributes_to_moral(): void
     {
         $infirmaryId = 46;
-        $moralPerLv  = (int) (config('buildings.infirmary.moral_per_lv', 3));
+        $trustPerLv  = (int) (config('buildings.infirmary.trust_per_lv', 3));
 
-        if ($moralPerLv === 0) {
-            $this->markTestSkipped('Infirmary has moral_per_lv=0 in config — no contribution to test.');
+        if ($trustPerLv === 0) {
+            $this->markTestSkipped('Infirmary has trust_per_lv=0 in config — no contribution to test.');
         }
 
         // Set infirmary to level 1 for predictable contribution (setUp already zeroed others)
@@ -190,28 +190,28 @@ class GameTickMoralTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 11303]);
 
-        $moral = $this->getMoral();
-        $this->assertEquals($moralPerLv, $moral,
-            "Infirmary level 1 must contribute moral_per_lv={$moralPerLv} to total moral");
+        $trust = $this->getTrust();
+        $this->assertEquals($trustPerLv, $trust,
+            "Infirmary level 1 must contribute trust_per_lv={$trustPerLv} to total trust");
     }
 
     // ── Edge cases ─────────────────────────────────────────────────────────────
 
     /**
-     * Moral must be clamped to +100 even when building contributions exceed +100.
+     * Trust must be clamped to +100 even when building contributions exceed +100.
      *
-     * Bar (building_id=52) has moral_per_lv=2. At level=60 → contribution=120 → clamped to 100.
-     * setUp has already zeroed ships and other moral-contributing buildings.
+     * Bar (building_id=52) has trust_per_lv=2. At level=60 → contribution=120 → clamped to 100.
+     * setUp has already zeroed ships and other trust-contributing buildings.
      */
     public function test_moral_clamped_at_positive_100(): void
     {
-        $barMoralPerLv = (int) config('buildings.bar.moral_per_lv', 2);
+        $barTrustPerLv = (int) config('buildings.bar.trust_per_lv', 2);
 
-        if ($barMoralPerLv <= 0) {
-            $this->markTestSkipped('Bar moral_per_lv is not positive — cannot test upper clamp via bar.');
+        if ($barTrustPerLv <= 0) {
+            $this->markTestSkipped('Bar trust_per_lv is not positive — cannot test upper clamp via bar.');
         }
 
-        // Level 60 × moral_per_lv=2 = 120 → exceeds +100 → must clamp to 100
+        // Level 60 × trust_per_lv=2 = 120 → exceeds +100 → must clamp to 100
         DB::table('colony_buildings')->updateOrInsert(
             ['colony_id' => self::COLONY_ID, 'building_id' => 52, 'instance_id' => 1],
             ['level' => 60, 'status_points' => 20, 'ap_spend' => 0]
@@ -219,33 +219,21 @@ class GameTickMoralTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 11310]);
 
-        $moral = $this->getMoral();
-        $this->assertLessThanOrEqual(100, $moral, 'Moral must never exceed +100');
-        $this->assertEquals(100, $moral, 'Moral must be clamped to exactly +100 when sum exceeds it');
+        $trust = $this->getTrust();
+        $this->assertLessThanOrEqual(100, $trust, 'Trust must never exceed +100');
+        $this->assertEquals(100, $trust, 'Trust must be clamped to exactly +100 when sum exceeds it');
     }
 
     /**
-     * Moral must be clamped to -100 even when negative contributions exceed -100.
+     * Trust must be clamped to -100 even when negative contributions exceed -100.
      *
-     * Temple (building_id=32) has moral_per_lv=-? — actually all seeded buildings
-     * have non-negative moral_per_lv. Use negative events of all distinct types.
-     * Multiple distinct event types (encounter_lost=-5, colony_threatened=-4,
-     * building_level_down=-3) combine to -12. To hit -100 we need bigger contributions.
-     *
-     * Best approach: use bar at level 60 with negative sign (bar moral_per_lv=+2 won't work
-     * for negative). Use many distinct negative event types.
-     * Actually: max reachable from events alone is Σ negative events = -5-4-3 = -12.
-     * To test -100 clamp we need building contribution. defense knowledge (id=96, moral_per_lv=-1)
-     * at level 100+ would do it, but knowledge is not in the research mechanism here.
-     * Simplest: fire many different negative event types, assert >= -100.
+     * Use events from all negative-value event types and assert the result is always >= -100.
      */
     public function test_moral_clamped_at_negative_100(): void
     {
-        // Insert a building that has a negative moral contribution if any exists,
-        // otherwise use events to push into negative territory and confirm clamp.
-        // Strategy: use events from all negative-value event types (5 distinct ones)
+        // Strategy: use events from all negative-value event types
         // and assert the result is always >= -100.
-        $negativeEvents = collect(config('game.moral.events', []))
+        $negativeEvents = collect(config('game.trust.events', []))
             ->filter(fn($v) => $v < 0)
             ->keys();
 
@@ -255,13 +243,13 @@ class GameTickMoralTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 11311]);
 
-        $moral = $this->getMoral();
-        $this->assertGreaterThanOrEqual(-100, $moral, 'Moral must never go below -100');
+        $trust = $this->getTrust();
+        $this->assertGreaterThanOrEqual(-100, $trust, 'Trust must never go below -100');
     }
 
     /**
-     * Moral events are consumed in one tick and must not affect the next tick.
-     * setUp has already zeroed building and ship moral contributions for isolation.
+     * Trust events are consumed in one tick and must not affect the next tick.
+     * setUp has already zeroed building and ship trust contributions for isolation.
      */
     public function test_moral_event_does_not_carry_to_next_tick(): void
     {
@@ -269,21 +257,21 @@ class GameTickMoralTest extends TestCase
         $this->insertMoralEvent('building_level_up', 11320);
 
         Artisan::call('game:tick', ['--tick' => 11320]);
-        $moralAfterTick1 = $this->getMoral();
+        $trustAfterTick1 = $this->getTrust();
 
         Artisan::call('game:tick', ['--tick' => 11321]);
-        $moralAfterTick2 = $this->getMoral();
+        $trustAfterTick2 = $this->getTrust();
 
         // Both ticks with no buildings → event fired only in tick 11320
-        // tick 11320: moral = +1 (event);  tick 11321: moral = 0 (no event)
-        $this->assertEquals(1, $moralAfterTick1, 'Moral must reflect the event in its tick');
-        $this->assertEquals(0, $moralAfterTick2, 'Moral event must not carry to the next tick');
+        // tick 11320: trust = +1 (event);  tick 11321: trust = 0 (no event)
+        $this->assertEquals(1, $trustAfterTick1, 'Trust must reflect the event in its tick');
+        $this->assertEquals(0, $trustAfterTick2, 'Trust event must not carry to the next tick');
     }
 
     /**
      * Two events of the same type in one tick do NOT stack — only the strongest counts.
      * 'encounter_lost' = -5; two of them → still -5 (not -10).
-     * setUp has already zeroed building and ship moral contributions for isolation.
+     * setUp has already zeroed building and ship trust contributions for isolation.
      */
     public function test_duplicate_moral_events_same_type_do_not_stack(): void
     {
@@ -293,26 +281,26 @@ class GameTickMoralTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 11330]);
 
-        $moral = $this->getMoral();
-        $singleEffect = (int) config('game.moral.events.encounter_lost', -5);
+        $trust        = $this->getTrust();
+        $singleEffect = (int) config('game.trust.events.encounter_lost', -5);
 
         // Must be exactly -5, not -10 (not stacked)
-        $this->assertEquals($singleEffect, $moral,
-            'Duplicate moral events of the same type must not stack — strongest (only one) wins');
+        $this->assertEquals($singleEffect, $trust,
+            'Duplicate trust events of the same type must not stack — strongest (only one) wins');
     }
 
     // ── Adversarial ────────────────────────────────────────────────────────────
 
     /**
      * An unknown event type fired via fireEvent() must not cause an exception
-     * and must not affect moral.
-     * setUp has already zeroed building and ship moral contributions for isolation.
+     * and must not affect trust.
+     * setUp has already zeroed building and ship trust contributions for isolation.
      */
     public function test_unknown_moral_event_type_is_ignored(): void
     {
-        // MoralService::fireEvent() guards unknown types — it never inserts.
+        // TrustService::fireEvent() guards unknown types — it never inserts.
         // But what if someone directly inserts an unknown type?
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => self::COLONY_ID,
             'tick'       => 11340,
             'event_type' => 'totally_unknown_event_xyz',
@@ -320,8 +308,8 @@ class GameTickMoralTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 11340]);
 
-        $moral = $this->getMoral();
+        $trust = $this->getTrust();
         // eventContribution() looks up $cfg[$type] which returns null/0 for unknown keys
-        $this->assertEquals(0, $moral, 'Unknown event type must contribute 0 to moral (silently ignored)');
+        $this->assertEquals(0, $trust, 'Unknown event type must contribute 0 to trust (silently ignored)');
     }
 }

--- a/tests/Feature/GameTick/GameTickResourceGenerationTest.php
+++ b/tests/Feature/GameTick/GameTickResourceGenerationTest.php
@@ -63,7 +63,7 @@ class GameTickResourceGenerationTest extends TestCase
             ['amount' => 0]
         );
         // Ensure moral events table is clean (no pending events that would shift moral)
-        DB::table('moral_events')->where('colony_id', self::COLONY_ID)->delete();
+        DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/tests/Feature/Onboarding/OnboardingTriggersTest.php
+++ b/tests/Feature/Onboarding/OnboardingTriggersTest.php
@@ -29,7 +29,7 @@ use Tests\TestCase;
  *   - Below cap: used supply < cap → trigger does NOT fire
  *
  * Trigger 3 — onboarding_trust (trust crosses from >= 0 to < 0)
- *   - Happy path:  trust was 0, MoralService drives it negative → INNN event + markFired
+ *   - Happy path:  trust was 0, TrustService drives it negative → INNN event + markFired
  *   - Already fired: trigger in fired_triggers → no second event
  *   - Already negative before tick: trust was -1 before tick → no event (transition already happened)
  *   - NPC colony (user_id = null): trust going negative must NOT fire trigger
@@ -55,7 +55,7 @@ class OnboardingTriggersTest extends TestCase
 
         $this->triggerService = $this->app->make(OnboardingTriggerService::class);
 
-        // Pin the tick to a known value so moral_events rows can be inserted at
+        // Pin the tick to a known value so trust_events rows can be inserted at
         // the correct tick number before calling game:tick.
         $this->app->make(\App\Services\TickService::class)->setTickCount(500);
 
@@ -344,11 +344,11 @@ class OnboardingTriggersTest extends TestCase
 
     /**
      * When trust (resource_id=12) transitions from >= 0 (before tick) to < 0 (after
-     * MoralService recalculates), the trigger must emit an onboarding_trust INNN event.
+     * TrustService recalculates), the trigger must emit an onboarding_trust INNN event.
      *
-     * We drive moral negative by inserting an 'encounter_lost' moral event (value = -5)
-     * into the moral_events table at the pinned tick (500) for this colony.
-     * After the tick, MoralService will store moral = -5 in colony_resources, which
+     * We drive trust negative by inserting an 'encounter_lost' moral event (value = -5)
+     * into the trust_events table at the pinned tick (500) for this colony.
+     * After the tick, TrustService will store trust = -5 in colony_resources, which
      * satisfies the onboarding_trust trigger condition (trustBefore=0 >= 0, trustAfter=-5 < 0).
      */
     public function test_trust_trigger_fires_when_trust_crosses_zero_to_negative(): void
@@ -356,8 +356,8 @@ class OnboardingTriggersTest extends TestCase
         // Trust starts at 0 (set in setUp); trigger not yet fired.
         $this->assertFalse($this->triggerService->hasFired($this->userId, 'onboarding_trust'));
 
-        // Insert a negative moral event at the pinned tick so MoralService produces -5.
-        DB::table('moral_events')->insert([
+        // Insert a negative moral event at the pinned tick so TrustService produces -5.
+        DB::table('trust_events')->insert([
             'colony_id'  => $this->colonyId,
             'tick'       => 500, // matches the tick pinned in setUp
             'event_type' => 'encounter_lost',
@@ -399,7 +399,7 @@ class OnboardingTriggersTest extends TestCase
         $this->triggerService->markFired($this->userId, 'onboarding_trust');
 
         // Force moral to go negative via encounter_lost event.
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => $this->colonyId,
             'tick'       => 500,
             'event_type' => 'encounter_lost',
@@ -431,7 +431,7 @@ class OnboardingTriggersTest extends TestCase
             ->update(['amount' => -5]);
 
         // Also insert a moral event so the result stays negative after recalculation.
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => $this->colonyId,
             'tick'       => 500,
             'event_type' => 'encounter_lost',
@@ -477,7 +477,7 @@ class OnboardingTriggersTest extends TestCase
         ]);
 
         // Moral event for the NPC colony so trust would go negative.
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => 9999,
             'tick'       => 500,
             'event_type' => 'encounter_lost',

--- a/tests/Feature/TrustServiceTest.php
+++ b/tests/Feature/TrustServiceTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature;
 
 /**
- * MoralServiceTest — comprehensive feature tests for MoralService.
+ * TrustServiceTest — comprehensive feature tests for TrustService.
  *
  * Covered scenarios:
  *
@@ -11,69 +11,69 @@ namespace Tests\Feature;
  *   - All five bands with exact lower/upper boundary values; assertions use __() so
  *     they stay locale-agnostic and pass regardless of APP_LOCALE
  *   - Boundary note: the code uses `>= -61` for Unruhig, so -61 maps to Unruhig and
- *     Aufruhr starts at -62 (the docblock in MoralService has a typo — code wins)
+ *     Aufruhr starts at -62 (the docblock in TrustService has a typo — code wins)
  *   - Locale-switch test: switching to a hypothetical 'en' locale returns English strings
  *     (or falls back gracefully to the translation key if no en file exists)
  *
  * getProductionMultiplier() / getApMultiplier():
- *   - Neutral moral (0) returns 1.0×
- *   - Euphorisch moral (80) returns the configured factor
- *   - Aufruhr moral (-80) returns the configured factor
- *   - Out-of-range moral that misses all bands falls back to 1.0
+ *   - Neutral trust (0) returns 1.0×
+ *   - Euphorisch trust (80) returns the configured factor
+ *   - Aufruhr trust (-80) returns the configured factor
+ *   - Out-of-range trust that misses all bands falls back to 1.0
  *
- * getMoral():
+ * getTrust():
  *   - Returns 0 when no colony_resources row exists for resource_id=12
  *   - Returns the stored integer value when the row exists
- *   - Handles stored negative moral correctly
+ *   - Handles stored negative trust correctly
  *
  * fireEvent():
- *   - Known event inserts a row into moral_events with correct colony_id/tick/event_type
+ *   - Known event inserts a row into trust_events with correct colony_id/tick/event_type
  *   - Unknown event type is silently ignored (no row inserted)
  *   - Default tick is current tick + 1 when no tick is passed
  *   - Explicit tick is respected when passed
  *
- * calculateMoral() — building contribution:
- *   - A positive-moral building (hospital, id=46) adds level × 3 to moral
+ * calculateTrust() — building contribution:
+ *   - A positive-trust building (hospital, id=46) adds level × 3 to trust
  *   - Building with status_points=0 is excluded from calculation
  *
- * calculateMoral() — research contribution:
- *   - A positive-moral research (health, id=94) adds level × 2
- *   - A negative-moral research (defense, id=96) subtracts level × 1
+ * calculateTrust() — research contribution:
+ *   - A positive-trust research (health, id=94) adds level × 2
+ *   - A negative-trust research (defense, id=96) subtracts level × 1
  *
- * calculateMoral() — ship contribution:
- *   - A positive-moral ship (frachter, id=47) adds level × 1
- *   - A negative-moral ship (korvette, id=37) subtracts level × 1
+ * calculateTrust() — ship contribution:
+ *   - A positive-trust ship (frachter, id=47) adds level × 1
+ *   - A negative-trust ship (korvette, id=37) subtracts level × 1
  *   - Total ship contribution is capped at ±30 before global clamp
  *
- * calculateMoral() — event contribution:
+ * calculateTrust() — event contribution:
  *   - A fired event contributes its delta at the matching tick
  *   - Same event type fired twice is counted only once (no stacking)
  *   - Events for a different tick are NOT included
  *   - Multiple distinct event types are summed
  *
- * calculateMoral() — global clamp:
+ * calculateTrust() — global clamp:
  *   - Result is clamped to +100 even when raw sum exceeds 100
  *   - Result is clamped to -100 even when raw sum exceeds -100
  *
  * calculateAndStore():
- *   - Persists the calculated moral in colony_resources (resource_id=12)
+ *   - Persists the calculated trust in colony_resources (resource_id=12)
  *   - Updates existing row rather than inserting a duplicate
  *   - Returns the clamped integer value
  */
 
 use App\Models\Colony;
-use App\Services\MoralService;
+use App\Services\TrustService;
 use App\Services\TickService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
-class MoralServiceTest extends TestCase
+class TrustServiceTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected MoralService $service;
+    protected TrustService $service;
     protected TickService $tickService;
     protected int $colonyId = 1;   // Springfield — owned by Bart (user_id=3)
     protected int $tick     = 100; // fixed tick, avoids wall-clock dependency
@@ -87,15 +87,15 @@ class MoralServiceTest extends TestCase
         $this->tickService = $this->app->make(TickService::class);
         $this->tickService->setTickCount($this->tick);
 
-        $this->service = $this->app->make(MoralService::class);
+        $this->service = $this->app->make(TrustService::class);
 
-        // Remove all seeded colony_resources rows for moral (resource_id=12) and all
-        // moral_events so each test starts from a known blank state.
+        // Remove all seeded colony_resources rows for trust (resource_id=12) and all
+        // trust_events so each test starts from a known blank state.
         DB::table('colony_resources')
-            ->where('resource_id', MoralService::RESOURCE_ID)
+            ->where('resource_id', TrustService::RESOURCE_ID)
             ->delete();
 
-        DB::table('moral_events')->delete();
+        DB::table('trust_events')->delete();
 
         // Remove seeded colony_buildings / colony_researches / colony_ships for
         // colony 1 so building/research/ship tests can insert exactly what they need.
@@ -106,70 +106,70 @@ class MoralServiceTest extends TestCase
 
     // ── getBand() ─────────────────────────────────────────────────────────────
     //
-    // Assertions compare against __('moral.band_*') so they pass regardless of which
+    // Assertions compare against __('trust.band_*') so they pass regardless of which
     // locale is active — the translation layer is tested separately below.
 
     public function testGetBand_returnsAufruhr_atMinus100(): void
     {
-        $this->assertSame(__('moral.band_aufruhr'), $this->service->getBand(-100));
+        $this->assertSame(__('trust.band_aufruhr'), $this->service->getBand(-100));
     }
 
     public function testGetBand_returnsUnruhig_atMinus61(): void
     {
         // The code uses `>= -61` for Unruhig, so -61 is the lower boundary of Unruhig.
-        // The docblock in MoralService is incorrect — the implementation is the source of truth.
-        $this->assertSame(__('moral.band_unruhig'), $this->service->getBand(-61));
+        // The docblock in TrustService is incorrect — the implementation is the source of truth.
+        $this->assertSame(__('trust.band_unruhig'), $this->service->getBand(-61));
     }
 
     public function testGetBand_returnsAufruhr_atMinus62(): void
     {
-        // Aufruhr starts at -62 (first value where `$moral >= -61` is false).
-        $this->assertSame(__('moral.band_aufruhr'), $this->service->getBand(-62));
+        // Aufruhr starts at -62 (first value where `$trust >= -61` is false).
+        $this->assertSame(__('trust.band_aufruhr'), $this->service->getBand(-62));
     }
 
     public function testGetBand_returnsUnruhig_atMinus60(): void
     {
-        $this->assertSame(__('moral.band_unruhig'), $this->service->getBand(-60));
+        $this->assertSame(__('trust.band_unruhig'), $this->service->getBand(-60));
     }
 
     public function testGetBand_returnsUnruhig_atMinus21(): void
     {
-        $this->assertSame(__('moral.band_unruhig'), $this->service->getBand(-21));
+        $this->assertSame(__('trust.band_unruhig'), $this->service->getBand(-21));
     }
 
     public function testGetBand_returnsStabil_atMinus20(): void
     {
-        $this->assertSame(__('moral.band_stabil'), $this->service->getBand(-20));
+        $this->assertSame(__('trust.band_stabil'), $this->service->getBand(-20));
     }
 
     public function testGetBand_returnsStabil_atZero(): void
     {
-        $this->assertSame(__('moral.band_stabil'), $this->service->getBand(0));
+        $this->assertSame(__('trust.band_stabil'), $this->service->getBand(0));
     }
 
     public function testGetBand_returnsStabil_at20(): void
     {
-        $this->assertSame(__('moral.band_stabil'), $this->service->getBand(20));
+        $this->assertSame(__('trust.band_stabil'), $this->service->getBand(20));
     }
 
     public function testGetBand_returnsZufrieden_at21(): void
     {
-        $this->assertSame(__('moral.band_zufrieden'), $this->service->getBand(21));
+        $this->assertSame(__('trust.band_zufrieden'), $this->service->getBand(21));
     }
 
     public function testGetBand_returnsZufrieden_at60(): void
     {
-        $this->assertSame(__('moral.band_zufrieden'), $this->service->getBand(60));
+        $this->assertSame(__('trust.band_zufrieden'), $this->service->getBand(60));
     }
 
     public function testGetBand_returnsEuphorisch_at61(): void
     {
-        $this->assertSame(__('moral.band_euphorisch'), $this->service->getBand(61));
+        $this->assertSame(__('trust.band_euphorisch'), $this->service->getBand(61));
     }
 
     public function testGetBand_returnsEuphorisch_at100(): void
     {
-        $this->assertSame(__('moral.band_euphorisch'), $this->service->getBand(100));
+        $this->assertSame(__('trust.band_euphorisch'), $this->service->getBand(100));
     }
 
     // ── getBand() — locale translation ───────────────────────────────────────
@@ -189,16 +189,16 @@ class MoralServiceTest extends TestCase
     {
         // When a locale has no translation file at all (not even in the fallback chain),
         // Laravel returns the translation key verbatim. This documents that behaviour:
-        // callers must ensure the active locale has a moral.php file.
+        // callers must ensure the active locale has a trust.php file.
         app()->setLocale('xx');
 
-        $this->assertSame('moral.band_euphorisch', $this->service->getBand(100));
-        $this->assertSame('moral.band_aufruhr',    $this->service->getBand(-100));
+        $this->assertSame('trust.band_euphorisch', $this->service->getBand(100));
+        $this->assertSame('trust.band_aufruhr',    $this->service->getBand(-100));
     }
 
     // ── getProductionMultiplier() ─────────────────────────────────────────────
 
-    public function testGetProductionMultiplier_neutralMoral_returnsOne(): void
+    public function testGetProductionMultiplier_neutralTrust_returnsOne(): void
     {
         $this->assertSame(1.0, $this->service->getProductionMultiplier(0));
     }
@@ -229,7 +229,7 @@ class MoralServiceTest extends TestCase
 
     // ── getApMultiplier() ────────────────────────────────────────────────────
 
-    public function testGetApMultiplier_neutralMoral_returnsOne(): void
+    public function testGetApMultiplier_neutralTrust_returnsOne(): void
     {
         $this->assertSame(1.0, $this->service->getApMultiplier(0));
     }
@@ -246,39 +246,39 @@ class MoralServiceTest extends TestCase
         $this->assertSame(0.80, $this->service->getApMultiplier(-80));
     }
 
-    // ── getMoral() ───────────────────────────────────────────────────────────
+    // ── getTrust() ───────────────────────────────────────────────────────────
 
-    public function testGetMoral_returnsZero_whenNoRowExists(): void
+    public function testGetTrust_returnsZero_whenNoRowExists(): void
     {
         // setUp already deleted all resource_id=12 rows
-        $this->assertSame(0, $this->service->getMoral($this->colonyId));
+        $this->assertSame(0, $this->service->getTrust($this->colonyId));
     }
 
-    public function testGetMoral_returnsStoredPositiveValue(): void
+    public function testGetTrust_returnsStoredPositiveValue(): void
     {
         DB::table('colony_resources')->insert([
-            'resource_id' => MoralService::RESOURCE_ID,
+            'resource_id' => TrustService::RESOURCE_ID,
             'colony_id'   => $this->colonyId,
             'amount'      => 42,
         ]);
 
-        $this->assertSame(42, $this->service->getMoral($this->colonyId));
+        $this->assertSame(42, $this->service->getTrust($this->colonyId));
     }
 
-    public function testGetMoral_returnsStoredNegativeValue(): void
+    public function testGetTrust_returnsStoredNegativeValue(): void
     {
         DB::table('colony_resources')->insert([
-            'resource_id' => MoralService::RESOURCE_ID,
+            'resource_id' => TrustService::RESOURCE_ID,
             'colony_id'   => $this->colonyId,
             'amount'      => -35,
         ]);
 
-        $this->assertSame(-35, $this->service->getMoral($this->colonyId));
+        $this->assertSame(-35, $this->service->getTrust($this->colonyId));
     }
 
-    public function testGetMoral_returnsZero_forUnknownColony(): void
+    public function testGetTrust_returnsZero_forUnknownColony(): void
     {
-        $this->assertSame(0, $this->service->getMoral(99999));
+        $this->assertSame(0, $this->service->getTrust(99999));
     }
 
     // ── fireEvent() ──────────────────────────────────────────────────────────
@@ -287,7 +287,7 @@ class MoralServiceTest extends TestCase
     {
         $this->service->fireEvent($this->colonyId, 'trade_success', $this->tick);
 
-        $this->assertDatabaseHas('moral_events', [
+        $this->assertDatabaseHas('trust_events', [
             'colony_id'  => $this->colonyId,
             'tick'       => $this->tick,
             'event_type' => 'trade_success',
@@ -298,7 +298,7 @@ class MoralServiceTest extends TestCase
     {
         $this->service->fireEvent($this->colonyId, 'made_up_event', $this->tick);
 
-        $this->assertDatabaseMissing('moral_events', [
+        $this->assertDatabaseMissing('trust_events', [
             'colony_id' => $this->colonyId,
         ]);
     }
@@ -310,7 +310,7 @@ class MoralServiceTest extends TestCase
 
         $expectedTick = $this->tickService->getTickCount() + 1;
 
-        $this->assertDatabaseHas('moral_events', [
+        $this->assertDatabaseHas('trust_events', [
             'colony_id'  => $this->colonyId,
             'tick'       => $expectedTick,
             'event_type' => 'encounter_won',
@@ -322,16 +322,16 @@ class MoralServiceTest extends TestCase
         $customTick = 9999;
         $this->service->fireEvent($this->colonyId, 'treaty_signed', $customTick);
 
-        $this->assertDatabaseHas('moral_events', [
+        $this->assertDatabaseHas('trust_events', [
             'colony_id'  => $this->colonyId,
             'tick'       => $customTick,
             'event_type' => 'treaty_signed',
         ]);
     }
 
-    // ── calculateMoral() — building contribution ─────────────────────────────
+    // ── calculateTrust() — building contribution ─────────────────────────────
 
-    public function testCalculateMoral_positiveBuildingContribution(): void
+    public function testCalculateTrust_positiveBuildingContribution(): void
     {
         // hospital (id=46): +3 per level; level=4 → +12
         DB::table('colony_buildings')->insert([
@@ -342,12 +342,12 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(12, $moral);
+        $this->assertSame(12, $trust);
     }
 
-    public function testCalculateMoral_buildingWithZeroStatusPoints_isExcluded(): void
+    public function testCalculateTrust_buildingWithZeroStatusPoints_isExcluded(): void
     {
         // hospital (id=46): status_points=0 → should not contribute
         DB::table('colony_buildings')->insert([
@@ -358,14 +358,14 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(0, $moral);
+        $this->assertSame(0, $trust);
     }
 
-    public function testCalculateMoral_buildingNotInConfig_isIgnored(): void
+    public function testCalculateTrust_buildingNotInConfig_isIgnored(): void
     {
-        // commandCenter (id=25) is not in game.moral.buildings → no contribution
+        // commandCenter (id=25) is not in trust config → no contribution
         DB::table('colony_buildings')->insert([
             'colony_id'    => $this->colonyId,
             'building_id'  => 25,
@@ -374,14 +374,14 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(0, $moral);
+        $this->assertSame(0, $trust);
     }
 
-    // ── calculateMoral() — research contribution ─────────────────────────────
+    // ── calculateTrust() — research contribution ─────────────────────────────
 
-    public function testCalculateMoral_positiveResearchContribution(): void
+    public function testCalculateTrust_positiveResearchContribution(): void
     {
         // health (id=94): +2 per level; level=3 → +6
         DB::table('colony_researches')->insert([
@@ -392,12 +392,12 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(6, $moral);
+        $this->assertSame(6, $trust);
     }
 
-    public function testCalculateMoral_negativeResearchContribution(): void
+    public function testCalculateTrust_negativeResearchContribution(): void
     {
         // defense (id=96): -1 per level; level=10 → -10
         DB::table('colony_researches')->insert([
@@ -408,14 +408,14 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(-10, $moral);
+        $this->assertSame(-10, $trust);
     }
 
-    public function testCalculateMoral_researchNotInConfig_isIgnored(): void
+    public function testCalculateTrust_researchNotInConfig_isIgnored(): void
     {
-        // mathematics (research_id=73 in testdata, not in moral.researches config)
+        // mathematics (research_id=73 in testdata, not in trust config)
         DB::table('colony_researches')->insert([
             'colony_id'    => $this->colonyId,
             'research_id'  => 73,
@@ -424,14 +424,14 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(0, $moral);
+        $this->assertSame(0, $trust);
     }
 
-    // ── calculateMoral() — ship contribution ─────────────────────────────────
+    // ── calculateTrust() — ship contribution ─────────────────────────────────
 
-    public function testCalculateMoral_positiveShipContribution(): void
+    public function testCalculateTrust_positiveShipContribution(): void
     {
         // frachter (id=47): +1 per unit; level=6 → +6
         DB::table('colony_ships')->insert([
@@ -442,12 +442,12 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(6, $moral);
+        $this->assertSame(6, $trust);
     }
 
-    public function testCalculateMoral_negativeShipContribution(): void
+    public function testCalculateTrust_negativeShipContribution(): void
     {
         // korvette (id=37): -1 per unit; level=20 → -20
         DB::table('colony_ships')->insert([
@@ -458,12 +458,12 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(-20, $moral);
+        $this->assertSame(-20, $trust);
     }
 
-    public function testCalculateMoral_shipContribution_isCapppedAtPositive30(): void
+    public function testCalculateTrust_shipContribution_isCapppedAtPositive30(): void
     {
         // frachter (id=47): +1 per unit; level=100 → raw +100, capped to +30
         DB::table('colony_ships')->insert([
@@ -474,12 +474,12 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(30, $moral);
+        $this->assertSame(30, $trust);
     }
 
-    public function testCalculateMoral_shipContribution_isCappedAtNegative30(): void
+    public function testCalculateTrust_shipContribution_isCappedAtNegative30(): void
     {
         // korvette (id=37): -1 per unit; level=100 → raw -100, capped to -30
         DB::table('colony_ships')->insert([
@@ -490,86 +490,86 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(-30, $moral);
+        $this->assertSame(-30, $trust);
     }
 
-    // ── calculateMoral() — event contribution ────────────────────────────────
+    // ── calculateTrust() — event contribution ────────────────────────────────
 
-    public function testCalculateMoral_eventContribution_addsDeltaForMatchingTick(): void
+    public function testCalculateTrust_eventContribution_addsDeltaForMatchingTick(): void
     {
         // trade_success: +2
         $this->service->fireEvent($this->colonyId, 'trade_success', $this->tick);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(2, $moral);
+        $this->assertSame(2, $trust);
     }
 
-    public function testCalculateMoral_sameEventTypeFiredTwice_countsOnlyOnce(): void
+    public function testCalculateTrust_sameEventTypeFiredTwice_countsOnlyOnce(): void
     {
         // trade_success: +2, fired twice — must NOT stack
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => $this->colonyId,
             'tick'       => $this->tick,
             'event_type' => 'trade_success',
         ]);
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => $this->colonyId,
             'tick'       => $this->tick,
             'event_type' => 'trade_success',
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
         // trade_success = +2, counted once
-        $this->assertSame(2, $moral);
+        $this->assertSame(2, $trust);
     }
 
-    public function testCalculateMoral_eventForDifferentTick_isNotIncluded(): void
+    public function testCalculateTrust_eventForDifferentTick_isNotIncluded(): void
     {
         // Fire event for tick+1 — should NOT appear in calculation for $this->tick
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => $this->colonyId,
             'tick'       => $this->tick + 1,
             'event_type' => 'trade_success',
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(0, $moral);
+        $this->assertSame(0, $trust);
     }
 
-    public function testCalculateMoral_multipleDistinctEvents_areSummed(): void
+    public function testCalculateTrust_multipleDistinctEvents_areSummed(): void
     {
         // trade_success (+2) + encounter_won (+2) + treaty_signed (+3) = +7
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             ['colony_id' => $this->colonyId, 'tick' => $this->tick, 'event_type' => 'trade_success'],
             ['colony_id' => $this->colonyId, 'tick' => $this->tick, 'event_type' => 'encounter_won'],
             ['colony_id' => $this->colonyId, 'tick' => $this->tick, 'event_type' => 'treaty_signed'],
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(7, $moral);
+        $this->assertSame(7, $trust);
     }
 
-    public function testCalculateMoral_negativeEventContribution(): void
+    public function testCalculateTrust_negativeEventContribution(): void
     {
         // encounter_lost: -5
         $this->service->fireEvent($this->colonyId, 'encounter_lost', $this->tick);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(-5, $moral);
+        $this->assertSame(-5, $trust);
     }
 
-    // ── calculateMoral() — global clamp ──────────────────────────────────────
+    // ── calculateTrust() — global clamp ──────────────────────────────────────
 
-    public function testCalculateMoral_isClampedToPositive100(): void
+    public function testCalculateTrust_isClampedToPositive100(): void
     {
-        // Insert many positive-moral hospitals to push raw sum well above 100
+        // Insert many positive-trust hospitals to push raw sum well above 100
         // hospital (id=46): +3/level; level=50 → raw building contribution = 150
         DB::table('colony_buildings')->insert([
             'colony_id'    => $this->colonyId,
@@ -579,12 +579,12 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(100, $moral);
+        $this->assertSame(100, $trust);
     }
 
-    public function testCalculateMoral_isClampedToNegative100(): void
+    public function testCalculateTrust_isClampedToNegative100(): void
     {
         // defense (id=96): -1/level; level=200 → raw -200, clamped to -100
         DB::table('colony_researches')->insert([
@@ -595,16 +595,16 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(-100, $moral);
+        $this->assertSame(-100, $trust);
     }
 
     // ── calculateAndStore() ───────────────────────────────────────────────────
 
-    public function testCalculateAndStore_persistsMoralInColonyResources(): void
+    public function testCalculateAndStore_persistsTrustInColonyResources(): void
     {
-        // hospital (id=46): +3/level; level=5 → moral = +15
+        // hospital (id=46): +3/level; level=5 → trust = +15
         DB::table('colony_buildings')->insert([
             'colony_id'    => $this->colonyId,
             'building_id'  => 46,
@@ -620,21 +620,21 @@ class MoralServiceTest extends TestCase
 
         $this->assertDatabaseHas('colony_resources', [
             'colony_id'   => $this->colonyId,
-            'resource_id' => MoralService::RESOURCE_ID,
+            'resource_id' => TrustService::RESOURCE_ID,
             'amount'      => 15,
         ]);
     }
 
     public function testCalculateAndStore_updatesExistingRow(): void
     {
-        // Pre-insert a stale moral value
+        // Pre-insert a stale trust value
         DB::table('colony_resources')->insert([
-            'resource_id' => MoralService::RESOURCE_ID,
+            'resource_id' => TrustService::RESOURCE_ID,
             'colony_id'   => $this->colonyId,
             'amount'      => 99,
         ]);
 
-        // No buildings/events → moral = 0
+        // No buildings/events → trust = 0
         $colony = Colony::find($this->colonyId);
         $result = $this->service->calculateAndStore($colony, $this->tick);
 
@@ -643,14 +643,14 @@ class MoralServiceTest extends TestCase
         // Must update, not insert a second row
         $count = DB::table('colony_resources')
             ->where('colony_id', $this->colonyId)
-            ->where('resource_id', MoralService::RESOURCE_ID)
+            ->where('resource_id', TrustService::RESOURCE_ID)
             ->count();
 
         $this->assertSame(1, $count);
 
         $this->assertDatabaseHas('colony_resources', [
             'colony_id'   => $this->colonyId,
-            'resource_id' => MoralService::RESOURCE_ID,
+            'resource_id' => TrustService::RESOURCE_ID,
             'amount'      => 0,
         ]);
     }
@@ -683,9 +683,9 @@ class MoralServiceTest extends TestCase
             'ap_spend'     => 0,
         ]);
 
-        $colony = Colony::find($this->colonyId);
+        $colony   = Colony::find($this->colonyId);
         $returned = $this->service->calculateAndStore($colony, $this->tick);
-        $stored   = $this->service->getMoral($this->colonyId);
+        $stored   = $this->service->getTrust($this->colonyId);
 
         $this->assertSame(14, $returned);
         $this->assertSame($returned, $stored);
@@ -693,7 +693,7 @@ class MoralServiceTest extends TestCase
 
     // ── Combined contributions ────────────────────────────────────────────────
 
-    public function testCalculateMoral_combinesAllSources(): void
+    public function testCalculateTrust_combinesAllSources(): void
     {
         // hospital (id=46): +3/level; level=2 → +6
         DB::table('colony_buildings')->insert([
@@ -723,15 +723,15 @@ class MoralServiceTest extends TestCase
         ]);
 
         // trade_success: +2
-        DB::table('moral_events')->insert([
+        DB::table('trust_events')->insert([
             'colony_id'  => $this->colonyId,
             'tick'       => $this->tick,
             'event_type' => 'trade_success',
         ]);
 
-        $moral = $this->service->calculateMoral($this->colonyId, $this->tick);
+        $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
         // +6 (buildings) + +6 (researches) + +2 (ships) + +2 (events) = +16
-        $this->assertSame(16, $moral);
+        $this->assertSame(16, $trust);
     }
 }


### PR DESCRIPTION
## Summary

**Moral → Trust/Vertrauen** — vollständige Umbenennung + Docs-Review-TODOs abgearbeitet.

### Refactoring: Moral → Trust
- `MoralService` → `TrustService`; `getMoral()` → `getTrust()`; `calculateMoral()` → `calculateTrust()`
- Config-Keys: `game.moral.*` → `game.trust.*`; `moral_per_lv` → `trust_per_lv`; `moral_per_unit` → `trust_per_unit`
- DB: Tabelle `moral_events` → `trust_events` (Migration `2026_06_05`); Resource-Slug `res_moral` → `res_trust`
- Lang: `lang/de/moral.php` → `trust.php`; `res_moral` → `res_trust`; `Moraleffekt` → `Vertrauenseffekt`
- Views/CSS: `.resicon-moral` → `.resicon-trust`; Nexusdb-Blade + Debug-Bar aktualisiert
- Tests: `MoralServiceTest` → `TrustServiceTest`; alle `moral_events`-Referenzen ersetzt
- CLAUDE.md: `TrustService` + `game.trust.*` + UI-Label-Konvention dokumentiert

### GDD-Korrekturen (Docs-Review-TODOs)
- **§2**: Tick-Phasen auf 5 Konzeptphasen komprimiert; `GameTick.php`-Docblock als kanonische Quelle
- **§5**: Harvester-Rate feste `×10/level` dokumentiert; tile-abhängige Mechanik auf Phase 4+ verschoben
- **§4a**: `terrain_fog`/`terrain_locked` als UI-Render-States dokumentiert (kein DB `tile_type`)
- **§13**: Burnout-Implementierungshinweis korrigiert — probabilistische Prüfung Phase 4+

### Characters
- `informationsagent` → `information_broker` (Slug-Konsistenz; alle anderen Slugs englisch)
- Betrifft: `docs/characters/`, `config/characters.php`, `data/cantina_hotspots.json`

## Test plan

- [x] 759 Tests grün (0 Failures)
- [x] Migration läuft auf Dev-DB durch
- [ ] Smoke-Test: Kolonie laden, Vertrauens-Wert im UI prüfen
- [ ] Nexus-DB-Screen: Vertrauenseffekt-Spalte prüfen