### PR TITLE
docs(gdd): §8b Hangar-Screen — Nexus-Akquise-Modell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - **GDD §5**: Harvester-Produktionsrate — feste Rate `×10/level` dokumentiert (Phase 3); tile-abhängige Mechanik auf Phase 4+ verschoben.
 - **GDD §4a**: `terrain_fog` / `terrain_locked` als UI-Render-States dokumentiert (kein `tile_type` in DB — abgeleitet aus `is_explored` + `is_colony_zone`).
 - **Characters**: `informationsagent` → `information_broker` (Slug-Konsistenz; alle anderen Slugs englisch).
+- **GDD §8b Hangar-Redesign**: Schiffsakquise vollständig überarbeitet — Nexus als Lieferant statt Selbstbau. 4 Akquise-Pfade: Standardkauf (Credits + Lieferzeit), Nexus-Kredit (ab CC Lv2, Trust-Penalty), Konsul-Verhandlung (AP-Rabatt 50 Cr/AP), Event/Händler. Kein Duplikat-Constraint mehr. Pending-State für Schiffe ohne Hangar-Zuweisung (Decay 5 Sole).
+- **feat(hangar)**: `requestShip()` ersetzt `buildShip()`; `getPendingShips()`, `assignToHangar()` neu. `colony_ships` PK auto-increment. TickService `processHangarDeliveries()`. Config: `nexus_cost`/`nexus_delivery_ticks` in ships.php, `hangar`-Block in game.php. UI: "Nexus anfragen"-Dialog, Lieferung-State, "Nicht zugewiesen"-Sektion. 760 Tests grün.
 
 ## 2026-06-04
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1029,40 +1029,70 @@ Im Mehrspielermodus hat jeder Spieler einen eigenen Planeten im selben System. I
 
 ## 8b. Hangar-Screen
 
-Der Hangar-Screen ist die Verwaltungsansicht aller Schiffe einer Kolonie. Er wird aktiv sobald mindestens ein Hangar (CC Lv3) gebaut wurde.
+Der Hangar-Screen ist die Verwaltungsansicht aller Schiffe einer Kolonie. Er wird aktiv sobald mindestens ein Hangar (building_id 44, CC Lv3) gebaut wurde.
 
-### Carousel-View
+### Schiffsakquise — Grundprinzip
 
-Der Screen zeigt Schiffe in einer **Carousel-Navigation** — eine Karte pro Hangar-Slot, Swipe-Navigation auf Mobile, Dots-Pager für die Positionsanzeige. Jede Karte repräsentiert einen Slot; der Spieler navigiert durch die Slots wie durch Seiten.
+Schiffe werden **nicht selbst gebaut**. Die Kolonie verfügt nicht über Werftkapazität — Schiffe kommen ausschließlich von Nexus oder durch externe Ereignisse. Der Hangar ist Anforderungsstelle und Operationsbasis, keine Produktionsstätte.
 
-### Karten-States
+### Akquise-Pfade
+
+| Pfad | Kosten | Ergebnis |
+|------|--------|---------|
+| **Nexus-Anfrage (Standard)** | Credits + Lieferzeit (N Sole) | Schiff landet nach N Solen auf `docked` |
+| **Nexus-Kredit** | 0 Cr jetzt + Nexus-Schulden ↑ | Schiff sofort verfügbar; Schulden-Risiko (§15) |
+| **Konsul-Verhandlung** | Credits (reduziert) + Verhandlungs-AP | Konsul investiert AP explizit → niedrigerer Preis |
+| **Event / Händler** | situativ (Wrackbergung, Sonderdeal) | Schiff direkt `docked` oder `pending` |
+
+**Lieferzeiten Nexus-Anfrage** (Richtwerte — nach erstem Playtest kalibrieren):
+
+| Schiffstyp | Lieferzeit |
+|------------|-----------|
+| Drohne | 1–2 Sole |
+| Frachter | 3 Sole |
+| Korvette | 5 Sole |
+
+**Nexus-Kredit** erst ab CC Lv2 verfügbar. Nutzung erzeugt kleinen Trust-Abzug ("Die Kolonisten machen sich Sorgen über wachsende Schulden").
+
+### Schiffs-Besitz-Modell
+
+Hangare sind **operationale Slots** — nur ein Schiff pro Hangar-Instanz kann entsendet werden. Darüber hinaus können Schiffe **ohne Hangar-Zuweisung** existieren (`hangar_instance_id = NULL`, `ship_state = 'pending'`):
+
+- Entsteht durch Wrackbergung, Händler-Kauf oder Nexus-Lieferung wenn kein freier Hangar-Slot vorhanden
+- Sichtbar im Hangar-Screen als separater Bereich "Nicht zugewiesen" mit Decay-Countdown
+- Verfällt automatisch nach N Solen (TickService) wenn nicht einem Hangar zugewiesen
+- **Decay-Zeit:** nach Playtest kalibrieren (Richtwert: 5 Sole)
+
+Mehrere Schiffe desselben Typs sind erlaubt. Die natürliche Begrenzung ergibt sich aus dem Koloniebauplatz — ein Spieler kann realistisch 2–3 Hangare errichten bevor der Platz für wichtigere Gebäude fehlt. Kein Hard-Cap nötig.
+
+### Karten-States (Carousel)
 
 | State | Beschreibung | Aktion |
 |-------|-------------|--------|
-| Leer | Slot verfügbar, kein Schiff | Kommissionierung starten |
-| Im Bau (`ship_state: building`) | Schiff im Bau, Fortschrittsanzeige | Wartet auf Abschluss |
-| Angedockt (`docked`) | Schiff einsatzbereit im Hangar | Entsenden / Reparieren |
-| Unterwegs (`dispatched`) | Schiff auf aktiver Mission | Recall / Missionslog anzeigen |
+| Leer | Slot verfügbar | Nexus-Anfrage starten |
+| Lieferung (`building`) | Schiff unterwegs von Nexus | Wartet N Sole |
+| Angedockt (`docked`) | Schiff einsatzbereit | Entsenden / Reparieren |
+| Unterwegs (`dispatched`) | Schiff auf aktiver Mission | Zurückrufen / Missionslog |
 
-### Constraint: Kein Duplikat-Schiffstyp
-
-Pro Kolonie ist jeder Schiffstyp nur einmal erlaubt — kein zweites Schiff desselben Typs. Das begrenzt die Flottenkomposition bewusst und verhindert Massenproduktion eines einzelnen Typs.
+Nicht zugewiesene Schiffe (`pending`) erscheinen als separate Karten am Ende des Carousels mit sichtbarem Decay-Timer.
 
 ### Missionslog
 
-Jede abgeschlossene Mission wird in `colony_hangar_missions` gespeichert. Gespeicherte Felder: Zielkoordinaten, Sol-Distanz, Ergebnis. Das Log ist im Screen einsehbar (Swipe oder separater Tab).
+Jede abgeschlossene Mission wird in `colony_hangar_missions` gespeichert (Zielkoordinaten, Sol-Distanz, Ergebnis). Im Screen einsehbar.
 
 ### UI-Buttons
 
 | Button | Zustand | Funktion |
 |--------|---------|---------|
+| Nexus anfragen | Leer | Schiffstyp wählen, Akquise-Pfad wählen |
 | Entsenden | `docked` | Flottenorder erteilen |
-| Recall | `dispatched` | Schiff zurückrufen |
-| Reparieren | `docked`, SP < max | Repair-Order erteilen (Construction-AP) |
+| Zurückrufen | `dispatched` | Schiff zurückrufen |
+| Reparieren | `docked`, SP < max | Repair-Order (Construction-AP) |
+| Hangar zuweisen | `pending` | Schiff einem freien Hangar-Slot zuordnen |
 
 ### Technischer Stack
 
-Alpine.js + PicoCSS — kein jQuery, kein Bootstrap. Carousel-Logik in `public/js/carousel.js`, Styles in `public/css/carousel.css`.
+Alpine.js + PicoCSS. Carousel-Logik in `public/js/carousel.js`, Styles in `public/css/carousel.css`.
 
 ---
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1063,7 +1063,7 @@ Hangare sind **operationale Slots** — nur ein Schiff pro Hangar-Instanz kann e
 - Verfällt automatisch nach N Solen (TickService) wenn nicht einem Hangar zugewiesen
 - **Decay-Zeit:** nach Playtest kalibrieren (Richtwert: 5 Sole)
 
-Mehrere Schiffe desselben Typs sind erlaubt. Die natürliche Begrenzung ergibt sich aus dem Koloniebauplatz — ein Spieler kann realistisch 2–3 Hangare errichten bevor der Platz für wichtigere Gebäude fehlt. Kein Hard-Cap nötig.
+Mehrere Schiffe desselben Typs sind erlaubt. Die natürliche Begrenzung ergibt sich aus drei Faktoren: Koloniebauplatz, Supply-Kosten des Hangars und Credits für Nexus-Anfragen. Kein Hard-Cap nötig.
 
 ### Karten-States (Carousel)
 


### PR DESCRIPTION
## Summary

GDD §8b komplett überarbeitet — Hangar-Design grundlegend neu definiert.

**Kernentscheidungen:**
- Schiffe werden nicht selbst gebaut — kommen ausschließlich von Nexus oder Events
- 4 Akquise-Pfade: Nexus-Anfrage (Standard), Nexus-Kredit, Konsul-Verhandlung, Event/Händler
- Nexus-Kredit ab CC Lv2, erzeugt Nexus-Schulden + kleinen Trust-Abzug
- Konsul investiert Verhandlungs-AP aktiv → niedrigerer Credit-Preis
- `pending`-State für Schiffe ohne Hangar-Zuweisung (Decay nach N Solen)
- Kein Duplikat-Constraint mehr — natürlicher Cap durch Bauplatz + Supply + Credits
- Lieferzeiten: Richtwerte (Drohne 1–2 / Frachter 3 / Korvette 5 Sole) — nach Playtest kalibrieren

## Nächste Schritte (Implementierung, separater Branch)

- `HangarService::buildShip()` → `requestShip()` mit Credit-Check + Lieferzeit
- `ship_state = 'pending'` in DB
- Nexus-Kredit: CC Lv2 Gate + Trust-Abzug
- TickService: pending-Decay
- UI: "Nexus anfragen"-Flow + "Nicht zugewiesen"-Bereich