### PR TITLE
feat(hangar): instant ship-type action buttons (kein Confirm-Dialog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **Characters**: `informationsagent` → `information_broker` (Slug-Konsistenz; alle anderen Slugs englisch).
 - **GDD §8b Hangar-Redesign**: Schiffsakquise vollständig überarbeitet — Nexus als Lieferant statt Selbstbau. 4 Akquise-Pfade: Standardkauf (Credits + Lieferzeit), Nexus-Kredit (ab CC Lv2, Trust-Penalty), Konsul-Verhandlung (AP-Rabatt 50 Cr/AP), Event/Händler. Kein Duplikat-Constraint mehr. Pending-State für Schiffe ohne Hangar-Zuweisung (Decay 5 Sole).
 - **feat(hangar)**: `requestShip()` ersetzt `buildShip()`; `getPendingShips()`, `assignToHangar()` neu. `colony_ships` PK auto-increment. TickService `processHangarDeliveries()`. Config: `nexus_cost`/`nexus_delivery_ticks` in ships.php, `hangar`-Block in game.php. UI: "Nexus anfragen"-Dialog, Lieferung-State, "Nicht zugewiesen"-Sektion. 760 Tests grün.
+- **feat(hangar) UI**: Nexus-Request-Dialog auf Sofort-Buttons umgestellt — je Schiffstyp (Drohne/Frachter/Korvette) ein großer Button, Klick führt Request direkt aus ohne Bestätigungsschritt. Optionale Controls (Nexus-Kredit, Konsul-AP) nur bei Verfügbarkeit sichtbar.
 
 ## 2026-06-04
 

--- a/public/css/hangar.css
+++ b/public/css/hangar.css
@@ -409,29 +409,7 @@
     font-weight: 600;
 }
 
-/* Radio group for ship type selection */
-.hangar-ship-radio-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.3rem;
-}
-
-.hangar-ship-radio-group label {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 0.8rem;
-    font-weight: 400;
-    color: #333;
-    cursor: pointer;
-    padding: 0.25rem 0.4rem;
-    border-radius: 5px;
-    transition: background 0.1s;
-}
-
-.hangar-ship-radio-group label:hover {
-    background: #f5f5f8;
-}
+/* (Radio group styles removed — replaced by .hangar-ship-btn-list) */
 
 .hangar-form-actions {
     display: flex;
@@ -609,37 +587,6 @@
     margin-bottom: 0.35rem;
 }
 
-.hangar-radio-label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.82rem;
-    font-weight: 400;
-    color: #333;
-    cursor: pointer;
-    padding: 0.2rem 0.3rem;
-    border-radius: 5px;
-    transition: background 0.1s;
-}
-
-.hangar-radio-label:hover {
-    background: #f5f5f8;
-}
-
-.hangar-radio-label input[type="radio"] {
-    flex-shrink: 0;
-    margin: 0;
-    accent-color: #3b5ac6;
-}
-
-/* Cost hint next to ship type */
-.hangar-ship-cost {
-    margin-left: auto;
-    font-size: 0.71rem;
-    color: #888;
-    font-variant-numeric: tabular-nums;
-}
-
 /* Nexus credit hint text */
 .hangar-nexus-credit-hint {
     font-size: 0.68rem;
@@ -662,13 +609,108 @@
     accent-color: #3b5ac6;
 }
 
-.hangar-dialog-footer {
+/* ── Dialog optional controls (Nexus toggle + Consul AP range) ─────────────── */
+
+.hangar-dialog-controls {
     display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem 0.85rem;
-    border-top: 1px solid #eeeef4;
-    margin-top: 0.6rem;
+    flex-direction: column;
+    gap: 0.55rem;
+    padding: 0.6rem 1rem 0;
+}
+
+/* Nexus credit toggle row */
+.hangar-nexus-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-size: 0.82rem;
+    color: #333;
+    cursor: pointer;
+    user-select: none;
+}
+
+.hangar-nexus-toggle input[type="checkbox"] {
+    flex-shrink: 0;
+    margin: 0;
+    accent-color: #3b5ac6;
+}
+
+.hangar-nexus-toggle span {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+}
+
+/* ── Ship action buttons (quick-pick, one click = submit) ──────────────────── */
+
+.hangar-ship-btn-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 0.75rem 1rem 0;
+}
+
+.hangar-ship-btn {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    padding: 0.9rem 1.1rem;
+    background: #fff;
+    border: 1.5px solid #dde0ee;
+    border-radius: 8px;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.hangar-ship-btn:hover:not(:disabled) {
+    border-color: #3b5ac6;
+    background: #f4f6ff;
+}
+
+.hangar-ship-btn:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.hangar-ship-btn-name {
+    font-weight: 600;
+    font-size: 1rem;
+    color: #1a1a2e;
+    line-height: 1.2;
+}
+
+.hangar-ship-btn-meta {
+    font-size: 0.8rem;
+    color: var(--pico-muted-color, #888);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    margin-left: 0.75rem;
+}
+
+/* ── Dialog error + cancel footer ─────────────────────────────────────────── */
+
+.hangar-dialog-error {
+    padding: 0 1rem;
+    margin-top: 0.5rem;
+}
+
+.hangar-dialog-cancel {
+    text-align: center;
+    padding: 0.65rem 1rem 0.9rem;
+}
+
+.hangar-dialog-cancel a {
+    font-size: 0.8rem;
+    color: #888;
+    text-decoration: none;
+}
+
+.hangar-dialog-cancel a:hover {
+    color: #555;
+    text-decoration: underline;
 }
 
 /* ── Pending ships section ─────────────────────────────────────────────────── */

--- a/public/js/hangar.js
+++ b/public/js/hangar.js
@@ -39,13 +39,12 @@ function hangarCarousel(config) {
 
         // Nexus request modal state (shared across all slots)
         requestModal: {
-            open:           false,
-            instanceId:     null,
-            shipId:         null,
-            useNexusCredit: false,
-            consulAp:       0,
-            loading:        false,
-            error:          null,
+            open:            false,
+            instanceId:      null,
+            useNexusCredit:  false,
+            consulApSpent:   0,
+            loading:         false,
+            error:           null,
         },
 
         // Pending ship assignment state: keyed by ship row id
@@ -95,8 +94,21 @@ function hangarCarousel(config) {
          * Returns the credit savings for the current consul AP selection (50 Cr per AP).
          */
         get consulApSavings() {
-            const ap = this.requestModal.consulAp ?? 0;
+            const ap = this.requestModal.consulApSpent ?? 0;
             return ap > 0 ? '−' + (ap * 50) + ' Cr' : '';
+        },
+
+        /**
+         * Returns the effective cost for a given ship after applying consul AP discount.
+         * Each AP spent reduces cost by 50 Cr; result is clamped to 0.
+         * @param {number} shipId
+         * @returns {number}
+         */
+        effectiveCostFor(shipId) {
+            const entry = this.shipCosts[shipId];
+            if (!entry) return 0;
+            const discount = (this.requestModal.consulApSpent ?? 0) * 50;
+            return Math.max(0, entry.cost - discount);
         },
 
         openModal(instanceId, type) {
@@ -118,9 +130,8 @@ function hangarCarousel(config) {
             this.requestModal = {
                 open:           true,
                 instanceId,
-                shipId:         this.shipTypes.length > 0 ? this.shipTypes[0].id : null,
                 useNexusCredit: false,
-                consulAp:       0,
+                consulApSpent:  0,
                 loading:        false,
                 error:          null,
             };
@@ -135,22 +146,22 @@ function hangarCarousel(config) {
         },
 
         /**
-         * POST: request a ship from Nexus for an empty hangar slot.
+         * POST: request a specific ship from Nexus for the currently open empty slot.
+         * Called directly from each ship button — no separate confirm step.
          * Endpoint: POST /colony/hangar/request
          * Payload: { instance_id, ship_id, use_nexus_credit, consul_ap_spent }
+         * @param {number} shipId
          */
-        async submitRequest() {
-            if (!this.requestModal.shipId) return;
-
+        async submitRequestFor(shipId) {
             this.requestModal.loading = true;
             this.requestModal.error   = null;
 
             try {
                 const res = await this._post(this.routes.request, {
                     instance_id:      this.requestModal.instanceId,
-                    ship_id:          this.requestModal.shipId,
+                    ship_id:          shipId,
                     use_nexus_credit: this.requestModal.useNexusCredit ? 1 : 0,
-                    consul_ap_spent:  this.requestModal.consulAp ?? 0,
+                    consul_ap_spent:  this.requestModal.consulApSpent ?? 0,
                 });
                 if (res.ok) {
                     this._updateSlot(this.requestModal.instanceId, res.slot);

--- a/resources/views/colony/hangar.blade.php
+++ b/resources/views/colony/hangar.blade.php
@@ -457,79 +457,64 @@ window.__hangarData = {
                 <button class="hangar-dialog-close" @click="closeRequestModal()" aria-label="Close">&#x2715;</button>
             </header>
 
-            {{-- Ship type selection --}}
-            <fieldset class="hangar-dialog-fieldset">
-                <legend x-text="i18n.shipType"></legend>
-                <div class="hangar-ship-radio-group">
-                    <template x-for="type in shipTypes" :key="type.id">
-                        <label class="hangar-radio-label">
-                            <input type="radio"
-                                   :value="type.id"
-                                   x-model.number="requestModal.shipId">
-                            <span x-text="shipLabel(type.name)"></span>
-                            {{-- Cost hint from shipCosts map --}}
-                            <span class="hangar-ship-cost"
-                                  x-show="shipCosts[type.id]"
-                                  x-text="shipCosts[type.id] ? shipCosts[type.id].cost + ' Cr · Sol +' + shipCosts[type.id].delivery_ticks : ''">
-                            </span>
-                        </label>
-                    </template>
-                </div>
-            </fieldset>
+            {{-- ── Optional top controls ────────────────────────────────────── --}}
+            <div class="hangar-dialog-controls">
 
-            {{-- Payment method --}}
-            <fieldset class="hangar-dialog-fieldset">
-                <legend x-text="i18n.paymentMethod"></legend>
-
-                <label class="hangar-radio-label">
-                    <input type="radio" :value="false" x-model="requestModal.useNexusCredit">
-                    <span x-text="i18n.standardPurchase"></span>
-                </label>
-
-                {{-- Nexus credit option — only if CC level >= 2 --}}
+                {{-- Nexus credit toggle — only if CC level >= 2 --}}
                 <template x-if="canUseNexusCredit">
-                    <label class="hangar-radio-label">
-                        <input type="radio" :value="true" x-model="requestModal.useNexusCredit">
-                        <span x-text="i18n.nexusCredit"></span>
-                        <span class="hangar-nexus-credit-hint" x-text="i18n.nexusCreditHint"></span>
+                    <label class="hangar-nexus-toggle">
+                        <input type="checkbox" role="switch" x-model="requestModal.useNexusCredit">
+                        <span>
+                            <span x-text="i18n.nexusCredit"></span>
+                            <small class="hangar-nexus-credit-hint" x-text="i18n.nexusCreditHint"></small>
+                        </span>
                     </label>
                 </template>
-            </fieldset>
 
-            {{-- Consul AP negotiation — only if an active Konsul advisor exists with AP available --}}
-            <template x-if="hasAktivierterKonsul && verfuegbareVerhandlungsAP > 0">
-                <fieldset class="hangar-dialog-fieldset">
-                    <legend x-text="i18n.consulApTitle"></legend>
+                {{-- Consul AP range — only if an active Konsul advisor exists with AP available --}}
+                <template x-if="hasAktivierterKonsul && verfuegbareVerhandlungsAP > 0">
                     <label class="hangar-consul-ap-label">
                         <div class="form-row-label">
-                            <span>AP (1–<span x-text="verfuegbareVerhandlungsAP"></span>)</span>
+                            <span x-text="i18n.consulApTitle"></span>
                             <strong x-text="consulApSavings"></strong>
                         </div>
                         <input type="range"
                                min="0"
                                :max="verfuegbareVerhandlungsAP"
-                               x-model.number="requestModal.consulAp">
+                               x-model.number="requestModal.consulApSpent">
                     </label>
-                </fieldset>
-            </template>
+                </template>
+
+            </div>{{-- /.hangar-dialog-controls --}}
+
+            {{-- ── Ship buttons ─────────────────────────────────────────────── --}}
+            <div class="hangar-ship-btn-list">
+                <template x-for="type in shipTypes" :key="type.id">
+                    <button class="hangar-ship-btn"
+                            @click="submitRequestFor(type.id)"
+                            :disabled="requestModal.loading">
+                        <span class="hangar-ship-btn-name" x-text="shipLabel(type.name)"></span>
+                        <span class="hangar-ship-btn-meta"
+                              x-show="shipCosts[type.id]"
+                              x-text="shipCosts[type.id]
+                                  ? effectiveCostFor(type.id) + ' Cr · Sol +' + shipCosts[type.id].delivery_ticks
+                                  : ''">
+                        </span>
+                    </button>
+                </template>
+            </div>
 
             {{-- Error display --}}
-            <div class="hangar-error"
+            <div class="hangar-error hangar-dialog-error"
                  x-show="requestModal.error"
                  x-text="requestModal.error">
             </div>
 
-            <footer class="hangar-dialog-footer">
-                <button class="btn-hangar-action btn-hangar-action--secondary"
-                        @click="closeRequestModal()">
-                    <span x-text="i18n.cancel"></span>
-                </button>
-                <button class="btn-hangar-action"
-                        @click="submitRequest()"
-                        :disabled="!requestModal.shipId || requestModal.loading">
-                    <span x-text="requestModal.loading ? '…' : i18n.nexusRequestSubmit"></span>
-                </button>
-            </footer>
+            {{-- Cancel link --}}
+            <div class="hangar-dialog-cancel">
+                <a href="#" @click.prevent="closeRequestModal()" x-text="i18n.cancel"></a>
+            </div>
+
         </article>
 
     </dialog>


### PR DESCRIPTION
## Summary

- Nexus-Request Dialog: Radio-Buttons + separater Confirm-Button ersetzt durch 3 große Sofort-Buttons (je Schiffstyp: Drohne / Frachter / Korvette)
- Klick auf Button → POST direkt, kein separater Bestätigungsschritt
- Optionale Controls (Nexus-Kredit Toggle, Konsul-AP Slider) erscheinen nur wenn zutreffend, über den Buttons
- Abbrechen als schlichter Text-Link

## Änderungen

- `public/js/hangar.js`: `submitRequest()` → `submitRequestFor(shipId)`, neuer `effectiveCostFor(shipId)` Getter
- `resources/views/colony/hangar.blade.php`: `<fieldset>`/Radio-Groups entfernt, `x-for` Ship-Button-Liste
- `public/css/hangar.css`: Radio-Styles entfernt, `.hangar-ship-btn-list` / `.hangar-ship-btn` neu

## Test plan

- [ ] Leeren Hangar-Slot öffnen → Dialog zeigt 3 große Buttons
- [ ] Button klicken → Request direkt ausgeführt, kein zweiter Schritt
- [ ] Nexus-Kredit Toggle nur sichtbar ab CC Level 2
- [ ] Konsul-AP Slider nur sichtbar wenn aktiver Konsul mit AP > 0
- [ ] Konsul-AP ändert angezeigte Kosten live (effectiveCostFor)
- [ ] Abbrechen-Link schließt Dialog
- [ ] Alle 54 Hangar-Tests grün