### PR TITLE
docs(roadmap): Phase 3j INNN-Redesign + Playtest-Vorbereitung

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -571,6 +571,35 @@ Lokale Admin-Tools für den Entwickler — kein Spieler-Feature, kein Laravel-St
 
 ---
 
+## Phase 3 Playtest — Vorbereitung & nächste Schritte
+
+> **Fokus:** Singleplayer only. Multiplayer folgt erst in einer späteren Phase.
+
+### Playtest-Ziel
+
+Spieler soll in der Lage sein, die Kolonie von Beginn an auf etwa 80% auszubauen — d.h. alle wesentlichen Gebäude bauen, Berater einstellen, Ressourcen managen, Schiffe über Nexus anfragen, Run-Objectives verfolgen und einen Run zu einem (erfolgreichen oder gescheiterten) Ende zu bringen.
+
+### Playtest-Checkliste (vor erstem Playtest prüfen)
+
+- [ ] **Onboarding-Hints vollständig?** — Rang-1/2/3-Hinweise abdecken: CC aufleveln, Berater einstellen, ersten Harvester-Level, erste Versorgungsknappheit, Trust-Warnung. Fehlende Hints identifizieren und ergänzen.
+- [ ] **Neuer Run spielbar?** — Frischer Run: CommandCenter Lv1, Harvester Lv1, 3000 CR, 15 Supply. Kann der Spieler ohne externe Anleitung weiterkommen?
+- [ ] **Kritische Blocker?** — Gibt es Screens/Flows ohne Rückmeldung (leere States, fehlende Fehlermeldungen, unverständliche Labels)?
+- [ ] **INNN/Nachrichten vereinfachen** (siehe unten) — vor Playtest erledigen
+
+### Phase 3j: INNN-System Redesign *(nächste Session)*
+
+Das aktuelle Nachrichten-System (INNN) ist zu komplex und für den Singleplayer-Kontext überdimensioniert. Kernproblem: Es fehlt ein klarer **Aktions- und Ereignis-Log**, der dem Spieler zeigt, was pro Sol passiert ist.
+
+**Ziele:**
+- Vereinfachung auf das Wesentliche: **Ereignis-Log** (was passierte diesen Sol?) + **Nexus-Meldungen** (story-getriebene Nachrichten)
+- Komplexe Nachrichten-Typen (Outbox, Archive, Compose, Trade-Meldungen) entfernen oder zusammenführen
+- Aktions-Log: pro Sol eine Liste von Events (Gebäude aufgestuft, Schiff angekommen, Trust-Änderung, Supply-Warnung, …)
+- Technisch: `innn_events`-Tabelle als Basis des Logs; UI als einfache chronologische Liste im Colony-Layout
+
+**Noch offen:** Genaues Scope-Design vor Implementierung mit game-designer abstimmen.
+
+---
+
 ## Phase 4: "Das Spiel vertiefen"
 *(nach Phase 3)*
 


### PR DESCRIPTION
Dokumentiert den Plan für die nächste Phase vor dem ersten Playtest:

- **Phase 3j: INNN-System Redesign** — Vereinfachung auf Aktions-/Ereignis-Log + Nexus-Meldungen; Design mit game-designer vor Implementierung
- **Playtest-Checkliste** — Onboarding-Hints, neuer Run von Null, Blocker identifizieren
- Singleplayer-only-Fokus explizit festgehalten