### PR TITLE
feat(onboarding): 6 base AP per Sol, Harvester/Housing lv0 seed, distance-based move cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-06-11
+
+- **AP-Grundwert implementiert** (GDD §13): `PersonellService::getTotalActionPoints()` addiert jetzt 6 Basis-AP für alle Bereiche (Bau/Forschung/Wirtschaft/Strategie), unabhängig von Beratern. Neuer Config-Key `game.ap.base = 6`. Verhindert Deadlocks zu Spielbeginn. Alle betroffenen Tests (`PersonellServiceTest`, `TradeApTest`) auf neue Baseline angepasst.
+- **Onboarding-Startszenario überarbeitet**: Harvester (ID 27) und Wohndepot (ID 28) werden beim Setup nicht mehr auf Level 1 gesetzt, sondern als `level=0, ap_spend=7` (7/10 AP bereits investiert) und `tile_x=null` vorseeded. Spieler muss Sol 1 beide Gebäude fertigstellen und platzieren. Narrativ: Spieler übernimmt Kolonie im Aufbau. `OnboardingTest` + `OnboardingE2ETest` entsprechend aktualisiert.
+- **Harvester versetzen: distanzbasierte AP-Kosten** — Kolonie-Controller berechnet Hex-Distanz (axiale Koordinaten) zwischen altem und neuem Tile; Kosten = 1 Bau-AP pro Tile-Distanz. Neuer Hilfs-Methode `hexDistance()`. I18n-String (`onboarding_trigger_harvester_move`) aktualisiert.
+
 ## 2026-06-08
 
 - **Cantina: NPC-Portraits** — 15 Charakter-Portraits (`public/img/characters/`) eingebunden. Hotspot-Buttons zeigen Portrait-Karten (160×220px) statt Icon-Kreisen; Modal-Avatar zeigt Portrait statt Person-Icon. `colony.css`: `.has-portrait`-Modifier, `.hotspot-portrait`, `.guest-avatar__portrait`. Dev-Tool (Cantina-Tab): Charakter-Matrix zeigt Thumbnail-Portraits. `informationsagent.webp` → `information_broker.webp` (Slug-Konsistenz).

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -223,18 +223,32 @@ class ColonyController extends BaseController
         if ($occupied)
             return response()->json(['ok' => false, 'error' => __('colony.error_tile_occupied')]);
 
-        if (!config('game.bypass.ap_checks') && $this->personellService->getConstructionPoints($colony->id) < 1)
+        $building = DB::table('buildings')->where('id', $data['building_id'])->first();
+        if (!$building)
+            return response()->json(['ok' => false, 'error' => __('colony.error_building_not_found')]);
+
+        // Determine AP cost: Harvester move costs 1 AP per hex tile distance.
+        $existingBuilding = $building->is_instanced ? null : DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', $data['building_id'])
+            ->first();
+
+        $isHarvesterMove = (int) $data['building_id'] === BuildingId::Harvester->value
+            && $existingBuilding !== null
+            && $existingBuilding->tile_x !== null;
+
+        $apCost = $isHarvesterMove
+            ? max(1, $this->hexDistance((int)$existingBuilding->tile_x, (int)$existingBuilding->tile_y, (int)$data['q'], (int)$data['r']))
+            : 1;
+
+        if (!config('game.bypass.ap_checks') && $this->personellService->getConstructionPoints($colony->id) < $apCost)
             return response()->json([
                 'ok'      => false,
                 'error'   => 'ap_limit',
                 'ap_type' => 'construction',
-                'current' => 0,
+                'current' => $this->personellService->getConstructionPoints($colony->id),
                 'message' => __('colony.onboarding_trigger_ap_limit'),
             ]);
-
-        $building = DB::table('buildings')->where('id', $data['building_id'])->first();
-        if (!$building)
-            return response()->json(['ok' => false, 'error' => __('colony.error_building_not_found')]);
 
         if ($building->is_instanced) {
             $nextInstanceId = (int) DB::table('colony_buildings')
@@ -258,12 +272,20 @@ class ColonyController extends BaseController
                 ->where('building_id', $data['building_id'])
                 ->first();
 
-            if ($existing) {
+            if ($existingBuilding) {
+                $update = ['tile_x' => $data['q'], 'tile_y' => $data['r']];
+                // Preserve pre-invested ap_spend (seeded buildings); reset only on fresh placements.
+                if ($existingBuilding->tile_x === null) {
+                    $update['ap_spend'] = max((int) $existingBuilding->ap_spend, 1);
+                } elseif (!$isHarvesterMove) {
+                    $update['ap_spend'] = 1;
+                }
+                // Harvester move: tile updates, ap_spend unchanged.
                 DB::table('colony_buildings')
                     ->where('colony_id', $colony->id)
                     ->where('building_id', $data['building_id'])
-                    ->update(['tile_x' => $data['q'], 'tile_y' => $data['r'], 'ap_spend' => 1]);
-                $nextInstanceId = (int) $existing->instance_id;
+                    ->update($update);
+                $nextInstanceId = (int) $existingBuilding->instance_id;
             } else {
                 DB::table('colony_buildings')->insert([
                     'colony_id'     => $colony->id,
@@ -279,7 +301,7 @@ class ColonyController extends BaseController
         }
 
         if (!config('game.bypass.ap_checks'))
-            $this->personellService->lockActionPoints('construction', $colony->id, 1);
+            $this->personellService->lockActionPoints('construction', $colony->id, $apCost);
 
         $this->eventService->createEvent([
             'user'       => Auth::id(),
@@ -445,6 +467,13 @@ class ColonyController extends BaseController
             'apNav'          => $this->personellService->getAvailableActionPoints('navigation', $colonyId),
             'apConstruction' => $this->personellService->getAvailableActionPoints('construction', $colonyId),
         ];
+    }
+
+    private function hexDistance(int $q1, int $r1, int $q2, int $r2): int
+    {
+        $dq = $q2 - $q1;
+        $dr = $r2 - $r1;
+        return (abs($dq) + abs($dr) + abs($dq + $dr)) / 2;
     }
 
     private function fetchBuildingRow(int $colonyId, int $buildingId, int $instanceId = 1): object

--- a/app/Services/OnboardingService.php
+++ b/app/Services/OnboardingService.php
@@ -85,9 +85,10 @@ class OnboardingService
 
     private function seedStartingBuilding(int $colonyId): void
     {
-        // CommandCenter (building_id=25) at level 1 — operational base from day one.
-        // Harvester (building_id=27) at level 1 — immediately starts producing Regolith.
-        // status_points = max_status_points (20) so both are fully intact at start.
+        // CommandCenter (building_id=25) at level 1 — operational base, 1 advisor slot open.
+        // Harvester (building_id=27) at level 0, ap_spend=7 — "almost done", needs 3 more AP.
+        // HousingComplex (building_id=28) at level 0, ap_spend=7 — same; unplaced, player positions it.
+        // Narrative: player takes over a colony mid-construction and finishes the job Sol 1.
         DB::table('colony_buildings')->insert([
             [
                 'colony_id'     => $colonyId,
@@ -95,13 +96,26 @@ class OnboardingService
                 'level'         => 1,
                 'status_points' => 20,
                 'ap_spend'      => 0,
+                'tile_x'        => null,
+                'tile_y'        => null,
             ],
             [
                 'colony_id'     => $colonyId,
                 'building_id'   => 27,
-                'level'         => 1,
+                'level'         => 0,
                 'status_points' => 20,
-                'ap_spend'      => 0,
+                'ap_spend'      => 7,
+                'tile_x'        => null,
+                'tile_y'        => null,
+            ],
+            [
+                'colony_id'     => $colonyId,
+                'building_id'   => 28,
+                'level'         => 0,
+                'status_points' => 20,
+                'ap_spend'      => 7,
+                'tile_x'        => null,
+                'tile_y'        => null,
             ],
         ]);
     }

--- a/app/Services/Techtree/PersonellService.php
+++ b/app/Services/Techtree/PersonellService.php
@@ -58,7 +58,8 @@ class PersonellService
             return 0;
         }
 
-        $baseAp = Advisor::where('personell_id', $personellId)
+        $baseAp    = (int) config('game.ap.base', 6);
+        $advisorAp = Advisor::where('personell_id', $personellId)
             ->whereNull('unavailable_until_tick')
             ->where('colony_id', $scopeId)
             ->get()
@@ -67,7 +68,7 @@ class PersonellService
         // Apply trust AP multiplier for colony-scoped types.
         $trust      = $this->trustService->getTrust($scopeId);
         $multiplier = $this->trustService->getApMultiplier($trust);
-        return (int) round($baseAp * $multiplier);
+        return (int) round(($baseAp + $advisorAp) * $multiplier);
     }
 
     public function getAvailableActionPoints(string $type, int $scopeId): int

--- a/config/game.php
+++ b/config/game.php
@@ -53,6 +53,13 @@ return [
         41 => [5 => 10],   // bioFacility    → Organika   (Organics)   × 10/level
     ],
 
+    // Action Points — base value per AP type per Sol, regardless of advisors.
+    // Advisors add their rank bonus on top. See GDD §13.
+    // Formula: availableAP = base + AP_bonus(advisor_rank) - lockedAP(tick)
+    'ap' => [
+        'base' => 6,
+    ],
+
     // Supply cap model — supply is not generated per tick, it is a capacity ceiling.
     // Formula: CC-Level × cap_commandcenter + housing_units × cap_housingcomplex + Σ(knowledge_cap_per_level)
     // Per-entity supply_cost values live in config/buildings.php and config/ships.php.

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -80,7 +80,7 @@ return [
     'onboarding_trigger_ap_limit'       => 'Keine Bau-AP mehr in diesem Sol verfügbar.',
 
     // Trigger 5 — Harvester-Verlagerung (Tooltip)
-    'onboarding_trigger_harvester_move' => 'Verlegen kostet 1 Bau-AP — der Harvester produziert danach auf dem neuen Tile.',
+    'onboarding_trigger_harvester_move' => 'Verlegen kostet 1 Bau-AP pro Tile-Distanz — der Harvester produziert danach auf dem neuen Tile.',
 
     // ── Error messages ────────────────────────────────────────────────────────
 

--- a/tests/Feature/Auth/OnboardingTest.php
+++ b/tests/Feature/Auth/OnboardingTest.php
@@ -55,14 +55,24 @@ class OnboardingTest extends TestCase
         $this->assertNotNull($cc, 'CommandCenter must be placed');
         $this->assertEquals(1, $cc->level);
 
-        // Harvester at level 1 — immediately operational from day one
+        // Harvester at level 0, ap_spend=7 — "almost done", player places + finishes it Sol 1
         $harvester = DB::table('colony_buildings')
             ->where('colony_id', $colony->id)
             ->where('building_id', 27)
             ->first();
-        $this->assertNotNull($harvester, 'Harvester must be placed at game start');
-        $this->assertEquals(1, $harvester->level);
-        $this->assertEquals(20, $harvester->status_points, 'Harvester must start fully intact');
+        $this->assertNotNull($harvester, 'Harvester must exist at game start');
+        $this->assertEquals(0, $harvester->level, 'Harvester starts unfinished (level 0)');
+        $this->assertEquals(7, $harvester->ap_spend, 'Harvester has 7/10 AP pre-invested');
+        $this->assertNull($harvester->tile_x, 'Harvester starts unplaced — player positions it');
+
+        // HousingComplex at level 0, ap_spend=7 — same as harvester
+        $housing = DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', 28)
+            ->first();
+        $this->assertNotNull($housing, 'HousingComplex must exist at game start');
+        $this->assertEquals(0, $housing->level, 'HousingComplex starts unfinished (level 0)');
+        $this->assertEquals(7, $housing->ap_spend, 'HousingComplex has 7/10 AP pre-invested');
     }
 
     public function test_setup_new_player_uses_free_planet(): void

--- a/tests/Feature/Onboarding/OnboardingE2ETest.php
+++ b/tests/Feature/Onboarding/OnboardingE2ETest.php
@@ -87,15 +87,11 @@ class OnboardingE2ETest extends TestCase
             'is_explored'    => 1,
         ]);
 
-        DB::table('colony_buildings')->insert([
-            'colony_id'     => $colony->id,
-            'building_id'   => 28,   // housingComplex
-            'level'         => 1,
-            'status_points' => 20,
-            'ap_spend'      => 0,
-            'tile_x'        => 1,
-            'tile_y'        => 0,
-        ]);
+        // Housing is pre-seeded by setupNewPlayer (level 0, unplaced). Simulate placement + completion.
+        DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', 28)
+            ->update(['level' => 1, 'status_points' => 20, 'ap_spend' => 0, 'tile_x' => 1, 'tile_y' => 0]);
 
         // ── 5. Rank-2 hint active (no engineer, tick above threshold) ────────
         $threshold = (int) config('game.onboarding.hint_no_engineer_ticks', 3);

--- a/tests/Feature/Techtree/PersonellServiceTest.php
+++ b/tests/Feature/Techtree/PersonellServiceTest.php
@@ -39,17 +39,17 @@ class PersonellServiceTest extends TestCase
 
     public function testGetTotalActionPoints(): void
     {
-        // 1 engineer rank2 = 7
-        $this->assertEquals(7, $this->service->getTotalActionPoints('construction', $this->colonyId));
-        // 1 scientist rank1 = 4
-        $this->assertEquals(4, $this->service->getTotalActionPoints('research', $this->colonyId));
-        // unknown = 0
+        // 6 base + engineer rank2 (7) = 13
+        $this->assertEquals(13, $this->service->getTotalActionPoints('construction', $this->colonyId));
+        // 6 base + scientist rank1 (4) = 10
+        $this->assertEquals(10, $this->service->getTotalActionPoints('research', $this->colonyId));
+        // unknown type: no base AP (early return)
         $this->assertEquals(0, $this->service->getTotalActionPoints('unknown', $this->colonyId));
     }
 
     public function testGetAvailableActionPoints(): void
     {
-        $this->assertEquals(7, $this->service->getAvailableActionPoints('construction', $this->colonyId));
+        $this->assertEquals(13, $this->service->getAvailableActionPoints('construction', $this->colonyId));
         $this->assertEquals(0,  $this->service->getAvailableActionPoints('unknown', $this->colonyId));
     }
 
@@ -179,8 +179,8 @@ class PersonellServiceTest extends TestCase
             'unavailable_until_tick' => 99999,
         ]);
 
-        // Economy AP should be 0 — the unavailable trader is excluded
-        $this->assertEquals(0, $this->service->getTotalActionPoints('economy', $this->colonyId));
+        // Economy AP should be base 6 only — the unavailable trader is excluded
+        $this->assertEquals(6, $this->service->getTotalActionPoints('economy', $this->colonyId));
     }
 
     // ── hire(): rank clamping and validation ──────────────────────────────────
@@ -238,8 +238,8 @@ class PersonellServiceTest extends TestCase
     {
         $this->service->lockActionPoints('construction', $this->colonyId, 3);
         $this->service->lockActionPoints('construction', $this->colonyId, 2);
-        // 7 total − 5 locked = 2
-        $this->assertEquals(2, $this->service->getAvailableActionPoints('construction', $this->colonyId));
+        // 13 total − 5 locked = 8
+        $this->assertEquals(8, $this->service->getAvailableActionPoints('construction', $this->colonyId));
     }
 
     public function testLockActionPointsWithNegativeAmountIsSanitised(): void
@@ -310,9 +310,10 @@ class PersonellServiceTest extends TestCase
 
     // ── getEconomyPoints() convenience wrapper ────────────────────────────────
 
-    public function testGetEconomyPointsReturnsZeroWithNoTraders(): void
+    public function testGetEconomyPointsReturnsBaseWithNoTraders(): void
     {
-        $this->assertEquals(0, $this->service->getEconomyPoints($this->colonyId));
+        // Base 6 AP always present even without advisor
+        $this->assertEquals(6, $this->service->getEconomyPoints($this->colonyId));
     }
 
     public function testGetEconomyPointsWithTrader(): void
@@ -324,7 +325,8 @@ class PersonellServiceTest extends TestCase
             'rank'         => 2,
             'active_ticks' => 0,
         ]);
-        $this->assertEquals(7, $this->service->getEconomyPoints($this->colonyId));
+        // 6 base + trader rank2 (7) = 13
+        $this->assertEquals(13, $this->service->getEconomyPoints($this->colonyId));
     }
 
     // ── incrementAdvisorTicks() via GameTick command ──────────────────────────

--- a/tests/Feature/Trade/TradeApTest.php
+++ b/tests/Feature/Trade/TradeApTest.php
@@ -95,10 +95,10 @@ class TradeApTest extends TestCase
      */
     public function test_add_offer_locks_economy_ap(): void
     {
-        $this->hireTrader(1); // 4 AP available on colony 1
+        $this->hireTrader(1); // 6 base + 4 trader rank1 = 10 AP
 
         $apBefore = $this->personellService->getEconomyPoints(1);
-        $this->assertSame(4, $apBefore);
+        $this->assertSame(10, $apBefore);
 
         $result = $this->gateway->addResourceOffer([
             'colony_id'   => 1,
@@ -112,8 +112,8 @@ class TradeApTest extends TestCase
         $this->assertTrue($result);
 
         $apAfter = $this->personellService->getEconomyPoints(1);
-        // min cost is 1 AP: max(1, floor(100×5/1000)) = max(1, 0) = 1
-        $this->assertSame(3, $apAfter);
+        // min cost is 1 AP: max(1, floor(100×5/1000)) = max(1, 0) = 1; 10 - 1 = 9
+        $this->assertSame(9, $apAfter);
     }
 
     /**
@@ -121,7 +121,8 @@ class TradeApTest extends TestCase
      */
     public function test_add_offer_fails_when_insufficient_economy_ap(): void
     {
-        // No trader hired → 0 economy AP
+        // No trader hired → 6 base AP. Lock all 6 first to exhaust the pool.
+        $this->personellService->lockActionPoints('economy', 1, 6);
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Wirtschafts-AP');
 
@@ -143,11 +144,11 @@ class TradeApTest extends TestCase
      */
     public function test_accept_offer_locks_economy_ap_on_buyer(): void
     {
-        $this->hireTrader(1); // Bart's colony gets 4 economy AP
+        $this->hireTrader(1); // 6 base + 4 trader rank1 = 10 AP
         $this->setColony2Resource(5, 200); // Homer stocks resource 5
 
         $apBefore = $this->personellService->getEconomyPoints(1);
-        $this->assertSame(4, $apBefore);
+        $this->assertSame(10, $apBefore);
 
         // Offer: col 2, dir=1, res=5, amount=123, price=32 → total = 3936 credits
         $result = $this->gateway->acceptResourceOffer(
@@ -161,7 +162,7 @@ class TradeApTest extends TestCase
         $this->assertTrue($result);
 
         $apAfter = $this->personellService->getEconomyPoints(1);
-        $this->assertSame(3, $apAfter); // 1 AP locked
+        $this->assertSame(9, $apAfter); // 10 - 1 AP locked
     }
 
     /**
@@ -169,7 +170,8 @@ class TradeApTest extends TestCase
      */
     public function test_accept_offer_fails_when_buyer_has_insufficient_economy_ap(): void
     {
-        // No trader on colony 1 → 0 economy AP
+        // No trader on colony 1 → 6 base AP. Lock all 6 to exhaust the pool.
+        $this->personellService->lockActionPoints('economy', 1, 6);
         $this->setColony2Resource(5, 200);
 
         $this->expectException(\InvalidArgumentException::class);
@@ -195,7 +197,7 @@ class TradeApTest extends TestCase
         $this->hireTrader(1, rank: 2);
 
         $apBefore = $this->personellService->getEconomyPoints(1);
-        $this->assertSame(7, $apBefore);
+        $this->assertSame(13, $apBefore); // 6 base + trader rank2 (7) = 13
 
         $result = $this->gateway->addResourceOffer([
             'colony_id'   => 1,
@@ -209,7 +211,7 @@ class TradeApTest extends TestCase
         $this->assertTrue($result);
 
         $apAfter = $this->personellService->getEconomyPoints(1);
-        $this->assertSame(2, $apAfter); // 7 - 5 = 2
+        $this->assertSame(8, $apAfter); // 13 - 5 = 8
     }
 
     // ── dev_mode bypasses AP checks ───────────────────────────────────────────
@@ -233,8 +235,8 @@ class TradeApTest extends TestCase
 
         $this->assertTrue($result);
 
-        // Also verify no AP were locked (bypass = no side effects)
+        // No AP locked (bypass = no side effects); base 6 AP intact
         $apAfter = $this->personellService->getEconomyPoints(1);
-        $this->assertSame(0, $apAfter);
+        $this->assertSame(6, $apAfter);
     }
 }


### PR DESCRIPTION
## Summary

- **AP-Grundwert (GDD §13):** `PersonellService::getTotalActionPoints()` addiert 6 Basis-AP für alle Bereiche unabhängig von Beratern. Neuer Config-Key `game.ap.base = 6`. Verhindert Sol-1-Deadlocks.
- **Onboarding-Startszenario:** Harvester (27) + Wohndepot (28) werden als `level=0, ap_spend=7, tile_x=null` geseedet — Spieler schließt beide Sol 1 ab und platziert sie. Narrativ: Kolonie im Aufbau übernommen.
- **Harvester versetzen:** Distanzbasierte Bau-AP-Kosten (1 AP/Tile, axiale Hex-Distanz). Neuer Hilfs-Methode `ColonyController::hexDistance()`.

## Betroffene Dateien

- `app/Services/Techtree/PersonellService.php` — base AP addiert
- `config/game.php` — `game.ap.base = 6`
- `app/Services/OnboardingService.php` — Harvester/Housing lv0 seed
- `app/Http/Controllers/Colony/ColonyController.php` — `hexDistance()`, distanzbasierte AP-Kosten, `ap_spend`-Logik beim Versetzen
- `lang/de/colony.php` — I18n-String für Harvester-Move aktualisiert
- Tests: `PersonellServiceTest`, `TradeApTest`, `OnboardingTest`, `OnboardingE2ETest`

## Test plan

- [ ] `php artisan test --filter PersonellServiceTest` — AP-Werte mit/ohne Berater
- [ ] `php artisan test --filter TradeApTest` — Economy-AP-Checks
- [ ] `php artisan test --filter OnboardingTest` — Registrierung, Harvester/Housing lv0
- [ ] `php artisan test --filter OnboardingE2ETest` — Full-Flow inkl. Housing-Placement
- [ ] `php artisan test` — alle 725 Tests grün