### PR TITLE
feat(colony): Harvester-Transit, Baumeister-Dialog, Mobile-First UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-06-12
+
+- **Harvester-Transit (1-Sol Verzögerung)** — Verlegen setzt `pending_until_tick` (Migration); in-transit Harvester produziert nicht (`GameTick`), ist nicht erneut verlegbar; Transit-Badge "HV →" im Grid; Controller blockiert Doppelmove; 6 Feature-Tests (`HarvesterTransitTest`).
+- **Baumeister-Dialog neu gestaltet** — Hire-Dialog zeigt Portrait, Name, JUNIOR-Badge, Beschreibung, AP-Typ, Einmalkosten, Unterhalt/Sol; PicoCSS-`<dialog>`-Override behebt Fullscreen-Bug; `AdvisorController::buildSlots()` liefert `desc`, `junior_ap`, `junior_upkeep`.
+- **Mobile: Colony-Zone-Viewport & SVG-Pan** — Hex-Grid clippt ViewBox auf Colony-Zone + Ring-3-Randstreifen (größere, tappbare Tiles); Touch-Drag verschiebt ViewBox um Ring-3-Tiles (Regolith-Ziele) zu erreichen; Pan-State überlebt Redraws.
+- **Mobile-First Layout** — Nav-Logo zeigt Seitennamen ("Kolonie") statt "NOURON"; Statuszeile, "TILE-INFO"-Header, Koordinaten-Zeile ausgeblendet; AP-Header-Row bricht auf Mobilgeräten korrekt um (kein horizontaler Overflow).
+- **Tile-First Build-Flow** — "Bauen"-Button aus Header entfernt; Tile antippen → Action-Strip zeigt "Bauen" (wenn bebaubar + leer); Klick öffnet Gebäudeliste; Gebäude wählen platziert sofort auf vorgemerktem Tile. Flow gilt für alle Screens (Mobile-first-Prinzip).
+- **Action-Strip über Tile-Info** — Kontext-Aktionen (Erkunden, Sondieren, AP investieren, Verlegen, Bauen) immer oben im Tile-Panel sichtbar, kein Scrollen nötig.
+
 ## 2026-06-11
 
 - **Harvester-Verlegung im Frontend** — "Verlegen"-Button am Harvester-Tile startet Move-Mode: gültige Ziele (erkundete, freie Regolith-Tiles) blau markiert, Hover zeigt gestrichelte Pfeil-Vorschau vom Harvester zum Ziel, Klick verlegt mit Move-Animation (1 Bau-AP pro Hex-Distanz). Ohne verfügbares Ziel zeigt das Panel einen Hinweis ("erst neue Tiles erkunden"). Bugfix dabei: Harvester (`is_instanced=1`) wurde beim Verlegen als neue Instanz eingefügt statt verschoben — Controller behandelt Harvester jetzt explizit als Move (UPDATE).

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -816,6 +816,12 @@ class GameTick extends Command
             return 0;
         }
 
+        // Buildings whose transit ended before this tick have arrived.
+        DB::table('colony_buildings')
+            ->whereNotNull('pending_until_tick')
+            ->where('pending_until_tick', '<', $tick)
+            ->update(['pending_until_tick' => null]);
+
         $colonies = Colony::all();
 
         foreach ($colonies as $colony) {
@@ -831,6 +837,11 @@ class GameTick extends Command
                     ->first();
 
                 if (!$building || $building->level <= 0) {
+                    continue;
+                }
+
+                // In transit (harvester relocation): no production this Sol.
+                if ($building->pending_until_tick !== null && (int) $building->pending_until_tick >= $tick) {
                     continue;
                 }
 

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -56,6 +56,8 @@ class ColonyController extends BaseController
             ->where('building_id', BuildingId::CommandCenter->value)
             ->value('level') ?? 0;
 
+        $globalTick = $this->getTick();
+
         $buildings = DB::table('colony_buildings')
             ->join('buildings', 'colony_buildings.building_id', '=', 'buildings.id')
             ->where('colony_buildings.colony_id', $colony->id)
@@ -67,15 +69,17 @@ class ColonyController extends BaseController
                 'colony_buildings.ap_spend',
                 'colony_buildings.tile_x',
                 'colony_buildings.tile_y',
+                'colony_buildings.pending_until_tick',
                 'buildings.name as building_key',
                 'buildings.max_level',
                 'buildings.ap_for_levelup',
                 'buildings.max_status_points',
             )
             ->get()
-            ->map(function ($b) {
+            ->map(function ($b) use ($globalTick) {
                 $b->label      = __('techtree.' . $b->building_key);
                 $b->image_slug = self::buildingImageSlug($b->building_key);
+                $b->in_transit = $b->pending_until_tick !== null && (int) $b->pending_until_tick >= $globalTick;
                 return $b;
             });
 
@@ -87,7 +91,6 @@ class ColonyController extends BaseController
         $supplyCapFull = in_array('supply_cap_full', $fireds);
 
         $trust      = (int) (DB::table('colony_resources')->where('colony_id', $colony->id)->where('resource_id', 12)->value('amount') ?? 0);
-        $globalTick = $this->getTick();
         $currentSol = max(1, $globalTick - (int) $colony->since_tick + 1);
         $solLimit   = (int) config('game.run.tick_limit', 100);
 
@@ -250,6 +253,12 @@ class ColonyController extends BaseController
             && $existingBuilding !== null
             && $existingBuilding->tile_x !== null;
 
+        if ($isHarvesterMove
+                && $existingBuilding->pending_until_tick !== null
+                && (int) $existingBuilding->pending_until_tick >= $this->getTick()) {
+            return response()->json(['ok' => false, 'error' => __('colony.error_harvester_in_transit')]);
+        }
+
         $apCost = $isHarvesterMove
             ? max(1, $this->hexDistance((int)$existingBuilding->tile_x, (int)$existingBuilding->tile_y, (int)$data['q'], (int)$data['r']))
             : 1;
@@ -294,6 +303,10 @@ class ColonyController extends BaseController
                     $update['ap_spend'] = 1;
                 }
                 // Harvester move: tile updates, ap_spend unchanged.
+                // Relocation takes 1 Sol — no production until arrival.
+                if ($isHarvesterMove) {
+                    $update['pending_until_tick'] = $this->getTick() + 1;
+                }
                 DB::table('colony_buildings')
                     ->where('colony_id', $colony->id)
                     ->where('building_id', $data['building_id'])
@@ -504,6 +517,7 @@ class ColonyController extends BaseController
                 'colony_buildings.ap_spend',
                 'colony_buildings.tile_x',
                 'colony_buildings.tile_y',
+                'colony_buildings.pending_until_tick',
                 'buildings.name as building_key',
                 'buildings.max_level',
                 'buildings.ap_for_levelup',
@@ -513,6 +527,7 @@ class ColonyController extends BaseController
 
         $row->label      = __('techtree.' . $row->building_key);
         $row->image_slug = self::buildingImageSlug($row->building_key);
+        $row->in_transit = $row->pending_until_tick !== null && (int) $row->pending_until_tick >= $this->getTick();
 
         return $row;
     }

--- a/app/Http/Controllers/Techtree/AdvisorController.php
+++ b/app/Http/Controllers/Techtree/AdvisorController.php
@@ -62,6 +62,8 @@ class AdvisorController extends BaseController
     private function buildSlots(Collection $advisors, array $slotInfo, int $currentTick): array
     {
         $rankThresholds = config('game.advisor.rank_thresholds', [1 => 10, 2 => 20]);
+        $upkeepMap      = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
+        $apPerRank      = config('game.advisor.ap_per_rank', [1 => 4]);
         $ccLevel        = $slotInfo['cc_level'];
 
         // Index active advisors by personell_id for O(1) lookup.
@@ -103,7 +105,6 @@ class AdvisorController extends BaseController
                     $progressPct = min(100, (int) round($advisor->active_ticks / $nextThreshold * 100));
                 }
 
-                $upkeepMap   = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
                 $advisorData = [
                     'id'                     => $advisor->id,
                     'rank'                   => $advisor->rank,
@@ -127,15 +128,18 @@ class AdvisorController extends BaseController
             }
 
             $slots[] = [
-                'position'     => $position,
-                'key'          => $key,
-                'name'         => trans("advisors.{$key}"),
-                'personell_id' => $personellId,
-                'ap_type'      => $apType,
-                'hire_cost'    => $hireCost,
-                'cc_required'  => $position,
-                'state'        => $state,
-                'advisor'      => $advisorData,
+                'position'      => $position,
+                'key'           => $key,
+                'name'          => trans("advisors.{$key}"),
+                'desc'          => trans("advisors.{$key}_desc"),
+                'personell_id'  => $personellId,
+                'ap_type'       => $apType,
+                'hire_cost'     => $hireCost,
+                'junior_ap'     => (int) ($apPerRank[1] ?? 4),
+                'junior_upkeep' => (int) ($upkeepMap[1] ?? 10),
+                'cc_required'   => $position,
+                'state'         => $state,
+                'advisor'       => $advisorData,
             ];
         }
 

--- a/database/migrations/2026_06_11_200000_add_pending_until_tick_to_colony_buildings.php
+++ b/database/migrations/2026_06_11_200000_add_pending_until_tick_to_colony_buildings.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Harvester relocation takes 1 Sol of transit time. While
+ * pending_until_tick >= current tick the building is "in transit":
+ * it does not produce and cannot be relocated again.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('colony_buildings', function (Blueprint $table) {
+            $table->integer('pending_until_tick')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('colony_buildings', function (Blueprint $table) {
+            $table->dropColumn('pending_until_tick');
+        });
+    }
+};

--- a/lang/de/advisors.php
+++ b/lang/de/advisors.php
@@ -38,4 +38,17 @@ return [
     'error_dismissed_this_tick'   => 'Dieser Berater wurde gerade erst entlassen und kann erst im nächsten Sol wieder eingestellt werden.',
     'error_generic'               => 'Berater konnte nicht eingestellt werden.',
 
+    // Hire/fire confirmation dialogs
+    'dialog_hire_title'   => 'Berater einstellen',
+    'dialog_fire_title'   => 'Berater entlassen',
+    'dialog_rank_junior'  => 'Junior',
+    'dialog_ap_label'     => 'pro Sol',
+    'dialog_cost_once'    => 'Einmalige Kosten',
+    'dialog_upkeep'       => 'Unterhalt',
+    'dialog_per_sol'      => 'Cr / Sol',
+    'dialog_fire_confirm' => 'wirklich entlassen? Bereits gesammelte Erfahrung (Rang) geht verloren.',
+    'dialog_hire'         => 'Einstellen',
+    'dialog_fire'         => 'Entlassen',
+    'dialog_cancel'       => 'Abbrechen',
+
 ];

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -98,6 +98,8 @@ return [
     'harvester_move'           => 'Verlegen',
     'harvester_move_mode_hint' => 'Erkundetes Regolith-Tile außerhalb der Koloniezone auswählen — 1 Bau-AP pro Hex-Distanz.',
     'harvester_move_no_targets' => 'Kein freies erkundetes Regolith-Tile verfügbar — erst neue Tiles erkunden (Nav-AP).',
+    'error_harvester_in_transit' => 'Der Harvester ist noch unterwegs — Verlegen erst nach Ankunft möglich.',
+    'harvester_in_transit'       => 'Unterwegs — Ankunft nächsten Sol.',
     'error_tile_occupied'       => 'Tile bereits belegt.',
     'error_no_construction_ap'  => 'Nicht genug Bau-AP.',
     'error_building_not_found'  => 'Gebäude nicht gefunden.',

--- a/lang/en/colony.php
+++ b/lang/en/colony.php
@@ -55,6 +55,8 @@ return [
     'harvester_move'           => 'Relocate',
     'harvester_move_mode_hint' => 'Select an explored regolith tile outside the colony zone — 1 construction AP per hex distance.',
     'harvester_move_no_targets' => 'No free explored regolith tile available — explore new tiles first (Nav AP).',
+    'error_harvester_in_transit' => 'The harvester is still in transit — relocation possible after arrival.',
+    'harvester_in_transit'       => 'In transit — arrives next Sol.',
     'error_tile_occupied'       => 'Tile already occupied.',
     'error_no_construction_ap'  => 'Not enough construction AP.',
     'error_building_not_found'  => 'Building not found.',

--- a/public/css/advisors.css
+++ b/public/css/advisors.css
@@ -362,17 +362,130 @@
 
 /* ── Hire / fire confirmation dialogs ─────────────────────────────────────── */
 
+/* Reset PicoCSS dialog (fullscreen flex overlay expecting an <article>)
+   back to a native centered dialog box. */
 dialog.advisor-dialog {
-    max-width: 360px;
+    display: block;
+    position: fixed;
+    inset: 0;
+    margin: auto;
     width: 90%;
-    border-radius: 10px;
+    min-width: 0;
+    max-width: 380px;
+    height: fit-content;
+    min-height: 0;
+    background: #fff;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    border-radius: 12px;
     border: 1px solid var(--color-border);
     padding: 1.5rem;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+}
+
+dialog.advisor-dialog:not([open]) {
+    display: none;
+}
+
+dialog.advisor-dialog::backdrop {
+    background: rgba(20, 20, 25, 0.45);
 }
 
 dialog.advisor-dialog h3 {
     margin: 0 0 1rem;
     font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-anthracite);
+    border-bottom: 2px solid #c0392b;
+    padding-bottom: 0.5rem;
+}
+
+/* Advisor summary: portrait + name/desc */
+.dialog-advisor {
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+}
+
+.dialog-portrait {
+    flex: 0 0 auto;
+    width: 4rem;
+    height: 4rem;
+    border-radius: 50%;
+    background-color: #eceff1;
+    background-size: cover;
+    background-position: center top;
+    border: 2px solid var(--color-border);
+}
+
+.dialog-advisor-info {
+    min-width: 0;
+}
+
+.dialog-advisor-name {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.25rem;
+}
+
+.dialog-advisor-name strong {
+    font-size: 1rem;
+    color: var(--color-anthracite);
+}
+
+.dialog-rank-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: #eceff1;
+    color: #546e7a;
+}
+
+.dialog-advisor-desc {
+    margin: 0;
+    font-size: 0.78rem;
+    line-height: 1.4;
+    color: #777;
+}
+
+/* Stat rows: AP gain, one-time cost, upkeep */
+.dialog-stats {
+    margin: 0 0 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.dialog-stat {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.82rem;
+}
+
+.dialog-stat + .dialog-stat {
+    border-top: 1px solid var(--color-border);
+}
+
+.dialog-stat dt {
+    color: #666;
+}
+
+.dialog-stat dd {
+    margin: 0;
+    font-weight: 700;
+    color: var(--color-anthracite);
+}
+
+.dialog-stat-positive {
+    color: #2e7d32 !important;
 }
 
 .dialog-cost {

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -346,6 +346,18 @@ button.btn-sol:hover,
     flex-direction: column;
 }
 
+/* Action strip: quick-action bar above the section header */
+.tile-panel-action-strip {
+    padding: 0.5rem 1.25rem;
+    border-bottom: 1px solid var(--color-border);
+    background: #fff;
+    flex-shrink: 0;
+}
+
+.tile-panel-action-strip .sidebar-actions {
+    margin-top: 0;
+}
+
 /* Sticky section header inside the sidebar */
 .tile-panel-header {
     padding: 0.65rem 1.25rem 0.55rem;
@@ -1214,21 +1226,48 @@ dialog[x-ref="discoveryDialog"] {
         border-bottom: 1px solid var(--color-border);
     }
 
+    /* Header row (title · status · AP chips · build button) must wrap on
+       narrow screens — otherwise its min-content width forces the whole
+       canvas column beyond the viewport (horizontal scroll). */
+    .hex-canvas-header {
+        flex-wrap: wrap;
+        row-gap: 0.4rem;
+    }
+
+    .hex-canvas-header .ap-chips {
+        flex-wrap: wrap;
+    }
+
     .hex-canvas {
-        min-height: 320px;
+        min-height: 48dvh;
+        padding: 0.4rem;
+    }
+
+    .hex-canvas svg {
+        max-width: 100%;
     }
 
     .tile-panel {
         border-left: none;
         border-top: 1px solid var(--color-border);
         /* Limit sidebar height on mobile so it doesn't push the grid far up */
-        max-height: 380px;
+        max-height: 360px;
     }
 
     .tile-panel-empty {
         justify-content: flex-start;
         padding: 1rem;
     }
+
+    /* Hide status line and build button in header on mobile (tile-first build flow) */
+    .hex-canvas-header .status-line { display: none; }
+
+    /* Hide section header — action strip + tile heading give enough context */
+    .tile-panel-header--hideable { display: none; }
+
+    /* Hide coordinate row in tile info on mobile */
+    .tile-dl-coords { display: none; }
+
 }
 
 /* ── Sol Button Overlay & Dialog (colony layout) ───────────────────────── */

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -108,9 +108,11 @@ function colonyHexView(config) {
         levelupNotice:      null,   // set to label string when a building levels up
         _lvlTimer:          null,
         harvesterMoveMode:  false,
+        buildTargetTile:    null,
         _svgPolygons:       new Map(),
         _tilePositions:     new Map(),
         _gridEl:            null,
+        _panState:          { x: 0, y: 0 },
 
         init() {
             this.$nextTick(async () => {
@@ -143,6 +145,7 @@ function colonyHexView(config) {
                 activeHint:        this.activeHint ?? null,
                 harvesterMoveMode: this.harvesterMoveMode,
                 harvesterBuilding: this.harvesterMoveMode ? this.harvesterBuilding() : null,
+                panState:          this._panState,
             });
         },
 
@@ -191,8 +194,9 @@ function colonyHexView(config) {
 
         async toggleBuildMode() {
             if (this.buildMode) {
-                this.buildMode       = false;
-                this.pendingBuilding = null;
+                this.buildMode         = false;
+                this.pendingBuilding   = null;
+                this.buildTargetTile   = null;
                 this.$nextTick(() => this.redrawGrid());
                 return;
             }
@@ -203,11 +207,31 @@ function colonyHexView(config) {
             this.$nextTick(() => this.redrawGrid());
         },
 
+        async startBuildForTile(tile) {
+            const data              = await this.get(this.routes.buildingsAvailable);
+            this.availableBuildings = data.buildings ?? [];
+            this.buildTargetTile    = tile;
+            this.buildMode          = true;
+            this.selectedTile       = null;
+            this.$nextTick(() => this.redrawGrid());
+        },
+
+        cancelBuildMode() {
+            this.buildMode         = false;
+            this.pendingBuilding   = null;
+            this.buildTargetTile   = null;
+            this.$nextTick(() => this.redrawGrid());
+        },
+
         selectPendingBuilding(building) {
             this.pendingBuilding = (this.pendingBuilding?.building_id === building.building_id)
                 ? null
                 : building;
-            this.$nextTick(() => this.redrawGrid());
+            if (this.pendingBuilding && this.buildTargetTile) {
+                this.doPlaceBuilding(this.buildTargetTile);
+            } else {
+                this.$nextTick(() => this.redrawGrid());
+            }
         },
 
         // ── Tile actions ──────────────────────────────────────────────────────
@@ -254,9 +278,10 @@ function colonyHexView(config) {
             });
             if (res.ok) {
                 this.updateBuilding(res.building);
-                this.buildMode       = false;
-                this.pendingBuilding = null;
-                this.selectedTile    = tile;
+                this.buildMode         = false;
+                this.pendingBuilding   = null;
+                this.buildTargetTile   = null;
+                this.selectedTile      = tile;
                 this.updateAp(res);
                 this.updateHint(res);
                 this.$nextTick(() => this.redrawGrid());
@@ -460,6 +485,12 @@ function colonyHexView(config) {
             return this.buildings.find(b => b.tile_x === tile.q && b.tile_y === tile.r) ?? null;
         },
 
+        isBuildableTile(tile) {
+            return tile && tile.is_colony_zone && tile.is_explored
+                && tile.tile_type.startsWith('terrain_')
+                && tile.tile_type !== 'terrain_impassable';
+        },
+
         statusLine() {
             const total    = this.tiles.length;
             const explored = this.tiles.filter(t => t.is_explored).length;
@@ -539,8 +570,10 @@ function drawHarvesterArrow(group, x1, y1, x2, y2) {
 function initHexGrid(container, tiles, opts = {}) {
     if (!container || tiles.length === 0) return;
 
-    const SIZE    = 40;
-    const PADDING = SIZE * 1.5;
+    const SIZE = 40;
+    // On narrow screens, use tighter padding so the colony zone fills the viewport.
+    const isMobile = container.clientWidth > 0 && container.clientWidth < 600;
+    const PADDING  = isMobile ? SIZE * 0.6 : SIZE * 1.5;
 
     // Build tile-coordinate → building lookup
     const buildingsByTile = new Map();
@@ -554,27 +587,52 @@ function initHexGrid(container, tiles, opts = {}) {
         }
     }
 
-    // Compute bounding box from actual tile positions
+    // Compute bounding boxes: full grid + colony zone only
     let minPx = Infinity, maxPx = -Infinity;
     let minPy = Infinity, maxPy = -Infinity;
+    let czMinPx = Infinity, czMaxPx = -Infinity;
+    let czMinPy = Infinity, czMaxPy = -Infinity;
 
     const positions = tiles.map(t => {
         const px = SIZE * Math.sqrt(3) * (t.q + t.r / 2);
         const py = SIZE * 1.5 * t.r;
-        minPx = Math.min(minPx, px);
-        maxPx = Math.max(maxPx, px);
-        minPy = Math.min(minPy, py);
-        maxPy = Math.max(maxPy, py);
+        minPx = Math.min(minPx, px); maxPx = Math.max(maxPx, px);
+        minPy = Math.min(minPy, py); maxPy = Math.max(maxPy, py);
+        if (t.is_colony_zone) {
+            czMinPx = Math.min(czMinPx, px); czMaxPx = Math.max(czMaxPx, px);
+            czMinPy = Math.min(czMinPy, py); czMaxPy = Math.max(czMaxPy, py);
+        }
         return { tile: t, px, py };
     });
 
-    const svgW = maxPx - minPx + SIZE * Math.sqrt(3) + PADDING * 2;
-    const svgH = maxPy - minPy + SIZE * 2 + PADDING * 2;
-    const offX = -minPx + PADDING + SIZE * Math.sqrt(3) / 2;
-    const offY = -minPy + PADDING + SIZE;
+    // On mobile, clip the viewBox to the colony zone + one hex margin so ring 3
+    // is partially visible ("hinted") while the colony zone fills most of the screen.
+    const hasCZ = czMinPx !== Infinity;
+    const margin = SIZE * 1.1;
+    const vbMinPx = isMobile && hasCZ ? czMinPx - margin : minPx;
+    const vbMaxPx = isMobile && hasCZ ? czMaxPx + margin : maxPx;
+    const vbMinPy = isMobile && hasCZ ? czMinPy - margin : minPy;
+    const vbMaxPy = isMobile && hasCZ ? czMaxPy + margin : maxPy;
+
+    const svgW = vbMaxPx - vbMinPx + SIZE * Math.sqrt(3) + PADDING * 2;
+    const svgH = vbMaxPy - vbMinPy + SIZE * 2 + PADDING * 2;
+    const offX = -vbMinPx + PADDING + SIZE * Math.sqrt(3) / 2;
+    const offY = -vbMinPy + PADDING + SIZE;
+
+    // Restore pan offset (persists across redraws so the user keeps their position)
+    let panX = opts.panState?.x ?? 0;
+    let panY = opts.panState?.y ?? 0;
+
+    // Clamp bounds: leftmost/rightmost tile edges within SVG coordinate space
+    const panXMin = minPx + offX - PADDING;
+    const panXMax = Math.max(0, maxPx + offX + SIZE * Math.sqrt(3) + PADDING - svgW);
+    const panYMin = minPy + offY - PADDING;
+    const panYMax = Math.max(0, maxPy + offY + SIZE * 2 + PADDING - svgH);
+    panX = Math.max(panXMin, Math.min(panX, panXMax));
+    panY = Math.max(panYMin, Math.min(panY, panYMax));
 
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('viewBox', `0 0 ${svgW} ${svgH}`);
+    svg.setAttribute('viewBox', `${panX} ${panY} ${svgW} ${svgH}`);
     svg.setAttribute('width', '100%');
     svg.style.display = 'block';
 
@@ -618,6 +676,41 @@ function initHexGrid(container, tiles, opts = {}) {
                 });
             }
         }
+    }
+
+    // Touch-drag pan (mobile only): lets the user slide the grid to reach ring 3+ tiles.
+    if (isMobile) {
+        let touchStartX, touchStartY, touchStartPanX, touchStartPanY, touchMoved = false;
+
+        svg.addEventListener('touchstart', e => {
+            if (e.touches.length !== 1) return;
+            touchStartX    = e.touches[0].clientX;
+            touchStartY    = e.touches[0].clientY;
+            touchStartPanX = panX;
+            touchStartPanY = panY;
+            touchMoved     = false;
+        }, { passive: true });
+
+        svg.addEventListener('touchmove', e => {
+            if (e.touches.length !== 1) return;
+            const dx = e.touches[0].clientX - touchStartX;
+            const dy = e.touches[0].clientY - touchStartY;
+            if (!touchMoved && Math.hypot(dx, dy) < 6) return;
+            touchMoved = true;
+            const scale = svgW / (svg.clientWidth || svgW);
+            panX = Math.max(panXMin, Math.min(touchStartPanX - dx * scale, panXMax));
+            panY = Math.max(panYMin, Math.min(touchStartPanY - dy * scale, panYMax));
+            svg.setAttribute('viewBox', `${panX} ${panY} ${svgW} ${svgH}`);
+            if (opts.panState) { opts.panState.x = panX; opts.panState.y = panY; }
+            e.preventDefault();
+        }, { passive: false });
+
+        svg.addEventListener('touchend', () => {
+            if (touchMoved) {
+                // Suppress the synthetic click that fires after a drag gesture.
+                svg.addEventListener('click', e => e.stopPropagation(), { once: true, capture: true });
+            }
+        }, { passive: true });
     }
 
     container.innerHTML = '';
@@ -741,7 +834,9 @@ function createHexTile(cx, cy, size, tile, building, opts, buildingsByTile) {
     if (building && !isCC && tile.is_explored) {
         const abbr        = BUILDING_ABBR[building.building_key] ?? '?';
         const isBuilt     = building.level > 0;
+        const inTransit   = !!building.in_transit;
         const levelSuffix = isBuilt ? ` ${building.level}` : '';
+        const badgeText   = inTransit ? `${abbr} →` : abbr + levelSuffix;
         const badgeW      = isBuilt ? 28 : 22;
         const badgeH      = 12;
         const bx          = cx - badgeW / 2;
@@ -753,11 +848,11 @@ function createHexTile(cx, cy, size, tile, building, opts, buildingsByTile) {
         rect.setAttribute('width',  badgeW);
         rect.setAttribute('height', badgeH);
         rect.setAttribute('rx',     '3');
-        rect.setAttribute('fill', isBuilt ? 'rgba(30,30,30,0.72)' : 'rgba(80,80,80,0.55)');
+        rect.setAttribute('fill', inTransit ? 'rgba(180,83,9,0.85)' : (isBuilt ? 'rgba(30,30,30,0.72)' : 'rgba(80,80,80,0.55)'));
         rect.setAttribute('pointer-events', 'none');
         g.appendChild(rect);
 
-        g.appendChild(svgText(cx, by + badgeH / 2 + 0.5, abbr + levelSuffix, 8, '#fff', 700));
+        g.appendChild(svgText(cx, by + badgeH / 2 + 0.5, badgeText, 8, '#fff', 700));
 
         // Red warning dot (top-right of badge) when condition < 10%
         if (isBuilt) {

--- a/resources/views/advisors/index.blade.php
+++ b/resources/views/advisors/index.blade.php
@@ -2,11 +2,11 @@
 @section('title', 'Berater — Nouron')
 
 @push('styles')
-    <link rel="stylesheet" href="{{ asset('css/advisors.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/advisors.css') }}?v={{ filemtime(public_path('css/advisors.css')) }}">
 @endpush
 
 @push('scripts')
-    <script src="{{ asset('js/advisors.js') }}"></script>
+    <script src="{{ asset('js/advisors.js') }}?v={{ filemtime(public_path('js/advisors.js')) }}"></script>
 @endpush
 
 @section('content')
@@ -225,17 +225,43 @@
 
     {{-- ── Hire confirmation dialog ─────────────────────────────────────────── --}}
     <dialog class="advisor-dialog" x-ref="hireDialog" @close="closeDialogs()">
-        <h3>Berater einstellen</h3>
+        <h3>{{ __('advisors.dialog_hire_title') }}</h3>
         <template x-if="dialogSlot">
             <div>
-                <p class="dialog-cost">
-                    <strong x-text="dialogSlot.name"></strong> &middot; Junior &middot; 4 AP/Tick<br>
-                    Kosten: <strong x-text="dialogSlot.hire_cost + ' Cr'"></strong>
-                </p>
+                <div class="dialog-advisor">
+                    <div class="dialog-portrait"
+                         :style="portraitImageUrl(dialogSlot.key)
+                             ? 'background-image: url(' + portraitImageUrl(dialogSlot.key) + ')'
+                             : ''"></div>
+                    <div class="dialog-advisor-info">
+                        <div class="dialog-advisor-name">
+                            <strong x-text="dialogSlot.name"></strong>
+                            <span class="dialog-rank-badge">{{ __('advisors.dialog_rank_junior') }}</span>
+                        </div>
+                        <p class="dialog-advisor-desc" x-text="dialogSlot.desc"></p>
+                    </div>
+                </div>
+
+                <dl class="dialog-stats">
+                    <div class="dialog-stat">
+                        <dt x-text="apTypeLabel(dialogSlot.ap_type)"></dt>
+                        <dd class="dialog-stat-positive"
+                            x-text="'+' + dialogSlot.junior_ap + ' {{ __('advisors.dialog_ap_label') }}'"></dd>
+                    </div>
+                    <div class="dialog-stat">
+                        <dt>{{ __('advisors.dialog_cost_once') }}</dt>
+                        <dd x-text="dialogSlot.hire_cost + ' Cr'"></dd>
+                    </div>
+                    <div class="dialog-stat">
+                        <dt>{{ __('advisors.dialog_upkeep') }}</dt>
+                        <dd x-text="dialogSlot.junior_upkeep + ' {{ __('advisors.dialog_per_sol') }}'"></dd>
+                    </div>
+                </dl>
+
                 <div class="dialog-error" x-text="errorMsg"></div>
                 <div class="dialog-actions">
-                    <button class="btn-cancel" @click="closeDialogs()">Abbrechen</button>
-                    <button class="btn-confirm-hire" @click="doHire()">Einstellen</button>
+                    <button class="btn-cancel" @click="closeDialogs()">{{ __('advisors.dialog_cancel') }}</button>
+                    <button class="btn-confirm-hire" @click="doHire()">{{ __('advisors.dialog_hire') }}</button>
                 </div>
             </div>
         </template>
@@ -243,16 +269,16 @@
 
     {{-- ── Fire confirmation dialog ─────────────────────────────────────────── --}}
     <dialog class="advisor-dialog" x-ref="fireDialog" @close="closeDialogs()">
-        <h3>Berater entlassen</h3>
+        <h3>{{ __('advisors.dialog_fire_title') }}</h3>
         <template x-if="dialogSlot">
             <div>
                 <p class="dialog-cost">
-                    <strong x-text="dialogSlot.name"></strong> wirklich entlassen?
+                    <strong x-text="dialogSlot.name"></strong> {{ __('advisors.dialog_fire_confirm') }}
                 </p>
                 <div class="dialog-error" x-text="errorMsg"></div>
                 <div class="dialog-actions">
-                    <button class="btn-cancel" @click="closeDialogs()">Abbrechen</button>
-                    <button class="btn-confirm-fire" @click="doFire()">Entlassen</button>
+                    <button class="btn-cancel" @click="closeDialogs()">{{ __('advisors.dialog_cancel') }}</button>
+                    <button class="btn-confirm-fire" @click="doFire()">{{ __('advisors.dialog_fire') }}</button>
                 </div>
             </div>
         </template>

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -1,5 +1,6 @@
 @extends('layouts.colony')
 @section('title', $colony->name . ' — Kolonie')
+@section('page-nav-title', 'Kolonie')
 
 @section('content')
 <script>
@@ -52,7 +53,7 @@ window.__colonyViewData = {
         <div class="hex-canvas-wrap">
             <div class="hex-canvas-header">
                 <h2>{{ $colony->name }}</h2>
-                <small x-text="statusLine()"></small>
+                <small class="status-line" x-text="statusLine()"></small>
                 <div class="ap-chips">
                     <span class="ap-chip ap-chip--nav" x-data="{ open: false }"
                           @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
@@ -91,11 +92,6 @@ window.__colonyViewData = {
                     🛸 {{ __('colony.merchant_in_system') }}
                 </a>
 
-                <button class="build-btn"
-                        :class="{ 'build-btn--active': buildMode }"
-                        @click="toggleBuildMode()">
-                    <span x-text="buildMode ? '{{ __('colony.cancel') }}' : '{{ __('colony.build') }}'"></span>
-                </button>
             </div>
 
             {{-- Onboarding hint bar — reactive, driven by colonyHexView.activeHint.
@@ -123,7 +119,65 @@ window.__colonyViewData = {
 
         {{-- Tile info / build mode sidebar --}}
         <aside class="tile-panel">
-            <div class="tile-panel-header">
+
+            {{-- Action strip: always visible above the section header.
+                 On desktop this serves as a top-of-panel quick-action bar.
+                 On mobile this is the primary action surface (no scrolling needed). --}}
+            <div class="tile-panel-action-strip"
+                 x-show="harvesterMoveMode || buildMode || selectedTile"
+                 x-cloak>
+                {{-- Harvester move mode: cancel --}}
+                <template x-if="harvesterMoveMode">
+                    <div class="sidebar-actions">
+                        <button class="sidebar-action-btn" @click="cancelHarvesterMove()">
+                            {{ __('colony.cancel') }}
+                        </button>
+                    </div>
+                </template>
+                {{-- Normal mode tile actions --}}
+                <template x-if="!harvesterMoveMode && !buildMode && selectedTile">
+                    <div class="sidebar-actions">
+                        <template x-if="!selectedTile.is_explored">
+                            <button class="sidebar-action-btn" @click="doExploreTile(selectedTile)">
+                                {{ __('colony.explore') }}
+                            </button>
+                        </template>
+                        <template x-if="selectedTile.has_signal && !selectedTile.is_deep_scanned">
+                            <button class="sidebar-action-btn" @click="doDeepScan(selectedTile)">
+                                {{ __('colony.deep_scan') }}
+                            </button>
+                        </template>
+                        <template x-if="buildingForTile(selectedTile) && (buildingForTile(selectedTile).max_level === null || buildingForTile(selectedTile).level < buildingForTile(selectedTile).max_level)">
+                            <button class="sidebar-action-btn" @click="doInvestAp(buildingForTile(selectedTile))">
+                                {{ __('colony.invest_ap') }}
+                            </button>
+                        </template>
+                        <template x-if="buildingForTile(selectedTile)?.building_key === 'building_harvester' && buildingForTile(selectedTile)?.level > 0 && !buildingForTile(selectedTile)?.in_transit">
+                            <button class="sidebar-action-btn sidebar-action-btn--secondary" @click="startHarvesterMove()">
+                                {{ __('colony.harvester_move') }}
+                            </button>
+                        </template>
+                        <template x-if="buildingForTile(selectedTile)?.building_key === 'building_harvester' && buildingForTile(selectedTile)?.in_transit">
+                            <p class="build-mode-hint" style="margin:0">{{ __('colony.harvester_in_transit') }}</p>
+                        </template>
+                        <template x-if="isBuildableTile(selectedTile) && !buildingForTile(selectedTile)">
+                            <button class="sidebar-action-btn sidebar-action-btn--secondary" @click="startBuildForTile(selectedTile)">
+                                {{ __('colony.build') }}
+                            </button>
+                        </template>
+                    </div>
+                </template>
+                {{-- Build mode: cancel button in strip --}}
+                <template x-if="buildMode">
+                    <div class="sidebar-actions">
+                        <button class="sidebar-action-btn sidebar-action-btn--secondary" @click="cancelBuildMode()">
+                            {{ __('colony.cancel') }}
+                        </button>
+                    </div>
+                </template>
+            </div>
+
+            <div class="tile-panel-header tile-panel-header--hideable">
                 <h3 x-text="harvesterMoveMode ? '{{ __('colony.harvester_move') }}' : (buildMode ? '{{ __('colony.build_mode_title') }}' : '{{ __('colony.tile_info') }}')"></h3>
             </div>
 
@@ -134,9 +188,6 @@ window.__colonyViewData = {
                     <div>
                         <p class="build-mode-hint"
                            x-text="hasHarvesterTargets() ? i18n.harvesterMoveModeHint : i18n.harvesterMoveNoTargets"></p>
-                        <button class="sidebar-action-btn" @click="cancelHarvesterMove()">
-                            {{ __('colony.cancel') }}
-                        </button>
                     </div>
                 </template>
 
@@ -190,7 +241,7 @@ window.__colonyViewData = {
 
                 {{-- Normal mode: selected tile info --}}
                 <template x-if="!harvesterMoveMode && !buildMode && selectedTile">
-                    <div>
+                    <div class="tile-info-container">
                         <h3 class="tile-heading" x-text="tileHeading(selectedTile)"></h3>
 
                         <div class="tile-status-chips">
@@ -207,8 +258,10 @@ window.__colonyViewData = {
                         </div>
 
                         <dl class="tile-dl">
-                            <dt>Koordinaten</dt>
-                            <dd x-text="`q=${selectedTile.q}, r=${selectedTile.r} (Ring ${selectedTile.ring})`"></dd>
+                            <div class="tile-dl-coords">
+                                <dt>Koordinaten</dt>
+                                <dd x-text="`q=${selectedTile.q}, r=${selectedTile.r} (Ring ${selectedTile.ring})`"></dd>
+                            </div>
 
                             <template x-if="selectedTile.is_explored">
                                 <div>
@@ -288,32 +341,6 @@ window.__colonyViewData = {
                             </div>
                         </template>
 
-                        {{-- Context action buttons --}}
-                        <div class="sidebar-actions">
-                            <template x-if="!selectedTile.is_explored">
-                                <button class="sidebar-action-btn" @click="doExploreTile(selectedTile)">
-                                    {{ __('colony.explore') }}
-                                </button>
-                            </template>
-
-                            <template x-if="selectedTile.has_signal && !selectedTile.is_deep_scanned">
-                                <button class="sidebar-action-btn" @click="doDeepScan(selectedTile)">
-                                    {{ __('colony.deep_scan') }}
-                                </button>
-                            </template>
-
-                            <template x-if="buildingForTile(selectedTile) && (buildingForTile(selectedTile).max_level === null || buildingForTile(selectedTile).level < buildingForTile(selectedTile).max_level)">
-                                <button class="sidebar-action-btn" @click="doInvestAp(buildingForTile(selectedTile))">
-                                    {{ __('colony.invest_ap') }}
-                                </button>
-                            </template>
-
-                            <template x-if="buildingForTile(selectedTile)?.building_key === 'building_harvester' && buildingForTile(selectedTile)?.level > 0">
-                                <button class="sidebar-action-btn sidebar-action-btn--secondary" @click="startHarvesterMove()">
-                                    {{ __('colony.harvester_move') }}
-                                </button>
-                            </template>
-                        </div>
                     </div>
                 </template>
 

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400&display=swap">
-    <link rel="stylesheet" href="{{ asset('css/colony.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/colony.css') }}?v={{ filemtime(public_path('css/colony.css')) }}">
     <link rel="stylesheet" href="{{ asset('css/swipe.css') }}">
     <link rel="stylesheet" href="{{ asset('css/carousel.css') }}">
     @stack('styles')
@@ -19,7 +19,7 @@
 <header class="colony-header">
     <nav>
         <ul>
-            <li><a href="{{ route('colony.view') }}" class="colony-logo">Nouron</a></li>
+            <li><a href="{{ route('colony.view') }}" class="colony-logo">@yield('page-nav-title', 'Nouron')</a></li>
         </ul>
 
         {{-- Desktop nav (visible from 600px up) --}}

--- a/tests/Feature/Colony/HarvesterTransitTest.php
+++ b/tests/Feature/Colony/HarvesterTransitTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Feature\Colony;
+
+use App\Services\TickService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Harvester relocation transit — moving the harvester takes 1 Sol.
+ *
+ * Rules:
+ * - A relocation sets pending_until_tick = currentTick + 1.
+ * - While in transit (pending_until_tick >= tick) the harvester
+ *   produces nothing and cannot be relocated again.
+ * - The tick after arrival clears pending_until_tick and production resumes.
+ *
+ * Fixture: Colony 1 (Springfield), user_id=3 (Bart), harvester building_id=27.
+ */
+class HarvesterTransitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID    = 1;
+    private const BART_USER_ID = 3;
+    private const HARVESTER_ID = 27;
+    private const RES_REGOLITH = 3;
+    private const TRUST_RES_ID = 12;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        // Neutral trust → production multiplier 1.0, AP multiplier 1.0
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
+            ['amount' => 0]
+        );
+        DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
+
+        // Harvester at level 1 on colony-zone tile (1,0)
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::HARVESTER_ID, 'instance_id' => 1],
+            ['level' => 1, 'status_points' => 16, 'ap_spend' => 0, 'tile_x' => 1, 'tile_y' => 0, 'pending_until_tick' => null]
+        );
+
+        // Tiles: start tile + two explored regolith targets outside the colony zone
+        DB::table('colony_tiles')->insertOrIgnore([
+            ['colony_id' => self::COLONY_ID, 'q' => 1, 'r' => 0, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_explored' => 1, 'is_colony_zone' => 1, 'is_deep_scanned' => 0],
+            ['colony_id' => self::COLONY_ID, 'q' => 3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0],
+            ['colony_id' => self::COLONY_ID, 'q' => -3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_poor', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0],
+        ]);
+    }
+
+    private function makeUser(int $userId): \App\Models\User
+    {
+        return \App\Models\User::where('user_id', $userId)->firstOrFail();
+    }
+
+    private function currentTick(): int
+    {
+        return $this->app->make(TickService::class)->getTickCount();
+    }
+
+    private function harvesterRow(): object
+    {
+        return DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::HARVESTER_ID)
+            ->first();
+    }
+
+    private function moveHarvester(int $q, int $r)
+    {
+        return $this->actingAs($this->makeUser(self::BART_USER_ID))
+            ->postJson(route('colony.building.place'), [
+                'building_id' => self::HARVESTER_ID,
+                'q'           => $q,
+                'r'           => $r,
+            ]);
+    }
+
+    private function regolithAmount(): int
+    {
+        return (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('resource_id', self::RES_REGOLITH)
+            ->value('amount');
+    }
+
+    // ── Transit is set on relocation ─────────────────────────────────────────
+
+    public function test_move_sets_pending_until_next_tick(): void
+    {
+        $tick = $this->currentTick();
+
+        $response = $this->moveHarvester(3, 0);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+        $row = $this->harvesterRow();
+        $this->assertSame(3, (int) $row->tile_x);
+        $this->assertSame($tick + 1, (int) $row->pending_until_tick);
+        $this->assertTrue($response->json('building.in_transit'));
+    }
+
+    public function test_initial_placement_does_not_set_transit(): void
+    {
+        // Unplaced harvester (tile_x null) — first placement is not a relocation.
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::HARVESTER_ID)
+            ->update(['tile_x' => null, 'tile_y' => null]);
+
+        $this->moveHarvester(3, 0)->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertNull($this->harvesterRow()->pending_until_tick);
+    }
+
+    // ── Second move blocked while in transit ─────────────────────────────────
+
+    public function test_second_move_blocked_while_in_transit(): void
+    {
+        $this->moveHarvester(3, 0)->assertJsonPath('ok', true);
+
+        $response = $this->moveHarvester(-3, 0);
+
+        $response->assertOk()->assertJsonPath('ok', false);
+        $this->assertSame(__('colony.error_harvester_in_transit'), $response->json('error'));
+        // Position unchanged
+        $this->assertSame(3, (int) $this->harvesterRow()->tile_x);
+    }
+
+    public function test_move_allowed_again_after_arrival(): void
+    {
+        $this->moveHarvester(3, 0)->assertJsonPath('ok', true);
+
+        // Simulate arrival: transit ended before the current tick.
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::HARVESTER_ID)
+            ->update(['pending_until_tick' => $this->currentTick() - 1]);
+
+        $this->moveHarvester(-3, 0)->assertJsonPath('ok', true);
+        $this->assertSame(-3, (int) $this->harvesterRow()->tile_x);
+    }
+
+    // ── Production pauses during transit ─────────────────────────────────────
+
+    public function test_no_production_while_in_transit(): void
+    {
+        $tick = 11300;
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::HARVESTER_ID)
+            ->update(['pending_until_tick' => $tick]);
+
+        $before = $this->regolithAmount();
+        Artisan::call('game:tick', ['--tick' => $tick]);
+
+        $this->assertSame($before, $this->regolithAmount(), 'Harvester in transit must not produce');
+    }
+
+    public function test_production_resumes_and_pending_cleared_after_arrival(): void
+    {
+        $tick = 11301;
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', self::HARVESTER_ID)
+            ->update(['pending_until_tick' => $tick - 1]);
+
+        $before = $this->regolithAmount();
+        Artisan::call('game:tick', ['--tick' => $tick]);
+
+        $this->assertGreaterThan($before, $this->regolithAmount(), 'Arrived harvester must produce again');
+        $this->assertNull($this->harvesterRow()->pending_until_tick, 'Arrived transit must be cleared');
+    }
+}


### PR DESCRIPTION
## Summary

- **Harvester-Transit** (1-Sol-Verzögerung): `pending_until_tick` Migration + GameTick-Skip + Controller-Blockade + Transit-Badge im Grid; 6 neue Feature-Tests (`HarvesterTransitTest`)
- **Baumeister Hire-Dialog**: Portrait + Name + JUNIOR-Badge + AP/Kosten-Stats; PicoCSS `<dialog>`-Override für korrektes Sizing; `AdvisorController::buildSlots()` liefert `desc`, `junior_ap`, `junior_upkeep`
- **Mobile Hex-Grid**: Colony-Zone ViewBox-Clipping (größere, besser tappbare Tiles); Touch-Drag Pan für Ring-3-Zugriff (Regolith → Harvester-Ziele erreichbar); Pan-State überlebt Grid-Redraws
- **Mobile-First Layout**: Nav-Logo zeigt Seitennamen ("Kolonie") statt NOURON; Statuszeile, TILE-INFO-Header, Koordinaten-Zeile auf Mobile ausgeblendet; Header-Row bricht korrekt um (kein horizontaler Overflow)
- **Tile-First Build-Flow**: "Bauen"-Button aus Header entfernt (Mobile-first-Prinzip gilt für alle Screens); Tile antippen → "Bauen" im Action-Strip → Gebäude wählen → sofort platziert auf vorgemerktem Tile
- **Action-Strip**: Kontext-Aktionen (Erkunden, Sondieren, AP, Verlegen, Bauen) immer oben über Tile-Info sichtbar — kein Scrollen nötig

## Test plan

- [ ] `php artisan test --filter HarvesterTransitTest` — alle 6 Tests grün
- [ ] Harvester verlegen → Transit-Badge "HV →" erscheint, zweites Verlegen blockiert
- [ ] Nach Sol-Advance: Transit-Badge weg, Harvester produziert wieder
- [ ] Baumeister einstellen → Dialog zeigt Portrait, AP-Typ, Kosten, Upkeep korrekt
- [ ] Mobile (390px): Colony-Zone füllt Grid, Tiles tappbar; Touch-Drag erreicht Ring-3-Regolith
- [ ] Tile antippen → "Bauen" in Action-Strip erscheint (bebaubar + leer); Gebäude wählen → platziert
- [ ] Desktop: selber Build-Flow über Action-Strip, kein Bauen-Button im Header