### PR TITLE
docs: AP-Kosten-Chip auf Fixkosten-Buttons eingrenzen (Rollout-Ergebnis)

### DIFF
--- a/docs/design-guide.md
+++ b/docs/design-guide.md
@@ -248,7 +248,11 @@ Alle Buttons verwenden system-ui, font-weight 600, font-size 0.9rem, letter-spac
 
 **Grösse:** Standard-Buttons ohne übertriebene Padding-Inflation. Keine XL-Hero-Buttons ausser in explizit dafür vorgesehenen leeren Zuständen.
 
-**AP-Kosten-Chip (verbindlich):** Jeder Aktionsbutton, der Aktionspunkte verbraucht, zeigt die Kosten **vorab** als Chip rechts im Button — optisch identisch zu den AP-Chips der Resource Bar (`.ap-chip` + Variante). Bau-AP → `.ap-chip--build` (grün), Nav-AP → `.ap-chip--nav` (blau). Button-Layout: `display:flex; justify-content:space-between` — Label-Body links (ein- oder zweizeilig: `__main` + optional `__sub`), Chip rechts (`flex-shrink:0`). Partial: `@include('partials.ap-cost-chip', ['amount' => 1, 'type' => 'build'])` (oder `'label' => '1 AP/Feld'` für distanzabhängige Kosten). Gilt screen-übergreifend (Colony, Techtree, Hangar, Cantina, …).
+**AP-Kosten-Chip (verbindlich):** Jeder Aktionsbutton mit **fixen AP-Kosten** zeigt die Kosten **vorab** als Chip rechts im Button — optisch identisch zu den AP-Chips der Resource Bar (`.ap-chip` + Variante). Bau-AP → `.ap-chip--build` (grün), Nav-AP → `.ap-chip--nav` (blau). Button-Layout: `display:flex; justify-content:space-between` — Label-Body links (ein- oder zweizeilig: `__main` + optional `__sub`), Chip rechts (`flex-shrink:0`). Partial: `@include('partials.ap-cost-chip', ['amount' => 1, 'type' => 'build'])` (oder `'label' => '1 AP/Feld'` für distanzabhängige Kosten).
+
+Umgesetzt im Colony-Screen (Erkunden/Sondieren/Reparieren/Ausbauen/Bauen/Verlegen).
+
+**Kein Chip** bei variabler/spielergewählter AP-Menge — dort macht das jeweilige Control die Kosten bereits sichtbar: Techtree investiert über eine Segment-Leiste (`x / y AP`, ein Klick = ein Segment), Hangar-Reparatur/-Dispatch über eine AP-Eingabe (Spieler wählt 1–10 / 0–20 AP). Cantina/Berater kosten Credits/Ressourcen, kein AP → kein Chip.
 
 ---
 


### PR DESCRIPTION
Folge auf #179. Rollout-Prüfung aller Screens ergab: **außer Colony gibt es keine Fixkosten-AP-Buttons**, daher keine weiteren Chips (würden sonst irreführen).

| Screen | AP-Nutzung | Chip? |
|---|---|---|
| Colony | fix 1 AP/Klick | ✓ (#179) |
| Techtree | Segment-Leiste (`x/y AP`, Klick = 1 Segment) | ✗ eigene Anzeige |
| Hangar | Repair/Dispatch: spielergewählte AP-Menge (1–10 / 0–20) | ✗ variabel |
| Cantina/Berater | Credits/Ressourcen | ✗ kein AP |

`design-guide.md` §5.5 präzisiert: Chip nur bei **fixen** AP-Kosten; bei variabler/segmentierter AP macht das jeweilige Control die Kosten sichtbar. Verhindert, dass künftig Chips auf Segment-Leisten/AP-Eingaben geklatscht werden.

Kein Code-Change.