### PR TITLE
fix(run): Pending-Runs von In-Run-Screens auf Lobby umleiten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- **In-Run-Screens gegen Pending-Runs abgesichert** — neue Middleware `run.started` (`EnsureRunStarted`) leitet auf die Lobby um, wenn kein aktiver Run mit `started_at` existiert (frisch erstellter Run ist `active` aber pending bis „Mission starten"). Behebt die Sackgasse, dass man die Kolonieansicht eines noch nicht gestarteten Runs öffnen konnte — ohne Sol-Button (Run-UI ist auf `started_at` gated). Gilt für colony/techtree/advisors/comm-log/nexus-db (Screens); `sol.next` behält seine eigene 404-Logik. AJAX-Aufrufe erhalten 409 + `redirect`. Info-Alert in der Lobby + `layouts.infra`.
+
 - **AP-Kosten-Chips an Aktionsbuttons** — jeder AP-verbrauchende Button zeigt die Kosten vorab als Chip (optisch wie die AP-Chips der Resource Bar: Bau=grün, Nav=blau). Wiederverwendbares Partial `partials/ap-cost-chip.blade.php` (`amount`+`type` oder `label`). Colony-Buttons umgesetzt: Erkunden (1 Nav), Sondieren (2 Nav), Reparieren/Ausbauen/Bauen (1 Bau), Verlegen (1 AP/Feld, distanzabhängig). Button-Layout auf Flex-Row (Label links, Chip rechts) umgestellt; redundante „1 AP"-Sub-Labels entfernt. Konvention in `docs/design-guide.md` §5.5 verankert (gilt screen-übergreifend). Render-Test ergänzt.
 
 - **Regressionstests Colony-Sidebar** — `BuildingInvestTest` (Levelup: AP-Fortschritt, Level-Schwelle setzt `ap_spend`→0 + Zustand→max, max_level-Block, Protokoll-Event) und `ColonyViewTest` (Render-Smoke: `colony.view` liefert 200 mit Tab-Markup + Repair/Invest-Wiring). Schließt die Coverage-Lücke für den Levelup-Endpoint; verifiziert die Logik hinter den manuellen Repair-/Levelup-Checks. 6 Tests, gesamt 647 grün.

--- a/app/Http/Middleware/EnsureRunStarted.php
+++ b/app/Http/Middleware/EnsureRunStarted.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Run;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Guards in-run game screens: a run must be active AND started (started_at set).
+ *
+ * A freshly created run is active but started_at = null (pending) until the
+ * player clicks "Mission starten" in the lobby. Without this guard a pending
+ * run could open the colony view but show no Sol button (dead end), since the
+ * run UI is gated on started_at. Pending / missing runs are sent to the lobby.
+ */
+class EnsureRunStarted
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $run = Run::where('user_id', Auth::id())
+            ->where('status', 'active')
+            ->first();
+
+        if ($run === null || $run->started_at === null) {
+            $redirect = redirect()->route('lobby')->with('info', __('lobby.run_not_started'));
+
+            // AJAX/JSON callers (in-run fetch actions) get a JSON pointer instead of HTML.
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'ok' => false,
+                    'error' => 'run_not_started',
+                    'redirect' => route('lobby'),
+                ], 409);
+            }
+
+            return $redirect;
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureRunStarted;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -11,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'run.started' => EnsureRunStarted::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/lang/de/lobby.php
+++ b/lang/de/lobby.php
@@ -6,6 +6,7 @@ return [
     'colony_ready' => 'Kolonie bereit zum Start',
     'start_button' => 'Mission starten',
     'no_run' => 'Kein aktiver Run gefunden. Bitte neu einloggen.',
+    'run_not_started' => 'Dein Run ist noch nicht gestartet — klicke „Mission starten", um loszulegen.',
 
     // New keys for the rewritten lobby view
     'page_title' => 'Mission Control',

--- a/public/css/infra.css
+++ b/public/css/infra.css
@@ -53,6 +53,11 @@
     border: 1px solid #f1aeb5;
     color: #58151c;
 }
+.infra-alert--info {
+    background: #e7f1fb;
+    border: 1px solid #aacbe9;
+    color: #0c3a5e;
+}
 
 /* ── Auth forms (login / register) ──────────────────────────────────────── */
 .infra-auth-wrap {

--- a/resources/views/layouts/infra.blade.php
+++ b/resources/views/layouts/infra.blade.php
@@ -1,71 +1,78 @@
 <!DOCTYPE html>
 <html lang="de" data-theme="light">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>@yield('title', 'Nouron')</title>
+    <title>@yield("title", "Nouron")</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400&display=swap">
-    <link rel="stylesheet" href="{{ asset('css/infra.css') }}">
-    @stack('styles')
+    <link rel="stylesheet" href="{{ asset("css/infra.css") }}">
+    @stack("styles")
 </head>
+
 <body>
 
-@auth
-<header class="infra-header">
-    <nav>
-        <ul>
-            <li><a href="{{ route('lobby') }}" class="infra-brand">Nouron</a></li>
-        </ul>
-        <ul>
-            @if($inActiveRun ?? false)
-            <li><a href="{{ route('colony.view') }}"><i class="bi bi-hexagon"></i><span class="infra-nav-label"> Kolonie</span></a></li>
-            @endif
-            <li>
-                <details class="dropdown">
-                    <summary>{{ Auth::user()->username }}</summary>
-                    <ul dir="rtl">
-                        <li><a href="{{ route('lobby') }}">{{ __('lobby.nav_runs') }}</a></li>
-                        <li><a href="{{ route('user.show') }}">Profil</a></li>
-                        <li><a href="{{ route('user.settings') }}">Einstellungen</a></li>
-                        <li>
-                            <form method="POST" action="{{ route('logout') }}" style="margin:0">
-                                @csrf
-                                <button type="submit">Abmelden</button>
-                            </form>
-                        </li>
-                    </ul>
-                </details>
-            </li>
-        </ul>
-    </nav>
-</header>
-@endauth
+    @auth
+        <header class="infra-header">
+            <nav>
+                <ul>
+                    <li><a href="{{ route("lobby") }}" class="infra-brand">Nouron</a></li>
+                </ul>
+                <ul>
+                    @if ($inActiveRun ?? false)
+                        <li><a href="{{ route("colony.view") }}"><i class="bi bi-hexagon"></i><span class="infra-nav-label">
+                                    Kolonie</span></a></li>
+                    @endif
+                    <li>
+                        <details class="dropdown">
+                            <summary>{{ Auth::user()->username }}</summary>
+                            <ul dir="rtl">
+                                <li><a href="{{ route("lobby") }}">{{ __("lobby.nav_runs") }}</a></li>
+                                <li><a href="{{ route("user.show") }}">Profil</a></li>
+                                <li><a href="{{ route("user.settings") }}">Einstellungen</a></li>
+                                <li>
+                                    <form method="POST" action="{{ route("logout") }}" style="margin:0">
+                                        @csrf
+                                        <button type="submit">Abmelden</button>
+                                    </form>
+                                </li>
+                            </ul>
+                        </details>
+                    </li>
+                </ul>
+            </nav>
+        </header>
+    @endauth
 
-<main class="infra-main">
-    @if(session('success'))
-        <p class="infra-alert infra-alert--success" role="alert">{{ session('success') }}</p>
-    @endif
-    @if(session('error'))
-        <p class="infra-alert infra-alert--error" role="alert">{{ session('error') }}</p>
-    @endif
-    @if(session('sol_advanced'))
-        <p class="infra-alert infra-alert--success" role="alert">Sol {{ session('sol_advanced') }} berechnet.</p>
-    @endif
+    <main class="infra-main">
+        @if (session("success"))
+            <p class="infra-alert infra-alert--success" role="alert">{{ session("success") }}</p>
+        @endif
+        @if (session("error"))
+            <p class="infra-alert infra-alert--error" role="alert">{{ session("error") }}</p>
+        @endif
+        @if (session("info"))
+            <p class="infra-alert infra-alert--info" role="alert">{{ session("info") }}</p>
+        @endif
+        @if (session("sol_advanced"))
+            <p class="infra-alert infra-alert--success" role="alert">Sol {{ session("sol_advanced") }} berechnet.</p>
+        @endif
 
-    @yield('content')
-</main>
+        @yield("content")
+    </main>
 
-@auth
-    @if(Auth::user()->role === 'admin')
-        @include('partials.debug-bar')
-    @endif
-@endauth
+    @auth
+        @if (Auth::user()->role === "admin")
+            @include("partials.debug-bar")
+        @endif
+    @endauth
 
-<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
-@stack('scripts')
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+    @stack("scripts")
 </body>
+
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,7 +60,7 @@ Route::middleware('auth')->prefix('user')->name('user.')->group(function () {
 
 // ── Colony ────────────────────────────────────────────────────────────────────
 
-Route::middleware('auth')->prefix('colony')->name('colony.')->group(function () {
+Route::middleware(['auth', 'run.started'])->prefix('colony')->name('colony.')->group(function () {
     Route::get('/view', [ColonyController::class, 'hexview'])->name('view');
     Route::patch('/name', [ColonyController::class, 'rename'])->name('rename');
 
@@ -104,14 +104,14 @@ Route::middleware('auth')->prefix('resources')->name('resources.')->group(functi
 
 // ── Kolonieprotokoll ──────────────────────────────────────────────────────────
 
-Route::middleware('auth')->prefix('comm-log')->name('comm.')->group(function () {
+Route::middleware(['auth', 'run.started'])->prefix('comm-log')->name('comm.')->group(function () {
     Route::get('/', [CommLogController::class, 'log'])->name('log');
     Route::get('/nexus', [CommLogController::class, 'nexus'])->name('nexus');
 });
 
 // ── Advisors ──────────────────────────────────────────────────────────────────
 
-Route::middleware('auth')->prefix('advisors')->name('advisors.')->group(function () {
+Route::middleware(['auth', 'run.started'])->prefix('advisors')->name('advisors.')->group(function () {
     Route::get('/', [AdvisorController::class, 'index'])->name('index');
     Route::post('/hire', [AdvisorController::class, 'hire'])->name('hire');
     Route::delete('/{id}', [AdvisorController::class, 'fire'])->name('fire')->where('id', '[0-9]+');
@@ -124,11 +124,11 @@ Route::middleware('auth')->get('/sol/remaining-ap', [SolController::class, 'rema
 
 // ── Nexus Database (static reference) ────────────────────────────────────────
 
-Route::middleware('auth')->get('/nexus-db', [NexusDbController::class, 'index'])->name('nexusdb.index');
+Route::middleware(['auth', 'run.started'])->get('/nexus-db', [NexusDbController::class, 'index'])->name('nexusdb.index');
 
 // ── Techtree (Schritt 10) ─────────────────────────────────────────────────────
 
-Route::middleware('auth')->prefix('techtree')->name('techtree.')->group(function () {
+Route::middleware(['auth', 'run.started'])->prefix('techtree')->name('techtree.')->group(function () {
     Route::get('/', [TechtreeController::class, 'index'])->name('index');
     Route::get('/{type}/{id}', [TechtreeController::class, 'technology'])->name('technology');
     // Action route called by techtree.js AJAX: GET /techtree/{type}/{id}/{order}[/{ap}]

--- a/tests/Feature/Colony/ColonyViewTest.php
+++ b/tests/Feature/Colony/ColonyViewTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Colony;
 use App\Models\User;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 /**
@@ -62,5 +63,19 @@ class ColonyViewTest extends TestCase
         $response->assertOk();
         // AP-cost chips (game-wide convention) sit inside the action buttons.
         $response->assertSee('ap-cost-chip', false);
+    }
+
+    public function test_pending_run_redirects_to_lobby(): void
+    {
+        // A pending run is active but not yet started (started_at = null).
+        DB::table('runs')
+            ->where('user_id', self::BART_USER_ID)
+            ->where('status', 'active')
+            ->update(['started_at' => null]);
+
+        $response = $this->actingAs($this->makeUser(self::BART_USER_ID))
+            ->get(route('colony.view'));
+
+        $response->assertRedirect(route('lobby'));
     }
 }


### PR DESCRIPTION
Behebt die Sackgasse, die beim Spielen auffiel: man konnte die Kolonieansicht eines **noch nicht gestarteten** Runs öffnen — dort fehlte der „Sol beenden"-Button (die Run-UI ist bewusst auf `started_at` gated), ohne Weg weiter.

## Ursache

`run.new` legt einen Run als `active` mit `started_at = null` an (= pending). Erst „Mission starten" in der Lobby (`lobby.start`) stempelt `started_at`. Die In-Run-Screens hatten aber keinen Guard — ein pending Run konnte colony.view etc. öffnen.

## Fix

Neue Middleware `run.started` (`EnsureRunStarted`):
- Kein aktiver Run **mit** `started_at` → Redirect Lobby (+ Info-Alert).
- AJAX/JSON-Aufrufe → `409 { ok:false, error:'run_not_started', redirect }`.

Angewendet auf **Screens**: colony, techtree, advisors, comm-log, nexus-db.
**Nicht** auf `sol.next` — der Action-Endpoint behält seine eigene 404-Logik (sonst brächen dessen Tests, und er ist über die colony.view-Sperre eh unerreichbar bei pending).

Info-Alert (`infra-alert--info`) in `layouts.infra` + `lobby.run_not_started`.

## Verifiziert

- [x] Test: pending Run (started_at=null) → `colony.view` redirectet zur Lobby
- [x] Volle Suite grün (649)
- [x] Pre-commit Hook sauber