### PR TITLE
fix(ui): build button chip + building list cost layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-20
 
+- **Hex-Bau-UI: zwei Layout-Fixes** (Owner-Report, Playtest). Der reine „Bauen"-Öffnen-Button (öffnet nur die Gebäudeauswahl, löst selbst keine AP-Aktion aus) zeigte fälschlich einen AP-Kosten-Chip — entfernt. In der Bauliste standen Gebäudename, AP-Kosten und Ressourcenkosten alle in einer Zeile und brachen hässlich um (z. B. „Lagerhalle-10 AP"); jetzt zwei Zeilen pro Eintrag: Name + AP-Kosten oben, Ressourcen-Chips (Regolith/Werkstoffe/Supply) darunter mit Flex-Wrap (`building-list-row`/`building-list-row--costs` in `colony.css`).
 - **Galaxie/Systemkarte + Fleet-Layer entfernt** (Owner-Entscheidung: „bis auf weiteres gestrichen"). Die navigierbare Galaxie-/Systemkarte und Flottenbewegung/-kampf waren UI-seitig längst weg; jetzt ist auch das tote Backend raus.
   - Gelöscht: `FleetService`, `GalaxyService`, alle `Fleet*`/`GlxSystem*`-Models, GameTick-Schritte Fleet-Move/Trade/Combat + Fleet-Ship-Decay. Migration droppt `fleets`/`fleet_*` + `glx_systems`/`glx_system*`-Tabellen + Views.
   - **Kolonie entkoppelt:** `glx_colonies` ohne `system_object_id`/`spot` neu gebaut (Koordinaten + System-Objekt-FK entfallen); `v_glx_colonies` ist jetzt ein Passthrough. Kolonie = ein Heimat-Standort ohne Systemraum.

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -1017,8 +1017,8 @@ button.btn-sol:hover,
 
 .building-list-item {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 0.25rem;
     padding: 0.45rem 0.7rem;
     border-radius: 5px;
     border: 1px solid var(--color-border);
@@ -1027,6 +1027,18 @@ button.btn-sol:hover,
     transition:
         background 0.1s ease,
         border-color 0.1s ease;
+}
+
+.building-list-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.building-list-row--costs {
+    justify-content: flex-start;
+    flex-wrap: wrap;
 }
 
 .building-list-item:hover {
@@ -1043,18 +1055,16 @@ button.btn-sol:hover,
     font-size: 0.85rem;
     font-weight: 600;
     color: var(--color-anthracite);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .building-list-ap {
     font-size: 0.72rem;
     color: #888;
     font-weight: 500;
-}
-
-.building-list-meta {
-    display: flex;
-    gap: 0.4rem;
-    align-items: center;
+    flex-shrink: 0;
 }
 
 .building-list-supply {

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -220,7 +220,6 @@
                                 <button class="tile-action-btn tile-action-btn--secondary"
                                     @click="startBuildForTile(selectedTile)">
                                     <span class="tile-action-btn__body">{{ __("colony.build") }}</span>
-                                    @include("partials.ap-cost-chip", ["amount" => 1, "type" => "build"])
                                 </button>
                             </template>
                         </div>
@@ -297,9 +296,11 @@
                                                 .building_id
                                         }"
                                         @click="selectPendingBuilding(b)">
-                                        <span class="building-list-name" x-text="b.label"></span>
-                                        <span class="building-list-meta">
+                                        <div class="building-list-row">
+                                            <span class="building-list-name" x-text="b.label"></span>
                                             <span class="building-list-ap" x-text="`${b.ap_for_levelup} AP`"></span>
+                                        </div>
+                                        <div class="building-list-row building-list-row--costs">
                                             <span class="building-list-supply" x-show="b.supply_cost > 0"
                                                 x-text="`${b.supply_cost} SUP`"></span>
                                             <span class="building-list-cost" x-show="b.build_cost && b.build_cost[3]"
@@ -307,7 +308,7 @@
                                             <span class="building-list-cost building-list-cost--compounds"
                                                 x-show="b.build_cost && b.build_cost[4]"
                                                 x-text="`${b.build_cost?.[4]} Wk`"></span>
-                                        </span>
+                                        </div>
                                     </li>
                                 </template>
                             </ul>


### PR DESCRIPTION
## Summary
- "Bauen"-Button öffnet nur die Gebäudeauswahl, spendet selbst keine AP — der AP-Kosten-Chip war irreführend, entfernt.
- Bauliste: Name+AP-Kosten und Ressourcenkosten-Chips (Regolith/Werkstoffe/Supply) jetzt in zwei Zeilen statt einer überfüllten Zeile (verursachte Wort-Umbrüche wie "Lagerhalle-10 AP").

## Test plan
- [x] `npx prettier --check` (Blade + CSS)
- [x] `php artisan view:cache` compiles
- [ ] Manuell im Browser verifizieren (Bauen-Button, Bauliste-Layout)