### PR TITLE
feat: Sol-Report V2 — 3-Screen-Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-06-29
+
+- **Sol-Report V2: 3-Screen-Flow.** Sol-Report erweitert auf drei aufeinanderfolgende Screens. Screen 1 (Gruppen-Report) unverändert; „Weiter"-Button führt jetzt zu Screen 2. Screen 2 zeigt Phase-Fortschritt: in Phase 1 die drei Abschluss-Kriterien (CC Lv3, 2 Gebäude Lv2, 3 Berater) mit aktuellem Stand; in Phase 2 die drei Nexus-Direktiven mit Revelations-Mechanik (Direktive erst sichtbar wenn Fortschritt > 0). Screen 3 zeigt „SOL N / startet" als elegante Fade-in-Animation auf dunklem Hintergrund, danach „Mission fortsetzen"-Button. `SolReportService::buildReport()` gibt jetzt `phase_progress`-Block aus (`SolReportService::phaseProgress()`). Alpine.js: `currentScreen` (1/2/3) + `screen3Phase` (0–3) State, `goScreen2()` / `goScreen3()` Methoden. CSS: `.sol-phase__*` (Screen 2) + `.sol-launch` / `.sol-launch__*` (Screen 3). Reduced-motion: Screen 3 überspringt Animation.
+
 ## 2026-06-28
 
 - **Voraussetzungsketten finalisiert** (Owner-Design). Analytiklabor + Hangar jetzt ab CC Lv1 baubar (Migration: `required_building_level` 2→1). Path-Gate (CC-Level−1-Formel) entfernt — natürliche Ressourcenknappheit steuert Spielerwahl statt künstlichem Gate. Techtree-Nav + Route gesperrt bis Analytiklabor gebaut (`sciencelabBuilt`-Flag in AppServiceProvider, Redirect in TechtreeController).

--- a/app/Services/SolReportService.php
+++ b/app/Services/SolReportService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Advisor;
 use App\Models\Run;
 use Illuminate\Support\Facades\DB;
 
@@ -143,6 +144,7 @@ class SolReportService
             'force_show' => $forceShow,
             'finale' => $finale,
             'groups' => $groups,
+            'phase_progress' => $this->phaseProgress($run),
         ];
     }
 
@@ -429,6 +431,91 @@ class SolReportService
         }
 
         return null;
+    }
+
+    // ── Phase progress (Screen 2) ───────────────────────────────────────────────
+
+    private function phaseProgress(Run $run): array
+    {
+        if ($run->phase === 1 || $run->phase === null) {
+            return $this->phase1Progress($run);
+        }
+
+        return $this->phase2Progress($run);
+    }
+
+    private function phase1Progress(Run $run): array
+    {
+        $ccId = config('buildings.commandCenter.id', 25);
+        $colonyId = (int) $run->colony_id;
+
+        $ccLevel = (int) (DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', $ccId)
+            ->value('level') ?? 0);
+
+        $buildingsLv2 = DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', '!=', $ccId)
+            ->where('level', '>=', 2)
+            ->count();
+
+        $advisorCount = Advisor::where('colony_id', $colonyId)
+            ->where(function ($q) use ($run): void {
+                $q->whereNull('unavailable_until_tick')
+                    ->orWhere('unavailable_until_tick', '<', $run->current_tick);
+            })
+            ->count();
+
+        return [
+            'phase' => 1,
+            'criteria' => [
+                [
+                    'key' => 'cc_level',
+                    'label' => __('colony.sol_report_phase1_cc'),
+                    'current' => min($ccLevel, 3),
+                    'target' => 3,
+                    'done' => $ccLevel >= 3,
+                ],
+                [
+                    'key' => 'buildings_lv2',
+                    'label' => __('colony.sol_report_phase1_buildings'),
+                    'current' => min($buildingsLv2, 2),
+                    'target' => 2,
+                    'done' => $buildingsLv2 >= 2,
+                ],
+                [
+                    'key' => 'advisors',
+                    'label' => __('colony.sol_report_phase1_advisors'),
+                    'current' => min($advisorCount, 3),
+                    'target' => 3,
+                    'done' => $advisorCount >= 3,
+                ],
+            ],
+        ];
+    }
+
+    private function phase2Progress(Run $run): array
+    {
+        $objectives = $run->objectives()
+            ->get(['task_key', 'current_value', 'target_value', 'completed_at']);
+
+        $items = $objectives->map(function ($obj): array {
+            $revealed = (int) $obj->current_value > 0 || $obj->completed_at !== null;
+
+            return [
+                'revealed' => $revealed,
+                'label' => $revealed ? __('run.'.$obj->task_key) : null,
+                'current' => (int) $obj->current_value,
+                'target' => (int) $obj->target_value,
+                'done' => $obj->completed_at !== null,
+            ];
+        })->values()->all();
+
+        return [
+            'phase' => 2,
+            'objectives' => $items,
+        ];
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -311,6 +311,22 @@ return [
     // UI-Steuertexte
     'sol_report_title' => 'Sol :sol abgeschlossen',
     'sol_report_continue' => 'Weiter zu Sol :sol',
+
+    // Screen 2 — Phase progress
+    'sol_report_screen2_title' => 'Fortschritt der Phase',
+    'sol_report_phase1_title' => 'Phase 1 — Stabilisierung',
+    'sol_report_phase2_title' => 'Phase 2 — Nexus-Direktiven',
+    'sol_report_phase1_cc' => 'Kontrollzentrum auf Stufe 3',
+    'sol_report_phase1_buildings' => '2 Gebäude auf Stufe 2',
+    'sol_report_phase1_advisors' => '3 aktive Berater',
+    'sol_report_phase2_objective_hidden' => 'Direktive noch unbekannt — im Spielverlauf erspielt',
+    'sol_report_phase2_objective_done' => 'Erfüllt',
+    'sol_report_next_screen' => 'Weiter',
+
+    // Screen 3 — SOL N startet
+    'sol_report_screen3_starts' => 'startet',
+    'sol_report_screen3_begin' => 'Mission fortsetzen',
+
     'sol_report_skip_hint' => 'Tippen zum Überspringen',
     'sol_report_skip_setting' => 'Sol-Report künftig automatisch überspringen',
     'sol_report_finale_win_cta' => 'Run abschließen',

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -2312,6 +2312,124 @@ dialog[x-ref="discoveryDialog"] {
     padding: 0.6rem 1.5rem;
 }
 
+/* ── Sol-Report Screen 2: Phase Progress ───────────────────────────────── */
+.sol-report--phase {
+    cursor: default;
+}
+.sol-phase__subtitle {
+    font-size: 0.8rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary, #6b6b7a);
+    margin: 0.25rem 0 0;
+}
+.sol-phase__body {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+.sol-phase__footer {
+    padding-top: 0.75rem;
+}
+.sol-phase__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+.sol-phase__item {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    font-size: 0.9rem;
+    color: var(--color-text-primary, #1a1a1e);
+    padding: 0.4rem 0.5rem;
+    border-radius: 5px;
+}
+.sol-phase__item--done {
+    color: #2e7d32;
+    background: #f2faf3;
+}
+.sol-phase__item--hidden {
+    color: var(--color-text-secondary, #6b6b7a);
+    font-style: italic;
+}
+.sol-phase__icon {
+    font-size: 1rem;
+    flex-shrink: 0;
+}
+.sol-phase__item--done .sol-phase__icon {
+    color: #2e7d32;
+}
+.sol-phase__item--hidden .sol-phase__icon {
+    color: var(--color-text-secondary, #6b6b7a);
+}
+.sol-phase__label {
+    flex: 1 1 auto;
+}
+.sol-phase__progress {
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary, #6b6b7a);
+}
+.sol-phase__item--done .sol-phase__progress {
+    color: #2e7d32;
+}
+
+/* ── Sol-Report Screen 3: Launch ───────────────────────────────────────── */
+.sol-launch {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3rem;
+    min-height: 60vh;
+    text-align: center;
+}
+.sol-launch__text {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+.sol-launch__sol {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-size: clamp(2.5rem, 8vw, 5rem);
+    font-weight: 400;
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    color: #ffffff;
+    line-height: 1;
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease;
+}
+.sol-launch__starts {
+    font-family: "Libre Baskerville", Baskerville, Georgia, serif;
+    font-size: clamp(1.1rem, 3vw, 1.6rem);
+    font-weight: 400;
+    letter-spacing: 0.5em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.65);
+    transition:
+        opacity 0.7s ease,
+        transform 0.7s ease;
+}
+.sol-launch__begin {
+    border-color: rgba(255, 255, 255, 0.4);
+    color: rgba(255, 255, 255, 0.85);
+    letter-spacing: 0.08em;
+    transition: opacity 0.5s ease;
+}
+.sol-launch__begin:hover {
+    border-color: rgba(255, 255, 255, 0.7);
+    color: #ffffff;
+    opacity: 1 !important;
+}
+
 @media (max-width: 30rem) {
     .sol-report__header,
     .sol-report__groups,

--- a/resources/views/partials/sol-button.blade.php
+++ b/resources/views/partials/sol-button.blade.php
@@ -13,6 +13,13 @@
         finaleWinCta: @js(__("colony.sol_report_finale_win_cta")),
         finaleLoseCta: @js(__("colony.sol_report_finale_lose_cta")),
         computing: @js(__("colony.next_sol_button")),
+        screen2Title: @js(__("colony.sol_report_screen2_title")),
+        phase1Title: @js(__("colony.sol_report_phase1_title")),
+        phase2Title: @js(__("colony.sol_report_phase2_title")),
+        objectiveHidden: @js(__("colony.sol_report_phase2_objective_hidden")),
+        nextScreen: @js(__("colony.sol_report_next_screen")),
+        solStarts: @js(__("colony.sol_report_screen3_starts")),
+        solBegin: @js(__("colony.sol_report_screen3_begin")),
     },
     routes: {
         remainingAp: @js(route("sol.remaining-ap")),
@@ -76,8 +83,8 @@
             </div>
         </template>
 
-        {{-- Standard group report --}}
-        <template x-if="report && !report.finale">
+        {{-- Screen 1: Standard group report --}}
+        <template x-if="report && !report.finale && currentScreen === 1">
             <div class="sol-report" @click.stop="skipToEnd()">
                 <header class="sol-report__header">
                     <h2 class="sol-report__title" x-text="headerTitle"></h2>
@@ -120,8 +127,85 @@
                         <span x-text="i18n.skipSetting"></span>
                     </label>
                     <button type="button" class="sol-btn sol-btn--primary sol-report__continue" x-show="finished"
-                        x-cloak @click.stop="goContinue()" x-text="continueLabel"></button>
+                        x-cloak @click.stop="goScreen2()" x-text="i18n.nextScreen"></button>
                 </footer>
+            </div>
+        </template>
+
+        {{-- Screen 2: Phase progress --}}
+        <template x-if="report && !report.finale && currentScreen === 2">
+            <div class="sol-report sol-report--phase" @click.stop>
+                <header class="sol-report__header">
+                    <h2 class="sol-report__title" x-text="i18n.screen2Title"></h2>
+                    <p class="sol-phase__subtitle"
+                        x-text="report.phase_progress.phase === 1 ? i18n.phase1Title : i18n.phase2Title"></p>
+                </header>
+
+                <div class="sol-report__groups sol-phase__body">
+
+                    {{-- Phase 1: criteria checklist --}}
+                    <template x-if="report.phase_progress.phase === 1">
+                        <ul class="sol-phase__list">
+                            <template x-for="c in report.phase_progress.criteria" :key="c.key">
+                                <li class="sol-phase__item" :class="c.done ? 'sol-phase__item--done' : ''">
+                                    <i class="bi sol-phase__icon"
+                                        :class="c.done ? 'bi-check-circle-fill' : 'bi-circle'"></i>
+                                    <span class="sol-phase__label" x-text="c.label"></span>
+                                    <span class="sol-phase__progress" x-text="c.current + ' / ' + c.target"></span>
+                                </li>
+                            </template>
+                        </ul>
+                    </template>
+
+                    {{-- Phase 2: objectives (with revelation mechanic) --}}
+                    <template x-if="report.phase_progress.phase === 2">
+                        <ul class="sol-phase__list">
+                            <template x-for="(obj, i) in report.phase_progress.objectives" :key="i">
+                                <li class="sol-phase__item"
+                                    :class="obj.done ? 'sol-phase__item--done' : (!obj.revealed ? 'sol-phase__item--hidden' :
+                                        '')">
+                                    <i class="bi sol-phase__icon"
+                                        :class="obj.done ? 'bi-check-circle-fill' : (obj.revealed ? 'bi-circle' :
+                                            'bi-question-circle')"></i>
+                                    <span class="sol-phase__label"
+                                        x-text="obj.revealed ? obj.label : i18n.objectiveHidden"></span>
+                                    <template x-if="obj.revealed">
+                                        <span class="sol-phase__progress"
+                                            x-text="obj.current + ' / ' + obj.target"></span>
+                                    </template>
+                                </li>
+                            </template>
+                        </ul>
+                    </template>
+                </div>
+
+                <footer class="sol-report__footer sol-phase__footer">
+                    <button type="button" class="sol-btn sol-btn--primary sol-report__continue"
+                        @click.stop="goScreen3()" x-text="i18n.nextScreen"></button>
+                </footer>
+            </div>
+        </template>
+
+        {{-- Screen 3: SOL N startet --}}
+        <template x-if="report && !report.finale && currentScreen === 3">
+            <div class="sol-launch" @click.stop>
+                <div class="sol-launch__text">
+                    <div class="sol-launch__sol"
+                        :style="{
+                            opacity: screen3Phase >= 1 ? 1 : 0,
+                            transform: screen3Phase >= 1 ? 'translateY(0)' : 'translateY(1.5rem)'
+                        }"
+                        x-text="'SOL ' + report.next_sol"></div>
+                    <div class="sol-launch__starts"
+                        :style="{
+                            opacity: screen3Phase >= 2 ? 1 : 0,
+                            transform: screen3Phase >= 2 ? 'translateY(0)' : 'translateY(1rem)'
+                        }"
+                        x-text="i18n.solStarts"></div>
+                </div>
+                <button type="button" class="sol-btn sol-btn--ghost sol-launch__begin"
+                    :style="{ opacity: screen3Phase >= 3 ? 1 : 0, pointerEvents: screen3Phase >= 3 ? 'auto' : 'none' }"
+                    @click.stop="goContinue()" x-text="i18n.solBegin"></button>
             </div>
         </template>
     </div>
@@ -147,6 +231,8 @@
             shakeKey: null,
             _timers: [],
             _reduceMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+            currentScreen: 1,
+            screen3Phase: 0, // 0=nothing visible, 1=sol-number, 2=starts text, 3=button
 
             get hasAp() {
                 return this.apData && this.apData.total > 0;
@@ -215,6 +301,8 @@
 
                     this.loading = false;
                     this.reportOpen = true;
+                    this.currentScreen = 1;
+                    this.screen3Phase = 0;
 
                     if (report.finale) {
                         // Finale renders immediately; no group animation.
@@ -313,11 +401,13 @@
             },
 
             skipToEnd() {
+                if (this.currentScreen !== 1) return;
                 if (this.finished) return;
                 this.finishNow();
             },
 
             finishNow() {
+                if (this.currentScreen !== 1) return;
                 this.clearTimers();
                 this.shakeKey = null;
                 this.visibleGroup = (this.report.groups || []).length - 1;
@@ -359,6 +449,28 @@
                 } catch (e) {
                     // Non-critical; preference simply won't persist this time.
                 }
+            },
+
+            goScreen2() {
+                this.clearTimers();
+                this.currentScreen = 2;
+            },
+
+            goScreen3() {
+                this.currentScreen = 3;
+                if (this._reduceMotion) {
+                    this.screen3Phase = 3;
+                    return;
+                }
+                this.schedule(() => {
+                    this.screen3Phase = 1;
+                }, 150);
+                this.schedule(() => {
+                    this.screen3Phase = 2;
+                }, 900);
+                this.schedule(() => {
+                    this.screen3Phase = 3;
+                }, 2000);
             },
 
             goContinue() {


### PR DESCRIPTION
## Summary

- **Screen 1**: bestehender Gruppen-Report unverändert; „Weiter"-Button führt zu Screen 2 statt direkt zur Kolonie
- **Screen 2**: Phase-Fortschritt — Phase 1 zeigt CC Lv3 / 2 Gebäude Lv2 / 3 Berater mit aktuellem Stand als Checkliste; Phase 2 zeigt Nexus-Direktiven mit Revelations-Mechanik (Direktive erst sichtbar wenn `current_value > 0`)
- **Screen 3**: „SOL N / startet" Fade-in-Animation auf dunklem Hintergrund (cinematic moment), danach „Mission fortsetzen"-Button; `prefers-reduced-motion` überspringt Animation

## Technisch

- `SolReportService::phaseProgress()` — neuer Block `phase_progress` im Report-JSON; `phase1Progress()` (3 Kriterien mit current/target/done) + `phase2Progress()` (Objectives mit revealed-Flag)
- Alpine.js: `currentScreen` (1/2/3) + `screen3Phase` (0–3) State; `goScreen2()` / `goScreen3()` Methoden; `skipToEnd()` / `finishNow()` guarded auf Screen 1
- CSS: `.sol-phase__*` (Screen-2-Checkliste, green done-state, italic hidden-state) + `.sol-launch` / `.sol-launch__*` (Screen 3, kein weißes Karte, direkt auf dunklem Overlay)
- 13 neue Lang-Keys (`sol_report_screen2_*`, `sol_report_phase1_*`, `sol_report_phase2_*`, `sol_report_screen3_*`)

## Test plan

- [ ] Sol beenden → Screen 1 spielt Gruppen-Report durch → „Weiter"-Button erscheint
- [ ] Screen 2 zeigt Phase-1-Kriterien mit korrektem Stand (CC-Level, Gebäude Lv2, Berater)
- [ ] In Phase 2: unrevealed Direktiven zeigen „Direktive noch unbekannt", revealed zeigen Label + Fortschritt
- [ ] „Weiter" → Screen 3: „SOL N" faded ein, dann „startet", dann „Mission fortsetzen"-Button
- [ ] Klick auf Overlay in Screen 1: beschleunigt Animation (skipToEnd); Screen 2/3: keine Wirkung
- [ ] skip_pref: überspringt alle Screens, navigiert direkt zur Kolonie
- [ ] Finale (win/lose): zeigt weiterhin Finale-Screen, kein Screen 2/3
- [ ] `prefers-reduced-motion`: Screen 3 zeigt sofort alles ohne Animation

https://claude.ai/code/session_01N6Jcf582UpFXjcPo1KCWY1