### PR TITLE
fix: hint_build_priority nach Pfadwahl + bebaubare Tiles visuell distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Changelog
 
-## 2026-06-29 (2)
-
-- **Fix: Nav-Links (Techtree/Cantina/Hangar) nach Level-Up sofort aktiv.** Analytiklabor/Bar/Hangar schalten ihren Nav-Link erst nach Seitenreload frei (Blade rendert `sciencelabBuilt` server-seitig). Fix: `investBuilding()` gibt `nav_unlocked: true` zurück wenn Building 31/44/52 von Level 0 auf 1 springt. `colony-hexgrid.js` lädt nach 600ms (Level-Up-Toast noch sichtbar) die Seite neu.
-
 ## 2026-06-29
 
-- **Sol-Report V2: 3-Screen-Flow.** Sol-Report erweitert auf drei aufeinanderfolgende Screens. Screen 1 (Gruppen-Report) unverändert; „Weiter"-Button führt jetzt zu Screen 2. Screen 2 zeigt Phase-Fortschritt: in Phase 1 die drei Abschluss-Kriterien (CC Lv3, 2 Gebäude Lv2, 3 Berater) mit aktuellem Stand; in Phase 2 die drei Nexus-Direktiven mit Revelations-Mechanik (Direktive erst sichtbar wenn Fortschritt > 0). Screen 3 zeigt „SOL N / startet" als elegante Fade-in-Animation auf dunklem Hintergrund, danach „Mission fortsetzen"-Button. `SolReportService::buildReport()` gibt jetzt `phase_progress`-Block aus (`SolReportService::phaseProgress()`). Alpine.js: `currentScreen` (1/2/3) + `screen3Phase` (0–3) State, `goScreen2()` / `goScreen3()` Methoden. CSS: `.sol-phase__*` (Screen 2) + `.sol-launch` / `.sol-launch__*` (Screen 3). Reduced-motion: Screen 3 überspringt Animation.
+- **Fix: Nav-Links (Techtree/Cantina/Hangar) nach Level-Up sofort aktiv.** Analytiklabor/Bar/Hangar schalten ihren Nav-Link erst nach Seitenreload frei (Blade rendert `sciencelabBuilt` server-seitig). Fix: `investBuilding()` gibt `nav_unlocked: true` zurück wenn Building 31/44/52 von Level 0 auf 1 springt. `colony-hexgrid.js` lädt nach 600ms (Level-Up-Toast noch sichtbar) die Seite neu.
+- **Sol-Report V2: 3-Screen-Flow.** Sol-Report erweitert auf drei aufeinanderfolgende Screens. Screen 1 (Gruppen-Report) unverändert; „Weiter"-Button führt jetzt zu Screen 2. Screen 2 zeigt Phase-Fortschritt: in Phase 1 die drei Abschluss-Kriterien (CC Lv3, 2 Gebäude Lv2, 3 Berater) mit aktuellem Stand; in Phase 2 die drei Nexus-Direktiven mit Revelations-Mechanik (Direktive erst sichtbar wenn Fortschritt > 0). Screen 3 zeigt „SOL N / startet" als elegante Fade-in-Animation auf dunklem Hintergrund, danach „Mission fortsetzen"-Button.
+- **Fix: `hint_build_priority` erscheint nicht mehr nach Pfadentscheidung.** Hint stumm sobald irgendein Pfadgebäude (31/44/52) platziert ist.
+- **Fix: Bebaubare Tiles visuell klar von unbebaubaren unterscheidbar.** Koloniezone-Tiles (`is_colony_zone=true, terrain_empty`) neu `#eaedf5` (deutlich heller), Explorations-Zone bleibt `#c8cdd6`. Neue Konstanten `BUILDABLE_COLOR`/`BUILDABLE_STROKE` in `colony-hexgrid.js`.
 
 ## 2026-06-28
 

--- a/app/Services/OnboardingHintService.php
+++ b/app/Services/OnboardingHintService.php
@@ -715,10 +715,17 @@ class OnboardingHintService
      */
     private function checkHintBuildPriority(int $colonyId, int $currentTick): bool
     {
+        // Once any path building is placed the player has made a choice — hint is moot.
+        if ($this->isBuildingPlaced($colonyId, 31)
+            || $this->isBuildingPlaced($colonyId, 44)
+            || $this->isBuildingPlaced($colonyId, 52)) {
+            return false;
+        }
+
         $eligible = 0;
-        $eligible += ($this->cantinaPrereqsMet($colonyId, $currentTick) && ! $this->isBuildingPlaced($colonyId, 52)) ? 1 : 0;
-        $eligible += ($this->hangarPrereqsMet($colonyId, $currentTick) && ! $this->isBuildingPlaced($colonyId, 44)) ? 1 : 0;
-        $eligible += ($this->analytikPrereqsMet($colonyId, $currentTick) && ! $this->isBuildingPlaced($colonyId, 31)) ? 1 : 0;
+        $eligible += $this->cantinaPrereqsMet($colonyId, $currentTick) ? 1 : 0;
+        $eligible += $this->hangarPrereqsMet($colonyId, $currentTick) ? 1 : 0;
+        $eligible += $this->analytikPrereqsMet($colonyId, $currentTick) ? 1 : 0;
 
         return $eligible >= 2;
     }

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -48,6 +48,10 @@ const TILE_STROKES = {
 
 const CC_COLOR = '#7ec87e';
 const CC_STROKE = '#2e7d32';
+// Colony-zone terrain: noticeably lighter than exploration-zone so "buildable" is
+// immediately visible without clicking. Exploration zone keeps the darker neutral grey.
+const BUILDABLE_COLOR = '#eaedf5'; // explored colony-zone terrain_empty
+const BUILDABLE_STROKE = '#b8c0d0';
 // Fog (state 3+4): clearly readable slate/blue-grey, distinct from the warm-grey
 // buildable terrain. Fog must stand out so the player sees what is still hidden.
 const FOG_COLOR = '#a9b2c4'; // unexplored colony zone (state 3) — buildable but hidden
@@ -1336,7 +1340,10 @@ function getTileColor(tile) {
     if (tile.q === 0 && tile.r === 0) return CC_COLOR;
     if (tile.is_deep_scanned && tile.event_type) return EVENT_COLOR;
 
-    // Exploration-zone terrain shows same fill as colony zone — distinction is dashed stroke + level badge
+    // Colony-zone terrain_empty is clearly lighter than exploration zone.
+    if (tile.is_colony_zone && tile.tile_type.startsWith('terrain_') && tile.tile_type !== 'terrain_impassable') {
+        return BUILDABLE_COLOR;
+    }
 
     return TILE_COLORS[tile.tile_type] ?? '#c8cdd6';
 }
@@ -1349,6 +1356,11 @@ function getTileStroke(tile, isCC) {
     if (!tile.is_explored) return [FOG_STROKE, '1.5'];
     if (tile.is_deep_scanned && tile.event_type) return [EVENT_STROKE, '1.5'];
     if (tile.tile_type === 'terrain_impassable') return ['#555', '0'];
+
+    // Colony-zone terrain: lighter stroke matching the buildable fill.
+    if (tile.is_colony_zone && tile.tile_type.startsWith('terrain_')) {
+        return [BUILDABLE_STROKE, '1.5'];
+    }
 
     // Exploration-zone terrain: dashed stroke signals "not yet claimed"
     if (!tile.is_colony_zone && tile.tile_type.startsWith('terrain_')) {


### PR DESCRIPTION
## Changes

### hint_build_priority zu spät

`checkHintBuildPriority()` feuerte in Sol 4 noch, weil 2 Pfadgebäude fehlten — egal ob eines schon gewählt war. Neue Bedingung: Hint stumm sobald building_id 31, 44 oder 52 platziert ist (Wahl getroffen → Hint obsolet).

### Bebaubare Tiles nicht erkennbar

`terrain_empty`-Tiles in der Koloniezone und außerhalb hatten identische Füllfarbe `#c8cdd6`. Neue Konstante `BUILDABLE_COLOR = '#eaedf5'` (deutlich heller/blasser) für `is_colony_zone=true` terrain-Tiles. Explorations-Zone behält `#c8cdd6`.

## Test plan

- [ ] Sol 1-2: `hint_build_priority` erscheint wenn 2+ Pfadgebäude baubar (noch keines gesetzt)
- [ ] Nach Platzieren von Analytiklabor/Hangar/Cantina: Hint erscheint nicht mehr
- [ ] Koloniezone-Tiles deutlich heller als Explorations-Zone-Tiles (visuell im Browser prüfen)
- [ ] Hazard + Regolith-Tiles behalten ihre Farben
- [ ] CC-Tile bleibt grün

https://claude.ai/code/session_01N6Jcf582UpFXjcPo1KCWY1