### PR TITLE
ADR-0003: Multiplayer-Turn-Resolution + Sofort-Maßnahmen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-01
+
+- **ADR 0003: Simultanes Turn-Resolution-System (Multiplayer-Architektur).** Architekturentscheidungen für den späteren optionalen Multiplayer-Modus (1–4 Spieler) dokumentiert: Hybrid-Trigger (sofort bei "alle ready" oder Deadline), generisches Option-B-Konfliktprinzip bei exklusiven Zielen, kein Elimination-Mechanismus, `games` ersetzt `runs` langfristig. Zwei Punkte davon sofort umgesetzt (siehe unten), Rest zurückgestellt bis Multiplayer aktiv angegangen wird.
+- **RNG-Seed-Vorbereitung.** `runs.rng_seed` (nullable) ergänzt, wird bei Run-Erstellung (`OnboardingService::setupNewPlayer()`) gesetzt — Grundlage für künftige deterministische Zufallsanwendung in der Multiplayer-Resolution-Engine. Bestehende Zufalls-Services unverändert.
+- **Domain-Events für Run-Lebenszyklus.** Drei neue Events (`app/Events/`): `RunStarted`, `SolAdvanced`, `RunEnded` — gefeuert bei Run-Erstellung, regulärem Tick-Abschluss (`game:tick`) und Run-Ende (`RunProgressService::endRun()`). Noch keine Listener registriert; dient als Andockpunkt für spätere Multiplayer-Trigger, ohne bestehende Logik (`colony_log`-Einträge) zu ersetzen.
+
 ## 2026-06-30
 
 - **Einheitliches Sci-Fi-Dialog-System (`dialogs.css`).** Neue globale CSS-Datei für alle `<dialog>`-Elemente im Spiel. Klasse `sol-modal` auf `<dialog>` gesetzt — erzeugt abgeschrägten Top-Right-Corner (clip-path Polygon), roten 3px Left-Accent-Stripe, dunklen Backdrop mit Blur und Drop-Shadow der dem Polygon folgt. PicoCSS-Konflikte (`overflow:auto`, `float:right` auf Close-Button, `border-radius`, `margin`) mit `!important` überschrieben. Beide Layouts (colony + infra) binden `dialogs.css` ein. Angewendet auf: Nexus-Direktiven-Dialog (hexview), Event-Discovery-Dialog (hexview), Schiff-Anfordern-Dialog (hangar).

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Enums\BuildingId;
+use App\Events\SolAdvanced;
 use App\Models\Advisor;
 use App\Models\Colony;
 use App\Models\ColonyBuilding;
@@ -182,6 +183,8 @@ class GameTick extends Command
 
             return self::SUCCESS;
         }
+
+        event(new SolAdvanced($run, $tick));
 
         $this->info("Tick {$tick} done.");
 

--- a/app/Events/RunEnded.php
+++ b/app/Events/RunEnded.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Run;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Fired when a run finishes, win or loss (ADR 0003 — Pub/Sub groundwork for
+ * the later Multiplayer Resolution Engine). No listeners yet.
+ */
+class RunEnded
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Run $run,
+        public readonly string $status,
+        public readonly ?string $failReason,
+    ) {}
+}

--- a/app/Events/RunStarted.php
+++ b/app/Events/RunStarted.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Run;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Fired when a new run is created (ADR 0003 — Pub/Sub groundwork for the
+ * later Multiplayer Resolution Engine). No listeners yet.
+ */
+class RunStarted
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Run $run,
+    ) {}
+}

--- a/app/Events/SolAdvanced.php
+++ b/app/Events/SolAdvanced.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Run;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Fired at the end of a fully processed game tick (ADR 0003 — Pub/Sub
+ * groundwork for the later Multiplayer Resolution Engine). No listeners yet.
+ */
+class SolAdvanced
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly Run $run,
+        public readonly int $tick,
+    ) {}
+}

--- a/app/Models/Run.php
+++ b/app/Models/Run.php
@@ -30,6 +30,7 @@ class Run extends Model
         'fail_reason',
         'nexus_debt',
         'phase2_start_tick',
+        'rng_seed',
     ];
 
     protected function casts(): array
@@ -39,6 +40,7 @@ class Run extends Model
             'phase' => 'integer',
             'nexus_debt' => 'integer',
             'phase2_start_tick' => 'integer',
+            'rng_seed' => 'integer',
             'started_at' => 'datetime',
             'ended_at' => 'datetime',
             'settings' => 'array',

--- a/app/Services/OnboardingService.php
+++ b/app/Services/OnboardingService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Events\RunStarted;
 use App\Models\Colony;
 use App\Models\Run;
 use Illuminate\Support\Facades\DB;
@@ -95,7 +96,7 @@ class OnboardingService
         $this->seedStartingTiles($colonyId);
         $this->eventService->createNexusBriefing($userId, 0, $colonyId);
 
-        Run::create([
+        $run = Run::create([
             'user_id' => $userId,
             'colony_id' => $colonyId,
             'current_tick' => 0,
@@ -109,7 +110,10 @@ class OnboardingService
                 'supply_cap_max' => config('game.supply.cap_max'),
                 'max_players' => config('game.run.max_players'),
             ],
+            'rng_seed' => random_int(1, PHP_INT_MAX),
         ]);
+
+        event(new RunStarted($run));
     }
 
     private function seedResources(int $userId, int $colonyId): void

--- a/app/Services/RunProgressService.php
+++ b/app/Services/RunProgressService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Events\RunEnded;
 use App\Models\Advisor;
 use App\Models\Run;
 use App\Models\RunObjective;
@@ -604,6 +605,8 @@ class RunProgressService
                 'run',
                 ['run_id' => $run->id, 'colony_id' => $run->colony_id, 'fail_reason' => $failReason]
             );
+
+            event(new RunEnded($run, $status, $failReason));
         });
     }
 

--- a/database/migrations/2026_07_01_000001_add_rng_seed_to_runs.php
+++ b/database/migrations/2026_07_01_000001_add_rng_seed_to_runs.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds rng_seed to runs — persisted per-run seed for deterministic randomness
+ * once the Multiplayer Resolution Engine needs reproducible outcomes (ADR 0003).
+ * Not yet consumed by any service.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('runs', function (Blueprint $table) {
+            $table->unsignedBigInteger('rng_seed')->nullable()->after('settings');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('runs', function (Blueprint $table) {
+            $table->dropColumn('rng_seed');
+        });
+    }
+};

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -145,7 +145,7 @@ Das Sol-System funktioniert in beiden Modi identisch — was sich unterscheidet,
 
 **Solo-Modus (primär):** Der Spieler steuert den Sol selbst. Nach dem Setzen aller Befehle löst er den nächsten Sol manuell aus ("Nächsten Sol starten"-Button) — der Sol feuert sofort. Es gibt kein Warten und keine Echtzeit-Begrenzung. "1 Sol" entspricht einem Spielzug, nicht einer Kalenderdauer.
 
-**Multiplayer-Modus (spätere Phase):** Alle Spieler einer Instanz teilen denselben Sol-Rhythmus. Der Sol feuert, sobald alle Spieler ihren Turn bestätigt haben — oder nach Ablauf des konfigurierten Timeouts, damit kein Mitspieler die Instanz dauerhaft blockieren kann.
+**Multiplayer-Modus (spätere Phase):** Alle Spieler einer Instanz teilen denselben Sol-Rhythmus. Der Sol feuert, sobald alle Spieler ihren Turn bestätigt haben — oder nach Ablauf des konfigurierten Timeouts, damit kein Mitspieler die Instanz dauerhaft blockieren kann. Technische Architektur (Turn-Resolution-Engine, Konfliktauflösung bei exklusiven Zielen, Event-System): siehe `docs/adr/0003-simultan-turn-resolution-multiplayer.md`.
 
 | Timeout-Konfiguration | Einsatz |
 |-----------------------|---------|

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1097,7 +1097,7 @@ Ein reisender Händler erscheint gelegentlich im System für eine begrenzte Anza
 
 ### Multiplayer
 
-Im Mehrspielermodus hat jeder Spieler einen eigenen Planeten im selben System. Interaktion findet über Flottenbewegung auf der Systemkarte statt (Handel, Diplomatie). Die Systemkarte ist der gemeinsame Interaktionsraum.
+> ⛔ **Veraltet (2026-07-01).** Der bisherige Ansatz (Interaktion über Flottenbewegung auf der Systemkarte) ist mit der Streichung der Systemkarte (siehe Banner oben) hinfällig. Derzeit ist **keine Multiplayer-Interaktionsmechanik geplant** — der Turn-Resolution-Layer aus ADR 0003 (`docs/adr/0003-simultan-turn-resolution-multiplayer.md`) ist davon unabhängig und unterstützt Multiplayer auch ohne gemeinsamen Interaktionsraum (z.B. mehrere Spieler, jeweils eigene isolierte Kolonie, gemeinsamer Sol-Rhythmus). Bei Bedarf neu evaluieren, sobald Multiplayer aktiv angegangen wird.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,7 +85,7 @@ Ziel: Entity-Namen (Ressourcen, Gebäude, Kenntnisse, Schiffe, Berater) überall
 - Berater Außendienst-Mechanik für weitere Typen (nach Playtest evaluieren)
 - Begegnungen & Gefahren (GDD §9) — konkrete Events + Encounter-Screens
 - Forschung / Techtree-Screen: Kenntnisse-Freischalt-Flow
-- Play-by-Mail-Multiplayer (3–4 Spieler, variable Tick-Zeiten) — optionale spätere Iteration
+- Play-by-Mail-Multiplayer (3–4 Spieler, variable Tick-Zeiten) — optionale spätere Iteration. Architektur festgelegt in ADR 0003 (`docs/adr/0003-simultan-turn-resolution-multiplayer.md`); zwei Sofort-Maßnahmen daraus bereits gemergt (2026-07-01): `runs.rng_seed`-Vorbereitung + Domain-Events (`RunStarted`/`SolAdvanced`/`RunEnded`). Rest (Games/TurnOrders/Resolution-Engine/KI) zurückgestellt bis aktiv angegangen.
 
 ---
 

--- a/docs/adr/0003-simultan-turn-resolution-multiplayer.md
+++ b/docs/adr/0003-simultan-turn-resolution-multiplayer.md
@@ -1,0 +1,166 @@
+# ADR 0003: Simultanes Turn-Resolution-System — Multiplayer-Architektur
+Datum: 2026-07-01
+Status: Akzeptiert (Umsetzung zurückgestellt — Vorentscheidungen sofort wirksam)
+
+## Kontext
+
+Nouron ist aktuell Singleplayer (Roguelike Mini-4X, 1 Spieler pro Run). Ein optionaler
+Multiplayer-Modus für 1–4 Spieler ist für eine spätere Phase geplant. Mehrere Architektur-
+entscheidungen müssen jetzt getroffen werden, damit die Singleplayer-Codebasis den
+Multiplayer nicht nachträglich blockiert.
+
+### Kernspannung: Interaktives Aktionsmodell vs. Batch-Order-Modell
+
+Das aktuelle Spiel funktioniert interaktiv: jede Spieleraktion ist ein eigener HTTP-Request
+(`ColonyController::placeBuilding()`, `PersonellService::hire()`, etc.) mit sofortiger DB-
+Änderung. Multiplayer erfordert ein **Batch-Order-Modell**: Alle Spieler planen ihren Zug
+parallel, Aktionen werden gesammelt und erst bei gemeinsamer Auflösung angewendet.
+
+Diese Spannung ist der größte Migrations-Aufwand für Multiplayer und muss bewusst gemanagt
+werden:
+
+- **Singleplayer bleibt interaktiv** (kein Umbau jetzt).
+- Bei Multiplayer-Einführung: Singleplayer-Modus = 1 Spieler, „alle ready" nach jeder
+  Aktion → sofortige Resolution. Der interaktive Eindruck bleibt erhalten; intern läuft
+  dieselbe Pipeline.
+
+### `games` ersetzt `runs` langfristig
+
+Das bestehende `runs`-Konzept (Run-Modell, Roguelike-Framing) und das geplante `games`-
+Konzept werden zu einem einzigen Modell zusammengeführt. Ein Singleplayer-Run ist ein
+`game` mit `player_count = 1`. Die Roguelike-Terminologie (Run, Sol) bleibt player-facing;
+intern wird `games` die kanonische Entität.
+
+Migration erfolgt bei Multiplayer-Einführung, nicht jetzt. Bis dahin bleibt `runs` bestehen.
+
+---
+
+## Entscheidungen
+
+### 1. Simultane Zugplanung mit Hybrid-Trigger
+
+Alle Spieler planen ihren Zug parallel (keine Zugreihenfolge). Auflösung erfolgt:
+- **Sofort**, sobald alle aktiven Spieler `is_ready = true` gesetzt haben, ODER
+- **Spätestens** bei Ablauf eines konfigurierten Zeitlimits (`turn_time_limit_seconds`,
+  Bereich: 300s–86400s, konfigurierbar pro Spiel in `config/game.php`).
+
+Bei Deadline-Ablauf: letzter gespeicherter (auch unvollständiger) Autosave-Stand wird
+angewendet. Kein Alles-oder-Nichts, kein reines Passen. Fehlt jeder Eintrag: `emptyOrder()`.
+
+Idempotenz-Schutz im `ResolveTurnJob`: DB-Transaktion mit `lockForUpdate()` auf `games`,
+Check ob `current_turn + phase` noch passen — schützt gegen Race zwischen Sofort- und
+Deadline-Trigger.
+
+**SQLite-Einschränkung:** `lockForUpdate()` unter SQLite fällt auf Table-Level-Lock zurück
+(kein Row-Level-Locking). Bei 1–4 Spielern akzeptabel. Bei PostgreSQL-Migration entfällt
+diese Einschränkung automatisch.
+
+### 2. Konfliktauflösung bei exklusiven Zielen — Option B
+
+Bei gleichzeitigem Zugriff von ≥2 Spielern auf dasselbe exklusive Ziel (freies Feld,
+begrenzt verfügbare Ressource, einmalige Aktion an einem Ort) im selben Zug gilt:
+
+**Option B: Alle konkurrierenden Aktionen scheitern. Das Ziel bleibt unverändert.**
+Alle beteiligten Spieler können es in der Folgerunde erneut versuchen. Eingesetzte
+Ressourcen/Einheiten bleiben unverändert erhalten (keine Aktion wird „verbraucht").
+
+Dies ist ein generisches Prinzip der `TurnResolutionEngine` über einen `ExclusiveClaimResolver`,
+nicht per Aktionstyp hartkodiert. Welche Aktionstypen als „exklusiv" gelten, wird über eine
+erweiterbare Markierung am jeweiligen Action-Handler konfiguriert (nicht in der Engine).
+
+Konkrete Anwendungsfälle werden ergänzt, sobald das Mechanik-Set für Multiplayer feststeht.
+
+### 3. Verpasste Züge — kein Elimination-Mechanismus
+
+`missed_turns_streak` ist ein rein informativer Zähler (hochzählen wenn kein/leerer
+Autosave, sonst Reset). Keine automatische Konsequenz (kein Kick, keine KI-Übernahme).
+
+**Zurückgestellt:** Regel, dass dauerhaft inaktive Spieler die „alle ready"-Sofortauflösung
+nicht blockieren (z.B. ab X verpassten Runden ignoriert). Wird nachgerüstet sobald sich
+Bedarf zeigt.
+
+### 4. KI-Spieler nutzen dieselbe Order-Pipeline
+
+KI-Slots reichen `turn_orders`-Einträge über denselben Submission-Pfad ein wie menschliche
+Spieler. Kein Sonderpfad an der `TurnResolutionEngine` vorbei. Entscheidungslogik (Scoring-
+Heuristiken) ist ein separates Concern; Qualität/Umfang bei Bedarf spezifizieren.
+
+### 5. Pub/Sub-Struktur (Event-System) — sofort wirksam
+
+Domain-Events werden von Services gefeuert. Presentation-/Notification-Logik ausschließlich
+in Listenern. Die Resolution Engine kennt nur Domain-Events.
+
+**Sofort umzusetzen (gilt für Singleplayer-Code jetzt):**
+- Services dürfen keine direkten Mail-/Notification-Aufrufe enthalten.
+- `TickService` und `RunProgressService` sollen Domain-Events feuern (z.B. `SolAdvanced`,
+  `RunStarted`, `RunEnded`) statt Presentation-Logik direkt auszuführen.
+- Event-Namen ohne `Run`-Präfix wählen, die bei späterer `games`-Migration noch passen
+  (Ausnahme: bestehende interne Events können zunächst bleiben, müssen aber bei Migration
+  umbenannt werden).
+
+**Für Multiplayer ergänzen (zurückgestellt):**
+`PlayerMarkedReady`, `TurnResolved`, `PlayerOrderResolutionFailed`, `GameStarted`.
+
+### 6. RNG-Seed — sofort vorbereiten
+
+Jedes Spiel (aktuell: jeder Run) benötigt einen persistierten `rng_seed` für deterministische
+Zufallsanwendung in der Resolution Engine. Das `runs`-Modell bekommt bei nächster Gelegenheit
+eine `rng_seed`-Spalte (nullable, für bestehende Runs rückwärts-kompatibel).
+
+Alle zufallsabhängigen Operationen in Services, die heute `rand()`/`mt_rand()` nutzen, sollen
+perspektivisch auf ein `SeededRng`-Objekt umgestellt werden, das den Seed als Zustand trägt.
+Nicht jetzt implementieren, aber bei neuen Services berücksichtigen.
+
+### 7. Realtime-Anbindung — Polling zuerst
+
+Entscheidung: **Polling-first**. Bei 1–4 Spielern und turn-basiertem Spielfluss ist Polling
+(kurzes Intervall beim Warten auf Mitspieler) ausreichend. Laravel Reverb / WebSocket-
+Broadcasting ist zurückgestellt bis Polling sich als unzureichend erweist.
+
+Falls Reverb später: `TurnResolved implements ShouldBroadcast`, Private Channel pro Spiel.
+
+---
+
+## Anpassungen gegenüber dem ursprünglichen Plan (Stand 2026-07-01)
+
+| Plan-Punkt | Anpassung |
+|---|---|
+| `games`-Tabelle parallel zu `runs` | `games` ersetzt `runs` langfristig (1 Konzept) |
+| `ColonizeActionResolver` in Phase 12 Tests | Leftover — ersetzt durch generischen `ExclusiveClaimResolver`-Test |
+| Phase 9 Pub/Sub: nur für Multiplayer | Event-Separation gilt sofort für alle Services |
+| RNG-Seed: nur in `games`-Migration | `runs` bekommt `rng_seed` jetzt als Vorarbeit |
+
+---
+
+## Umsetzungsreihenfolge (wenn Multiplayer aktiv angegangen wird)
+
+1. **Migration**: `rng_seed` auf `runs` (Vorarbeit, sofort). Bei Multiplayer: `games`-Tabelle
+   als Ablösung von `runs`, plus `game_players`, `turn_orders` (inkl. `placed_at_tick`-Analogie).
+2. **Event-Separation**: Singleplayer-Services auf Domain-Events umstellen (kann schrittweise
+   erfolgen).
+3. **Order-Submission-Layer**: `SaveTurnOrderRequest`, `TurnOrderController`, Autosave-API.
+4. **State Machine + Trigger**: `TurnService::startTurn()`, `PlayerMarkedReady`-Event,
+   `CheckAllPlayersReady`-Listener, Scheduler für Deadline-Check + Erinnerung.
+5. **Resolution Engine**: `ResolveTurnJob` (idempotent), `TurnResolutionEngine::apply()`,
+   `ExclusiveClaimResolver`, `emptyOrder()`-Fallback.
+6. **KI-Slots**: Listener auf `GameStarted`/`TurnService::startTurn()`, Order-Einreichung.
+7. **Tests**: Unit `TurnResolutionEngine` + `ExclusiveClaimResolver`, Feature `ResolveTurnJob`
+   Idempotenz/Fehlerisolation, Trigger-Pfade, Autosave-Verhalten, Missed-Turns-Zähler.
+
+---
+
+## Zurückgestellt (bewusst)
+
+- Inaktiv-Sonderregel für „alle ready"-Sofortauflösung (Phase 7 — bei Bedarf nachrüsten)
+- Laravel Reverb / WebSocket-Broadcasting (Phase 10 — Polling zuerst)
+- KI-Entscheidungslogik im Detail (Phase 8 — Umfang separat spezifizieren)
+- Vollständige `runs` → `games` Migration (bei Multiplayer-Einführung)
+- Konkrete exklusive Aktionstypen als Checkliste (ergänzen wenn Mechanik-Set feststeht)
+
+## Konsequenzen
+
+- Singleplayer-Code läuft bis auf weiteres unverändert auf dem interaktiven Modell.
+- Neue Services sollen Domain-Events statt direkter Presentation-Logik verwenden.
+- `rng_seed` auf `runs` ergänzen bei nächster passender Migration.
+- `TurnResolutionEngine` und `ExclusiveClaimResolver` sind bei Multiplayer-Einführung
+  Greenfield-Code (kein Refactoring bestehender Services nötig, da kein Sonderpfad).

--- a/tests/Feature/GameTick/GameTickTest.php
+++ b/tests/Feature/GameTick/GameTickTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Feature\GameTick;
 
+use App\Events\SolAdvanced;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 /**
@@ -126,6 +128,22 @@ class GameTickTest extends TestCase
             ->value('status_points');
 
         $this->assertEqualsWithDelta(11.0 - 0.17, $sp, 0.001);
+    }
+
+    // ── Domain events (ADR 0003) ─────────────────────────────────────────────
+
+    /**
+     * A regularly completed tick fires SolAdvanced with the processed run and tick.
+     */
+    public function test_sol_advanced_event_fires_on_regular_tick(): void
+    {
+        Event::fake([SolAdvanced::class]);
+
+        Artisan::call('game:tick', ['--run' => 1, '--tick' => 9020]);
+
+        Event::assertDispatched(SolAdvanced::class, function (SolAdvanced $event) {
+            return $event->run->id === 1 && $event->tick === 9020;
+        });
     }
 
     /**

--- a/tests/Feature/Onboarding/OnboardingE2ETest.php
+++ b/tests/Feature/Onboarding/OnboardingE2ETest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Onboarding;
 
+use App\Events\RunStarted;
 use App\Models\ColonyLog;
+use App\Models\Run;
 use App\Services\EventService;
 use App\Services\OnboardingHintService;
 use App\Services\OnboardingService;
@@ -11,6 +13,7 @@ use App\Services\TickService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 /**
@@ -191,5 +194,23 @@ class OnboardingE2ETest extends TestCase
 
         $hint = $this->hintService->getActiveHint($colony->id, $this->userId);
         $this->assertNotNull($hint, 'Hints should be active by default when no prefs row exists');
+    }
+
+    /**
+     * setupNewPlayer creates the run with a persisted rng_seed and fires
+     * RunStarted (ADR 0003 — groundwork for the Multiplayer Resolution Engine).
+     */
+    public function test_setup_new_player_seeds_rng_and_fires_run_started(): void
+    {
+        Event::fake([RunStarted::class]);
+
+        $colony = $this->onboardingService->setupNewPlayer($this->userId, 'RngSeed-Test');
+
+        $run = Run::where('colony_id', $colony->id)->firstOrFail();
+        $this->assertNotNull($run->rng_seed, 'rng_seed must be set on run creation');
+
+        Event::assertDispatched(RunStarted::class, function (RunStarted $event) use ($run) {
+            return $event->run->id === $run->id;
+        });
     }
 }

--- a/tests/Feature/RunProgressServiceTest.php
+++ b/tests/Feature/RunProgressServiceTest.php
@@ -65,6 +65,7 @@ namespace Tests\Feature;
  *   - sol 80 countdown fires when current_tick >= tick_limit - 20
  */
 
+use App\Events\RunEnded;
 use App\Models\Advisor;
 use App\Models\Run;
 use App\Models\RunObjective;
@@ -72,6 +73,7 @@ use App\Services\RunProgressService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
 class RunProgressServiceTest extends TestCase
@@ -553,6 +555,24 @@ class RunProgressServiceTest extends TestCase
         $this->assertEquals('completed', $row->status);
         $this->assertNull($row->fail_reason, 'fail_reason must be null for a successful run');
         $this->assertNotNull($row->ended_at);
+    }
+
+    /**
+     * endRun fires RunEnded with the final status and fail reason (ADR 0003).
+     */
+    public function test_end_run_fires_run_ended_event(): void
+    {
+        Event::fake([RunEnded::class]);
+
+        $run = $this->makeRun();
+
+        $this->service->endRun($run, 'failed', 'trust_collapse');
+
+        Event::assertDispatched(RunEnded::class, function (RunEnded $event) use ($run) {
+            return $event->run->id === $run->id
+                && $event->status === 'failed'
+                && $event->failReason === 'trust_collapse';
+        });
     }
 
     // ── calculateScore ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Neue ADR `docs/adr/0003-simultan-turn-resolution-multiplayer.md`: Architekturentscheidungen für den späteren optionalen Multiplayer-Modus (simultane Zugplanung, Hybrid-Trigger, generisches Option-B-Konfliktprinzip bei exklusiven Zielen, kein Elimination-Mechanismus, `games` ersetzt `runs` langfristig).
- Zwei ADR-Punkte sofort umgesetzt:
  - `runs.rng_seed` (nullable) — gesetzt bei Run-Erstellung, Grundlage für spätere deterministische Multiplayer-Resolution.
  - Drei Domain-Events (`RunStarted`, `SolAdvanced`, `RunEnded`) an den bestehenden Run-Lebenszyklus-Punkten (`OnboardingService`, `game:tick`, `RunProgressService::endRun()`) — noch ohne Listener, dient als Andockpunkt für später.
- GDD §2 + Roadmap Phase 4 verweisen jetzt auf die ADR.
- GDD §8a „Multiplayer"-Absatz korrigiert: nahm bisher Interaktion über die (am 2026-06-20 gestrichene) Systemkarte an — als veraltet markiert. Multiplayer selbst bleibt Ziel, nur diese Interaktionsmechanik ist hinfällig; Ersatz bei Bedarf neu evaluieren.

## Test plan
- [x] `php artisan test` — volle Suite grün (653 passed, 1 vorbestehender Fehler unabhängig von dieser PR — `TrustServiceTest::get_band_unknown_locale_returns...`, verifiziert auch auf `master` vor dieser Änderung reproduzierbar)
- [x] `./bin/pint --test` auf alle geänderten Dateien
- [x] Neue Tests: `RunStarted`/`SolAdvanced`/`RunEnded` Event-Dispatch + `rng_seed`-Persistenz
- [x] Manuell: `game:tick` gegen bestehenden Dev-Run gelaufen, keine Fehler, keine ungewollte Statusänderung

https://claude.ai/code/session_01N6Jcf582UpFXjcPo1KCWY1