### PR TITLE
game:snapshot — Playtest-Fortsetzung ohne Sol-1-Neustart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-08 (3)
+
+- **Fix: Entity-Chip-Tooltip clippte in Modals.** Owner-Playtest-Fund (Berater-Einstellen-Dialog): der Raumfahrer-Glossar-Chip öffnet sein Tooltip fix nach oben (`bottom: calc(100% + 0.4rem)`), ohne Boundary-Check — im `sol-modal` (`overflow: hidden` Article) wurde der obere Teil abgeschnitten und überlappte sichtbar die Modal-Kopfzeile. Fix (`components/entity-chip.blade.php`): gleiches Boundary-Clamp-Pattern wie `res-popup` (horizontales Clamping + jetzt zusätzlich vertikales Flip auf "unten öffnen", wenn der nächste `<dialog>`-Vorfahre das Tooltip oben clippen würde). Bewusst kein Merge der beiden Popup-Systeme (unterschiedliche UX-Rollen: Toolbar-Chips vs. Glossar-Begriffe im Fließtext) — nur das Positionierungs-Pattern geteilt. Per Playwright verifiziert (schmaler Viewport, Tooltip öffnet sauber nach unten, keine Überlappung mehr).
+
 ## 2026-07-08 (2)
 
 - **Fix: Berater-Screen zeigte Raumfahrer doppelt.** Owner-Playtest-Fund (Sol 4, direkt nach Hangar-Fertigstellung): Slot 2 zeigte den echten (hireable) Raumfahrer, Slot 3 zeigte fälschlich ebenfalls "Raumfahrer" als Preview statt des noch offenen Pfads. Root Cause: `AdvisorController::buildSlots()` mappte offene Pfad-Slots per fixer Position (`2=>scientist, 3=>pilot, 4=>trader`), obwohl Positionen dynamisch nach Bau-Reihenfolge vergeben werden — nach Hangar-Bau rutschte Pilot auf Position 2, Position 3 zeigte aber weiter ihren alten Fix-Preview statt des tatsächlich noch offenen Pfads. Fix: Preview-Keys jetzt als "alle Pfade minus bereits aufgelöste" berechnet, in kanonischer Reihenfolge. Live gegen Barts echten Sol-4-Stand verifiziert (Position 3/4 zeigen jetzt korrekt Analytiker/Konsul).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-08 (2)
+
+- **Fix: Berater-Screen zeigte Raumfahrer doppelt.** Owner-Playtest-Fund (Sol 4, direkt nach Hangar-Fertigstellung): Slot 2 zeigte den echten (hireable) Raumfahrer, Slot 3 zeigte fälschlich ebenfalls "Raumfahrer" als Preview statt des noch offenen Pfads. Root Cause: `AdvisorController::buildSlots()` mappte offene Pfad-Slots per fixer Position (`2=>scientist, 3=>pilot, 4=>trader`), obwohl Positionen dynamisch nach Bau-Reihenfolge vergeben werden — nach Hangar-Bau rutschte Pilot auf Position 2, Position 3 zeigte aber weiter ihren alten Fix-Preview statt des tatsächlich noch offenen Pfads. Fix: Preview-Keys jetzt als "alle Pfade minus bereits aufgelöste" berechnet, in kanonischer Reihenfolge. Live gegen Barts echten Sol-4-Stand verifiziert (Position 3/4 zeigen jetzt korrekt Analytiker/Konsul).
+
 ## 2026-07-08
 
 - **Fix: Resourcebar-Chip-Popups grau + von Hint-Bar verdeckt.** Owner-Playtest-Fund (Sol 1): Popups von `.res-chip`-Chips (Credits, Supply, Rg/Co/Or) erschienen grau statt weiß und ihr Titel wurde von der Hint-Bar überdeckt — Vertrauen/AP-Chips (`.ap-chip`) waren korrekt. Root Cause: `.res-chip:hover { filter: brightness(0.94) }` — der Filter wirkt auf den ganzen Subtree inkl. Popup (#fff × 0.94 = #f0f0f0) und erzeugt einen Stacking Context, der das Popup trotz `z-index: 300` unter der später gerenderten Hint-Bar gefangen hielt. Fix: Hover-Verdunkelung via `inset box-shadow` statt `filter` (`public/css/resources.css`) — wirkt nur auf den Chip-Hintergrund, kein Stacking Context. Per Playwright-Screenshot verifiziert (Supply + Credits: Titel sichtbar, weiß, über Hint-Bar).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-06
+
+- **Fix: Resourcebar-Popups überlappten sich.** Owner-Playtest-Fund (Sol 1): alle 11 Resourcebar-Chips hatten isolierten `x-data="{ open: false }"` — nichts schloss ein Nachbar-Popup beim Wechsel. Bei eng gepackten Chips mit breiten Popups (220-300px) konnten zwei gleichzeitig offen sein und sich überlagern (verwaschener Look, Titel eines Popups optisch verdeckt vom anderen). Fix: gemeinsamer `openChip`-State auf `.res-bar-wrap` (`resources/views/resources/resourcebar.blade.php`), jeder Chip vergleicht nur noch dagegen (`openChip === 'cr'` etc.) statt eigenem Boolean — immer nur ein Popup gleichzeitig offen. `partials/res-popup.blade.php` erwartet jetzt `popup_key`. Live verifiziert: alle 12 Chip-Popups (Sol/Credits/Supply/Vertrauen/Regolith/Werkstoffe/Organika/5×AP) rendern mit eindeutigem Key, keine Überlappung mehr möglich.
+
 ## 2026-07-05 (2)
 
 - **`game:snapshot` — Playtest-Fortsetzung ohne Sol-1-Neustart.** Owner-Pain-Point: jeder Blocker während des täglichen Playtests zwang zum Reset auf Sol 1 (`game:reset-player` bietet nur 5 feste Szenarien, keine Fortsetzung des echten Runs). Neuer Dev-Command dumpt/restored den kompletten Live-Zustand eines Spielers (Colony/Run/Resources/Buildings/Tiles/Advisors/Ships/Missions/Researches/Log) als JSON unter `storage/app/private/snapshots/{user_id}/{label}.json` — `save`/`restore`/`list`. Workflow: vor riskanter Aktion snapshotten, bei Blocker fixen + zurückspulen statt neu hochzuspielen. Live gegen Bart (echter Sol-97-Run) verifiziert: save → Mutation → restore → Zustand + alle Kernscreens (Colony/Hangar/Comm-Log/Advisors) korrekt.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-05 (2)
+
+- **`game:snapshot` — Playtest-Fortsetzung ohne Sol-1-Neustart.** Owner-Pain-Point: jeder Blocker während des täglichen Playtests zwang zum Reset auf Sol 1 (`game:reset-player` bietet nur 5 feste Szenarien, keine Fortsetzung des echten Runs). Neuer Dev-Command dumpt/restored den kompletten Live-Zustand eines Spielers (Colony/Run/Resources/Buildings/Tiles/Advisors/Ships/Missions/Researches/Log) als JSON unter `storage/app/private/snapshots/{user_id}/{label}.json` — `save`/`restore`/`list`. Workflow: vor riskanter Aktion snapshotten, bei Blocker fixen + zurückspulen statt neu hochzuspielen. Live gegen Bart (echter Sol-97-Run) verifiziert: save → Mutation → restore → Zustand + alle Kernscreens (Colony/Hangar/Comm-Log/Advisors) korrekt.
+
 ## 2026-07-05
 
 - **Hangar-Missionskatalog implementiert** (GDD §8b, 12 Missionstypen — `mission_perimeter_patrol` zurückgestellt bis §9 existiert). `config/missions.php` neu (Katalog, Kosten-/Skalierungsparameter). `HangarService::dispatchShip()` auf `(colonyId, instanceId, missionKey, ?target)` umgestellt — validiert Schiffstyp, Kenntnis-Gate, Ziel (Signal-/Ruinen-Tile oder Kenntnis), SP-Dispatch-Sperre (<25%); neue `getMissionCatalogFor()` liefert lokalisierten, kostenberechneten Katalog für die UI. `organikaCostFor()` implementiert die Kenntnis-Skalierung (−1 Organika/Distanz-Sol je Level über Gate, Floor 1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 2026-07-06
+## 2026-07-08
 
-- **Fix: Resourcebar-Popups überlappten sich.** Owner-Playtest-Fund (Sol 1): alle 11 Resourcebar-Chips hatten isolierten `x-data="{ open: false }"` — nichts schloss ein Nachbar-Popup beim Wechsel. Bei eng gepackten Chips mit breiten Popups (220-300px) konnten zwei gleichzeitig offen sein und sich überlagern (verwaschener Look, Titel eines Popups optisch verdeckt vom anderen). Fix: gemeinsamer `openChip`-State auf `.res-bar-wrap` (`resources/views/resources/resourcebar.blade.php`), jeder Chip vergleicht nur noch dagegen (`openChip === 'cr'` etc.) statt eigenem Boolean — immer nur ein Popup gleichzeitig offen. `partials/res-popup.blade.php` erwartet jetzt `popup_key`. Live verifiziert: alle 12 Chip-Popups (Sol/Credits/Supply/Vertrauen/Regolith/Werkstoffe/Organika/5×AP) rendern mit eindeutigem Key, keine Überlappung mehr möglich.
+- **Fix: Resourcebar-Chip-Popups grau + von Hint-Bar verdeckt.** Owner-Playtest-Fund (Sol 1): Popups von `.res-chip`-Chips (Credits, Supply, Rg/Co/Or) erschienen grau statt weiß und ihr Titel wurde von der Hint-Bar überdeckt — Vertrauen/AP-Chips (`.ap-chip`) waren korrekt. Root Cause: `.res-chip:hover { filter: brightness(0.94) }` — der Filter wirkt auf den ganzen Subtree inkl. Popup (#fff × 0.94 = #f0f0f0) und erzeugt einen Stacking Context, der das Popup trotz `z-index: 300` unter der später gerenderten Hint-Bar gefangen hielt. Fix: Hover-Verdunkelung via `inset box-shadow` statt `filter` (`public/css/resources.css`) — wirkt nur auf den Chip-Hintergrund, kein Stacking Context. Per Playwright-Screenshot verifiziert (Supply + Credits: Titel sichtbar, weiß, über Hint-Bar).
+- **Refactor nebenbei:** Resourcebar-Popups von 11 isolierten `x-data="{ open: false }"` auf gemeinsamen `openChip`-State auf `.res-bar-wrap` umgestellt (`resourcebar.blade.php`, `partials/res-popup.blade.php` erwartet jetzt `popup_key`) — garantiert dass nie zwei Popups gleichzeitig offen sind.
 
 ## 2026-07-05 (2)
 

--- a/app/Console/Commands/GameSnapshot.php
+++ b/app/Console/Commands/GameSnapshot.php
@@ -1,0 +1,281 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\table;
+
+/**
+ * GameSnapshot — dev tool to save/restore a player's actual live run state.
+ *
+ * Solves the "reset-player forces a restart from Sol 1" problem: unlike
+ * game:reset-player (which seeds one of 5 hand-crafted scenarios), this
+ * captures/restores whatever state a real playtest run is actually in — so
+ * fixing a blocker found at e.g. Sol 47 doesn't require re-clicking from
+ * Sol 1 to get back there.
+ *
+ * Usage:
+ *   php artisan game:snapshot save bart pre-blocker
+ *   php artisan game:snapshot restore bart pre-blocker
+ *   php artisan game:snapshot list bart
+ *
+ * Storage: storage/app/snapshots/{user_id}/{label}.json (local disk, dev-only —
+ * not part of the game's DB schema, nothing to migrate).
+ */
+class GameSnapshot extends Command
+{
+    protected $signature = 'game:snapshot
+        {action : save|restore|list}
+        {user? : Username or user_id (omit for interactive select)}
+        {label? : Snapshot label (omit for interactive select on restore/list, timestamp on save)}
+        {--yes : Skip confirmation prompts}';
+
+    protected $description = 'Save/restore a player\'s live run state (dev tool) — resume a playtest after fixing a blocker instead of restarting from Sol 1.';
+
+    /**
+     * Tables scoped by colony_id, in FK-safe delete order (children before
+     * glx_colonies) — mirrors ResetPlayer's wipe list.
+     */
+    private const COLONY_SCOPED_TABLES = [
+        'colony_resources', 'colony_buildings', 'colony_tiles', 'advisors',
+        'colony_ships', 'colony_researches', 'colony_personell',
+        'trade_resources', 'trust_events', 'merchant_visits', 'colony_hangar_missions',
+    ];
+
+    public function handle(): int
+    {
+        $action = $this->argument('action');
+        if (! in_array($action, ['save', 'restore', 'list'], true)) {
+            $this->error("Unknown action: {$action} (expected save|restore|list)");
+
+            return self::FAILURE;
+        }
+
+        $user = $this->resolveUser();
+        if ($user === null) {
+            return self::FAILURE;
+        }
+
+        return match ($action) {
+            'save' => $this->save($user),
+            'restore' => $this->restore($user),
+            'list' => $this->list($user),
+        };
+    }
+
+    // ── User resolution (same lookup as ResetPlayer) ─────────────────────────
+
+    private function resolveUser(): ?User
+    {
+        $input = $this->argument('user');
+
+        if ($input !== null) {
+            $user = is_numeric($input)
+                ? User::find((int) $input)
+                : User::whereRaw('LOWER(username) = LOWER(?)', [$input])->first();
+
+            if (! $user) {
+                $this->error("User not found: {$input}");
+            }
+
+            return $user;
+        }
+
+        $rows = DB::table('user')->select('user_id', 'username')->orderBy('username')->get();
+        if ($rows->isEmpty()) {
+            $this->error('No users in database.');
+
+            return null;
+        }
+
+        $chosen = select(label: 'Spieler', options: $rows->pluck('username', 'user_id')->toArray());
+
+        return User::find((int) $chosen);
+    }
+
+    // ── save ──────────────────────────────────────────────────────────────────
+
+    private function save(User $user): int
+    {
+        $label = $this->argument('label') ?? now()->format('Y-m-d_His');
+
+        $colonyIds = DB::table('glx_colonies')->where('user_id', $user->user_id)->pluck('id');
+        $runIds = DB::table('runs')->where('user_id', $user->user_id)->pluck('id');
+
+        $path = $this->snapshotPath($user->user_id, $label);
+        if (Storage::exists($path) && ! $this->option('yes')) {
+            if (! confirm("Snapshot '{$label}' existiert bereits — überschreiben?", default: false)) {
+                $this->line('Aborted.');
+
+                return self::SUCCESS;
+            }
+        }
+
+        $data = [
+            'colony_ids' => $colonyIds->all(),
+            'run_ids' => $runIds->all(),
+            'tables' => [],
+        ];
+
+        foreach (self::COLONY_SCOPED_TABLES as $table) {
+            $data['tables'][$table] = DB::table($table)->whereIn('colony_id', $colonyIds)->get()->toArray();
+        }
+        $data['tables']['run_objectives'] = DB::table('run_objectives')->whereIn('run_id', $runIds)->get()->toArray();
+        $data['tables']['runs'] = DB::table('runs')->where('user_id', $user->user_id)->get()->toArray();
+        $data['tables']['glx_colonies'] = DB::table('glx_colonies')->where('user_id', $user->user_id)->get()->toArray();
+        $data['tables']['user_resources'] = DB::table('user_resources')->where('user_id', $user->user_id)->get()->toArray();
+        $data['tables']['user_preferences'] = DB::table('user_preferences')->where('user_id', $user->user_id)->get()->toArray();
+        $data['tables']['colony_log'] = DB::table('colony_log')->where('user', $user->user_id)->get()->toArray();
+
+        $run = DB::table('runs')->where('user_id', $user->user_id)->where('status', 'active')->first();
+        $data['meta'] = [
+            'user_id' => $user->user_id,
+            'username' => $user->username,
+            'created_at' => now()->toDateTimeString(),
+            'current_tick' => $run->current_tick ?? null,
+            'phase' => $run->phase ?? null,
+            'run_status' => $run->status ?? null,
+        ];
+
+        Storage::put($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        $this->info("Snapshot '{$label}' gespeichert (Sol {$data['meta']['current_tick']}, Phase {$data['meta']['phase']}).");
+
+        return self::SUCCESS;
+    }
+
+    // ── restore ───────────────────────────────────────────────────────────────
+
+    private function restore(User $user): int
+    {
+        $label = $this->argument('label') ?? $this->selectLabel($user->user_id);
+        if ($label === null) {
+            return self::FAILURE;
+        }
+
+        $path = $this->snapshotPath($user->user_id, $label);
+        if (! Storage::exists($path)) {
+            $this->error("Snapshot not found: {$label}");
+
+            return self::FAILURE;
+        }
+
+        $data = json_decode(Storage::get($path), true);
+
+        if (! $this->option('yes')) {
+            $tick = $data['meta']['current_tick'] ?? '?';
+            if (! confirm("Aktuellen Spielstand von '{$user->username}' durch Snapshot '{$label}' (Sol {$tick}) ersetzen?", default: false)) {
+                $this->line('Aborted.');
+
+                return self::SUCCESS;
+            }
+        }
+
+        DB::transaction(function () use ($user, $data) {
+            $colonyIds = DB::table('glx_colonies')->where('user_id', $user->user_id)->pluck('id');
+            $runIds = DB::table('runs')->where('user_id', $user->user_id)->pluck('id');
+
+            // Wipe current state — same table set/order as ResetPlayer's reset.
+            foreach ($colonyIds as $cid) {
+                foreach (self::COLONY_SCOPED_TABLES as $table) {
+                    DB::table($table)->where('colony_id', $cid)->delete();
+                }
+                DB::table('locked_actionpoints')->where('scope_type', 'colony')->where('scope_id', $cid)->delete();
+            }
+            DB::table('run_objectives')->whereIn('run_id', $runIds)->delete();
+            DB::table('runs')->where('user_id', $user->user_id)->delete();
+            DB::table('glx_colonies')->where('user_id', $user->user_id)->delete();
+            DB::table('user_resources')->where('user_id', $user->user_id)->delete();
+            DB::table('user_preferences')->where('user_id', $user->user_id)->delete();
+            DB::table('colony_log')->where('user', $user->user_id)->delete();
+
+            // Re-insert snapshot — parents before children.
+            $this->insertRows('glx_colonies', $data['tables']['glx_colonies']);
+            $this->insertRows('runs', $data['tables']['runs']);
+            foreach ($data['tables'] as $table => $rows) {
+                if (in_array($table, ['glx_colonies', 'runs'], true)) {
+                    continue;
+                }
+                $this->insertRows($table, $rows);
+            }
+        });
+
+        $tick = $data['meta']['current_tick'] ?? '?';
+        $this->info("Snapshot '{$label}' wiederhergestellt (Sol {$tick}).");
+
+        return self::SUCCESS;
+    }
+
+    private function insertRows(string $table, array $rows): void
+    {
+        if ($rows === []) {
+            return;
+        }
+        // Chunk to stay well under SQLite's default bound-parameter limit.
+        foreach (array_chunk($rows, 200) as $chunk) {
+            DB::table($table)->insert($chunk);
+        }
+    }
+
+    // ── list ──────────────────────────────────────────────────────────────────
+
+    private function list(User $user): int
+    {
+        $labels = $this->labelsFor($user->user_id);
+        if ($labels === []) {
+            $this->line("Keine Snapshots für '{$user->username}'.");
+
+            return self::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($labels as $label) {
+            $meta = json_decode(Storage::get($this->snapshotPath($user->user_id, $label)), true)['meta'] ?? [];
+            $rows[] = [$label, $meta['current_tick'] ?? '?', $meta['phase'] ?? '?', $meta['created_at'] ?? '?'];
+        }
+
+        table(['Label', 'Sol', 'Phase', 'Gespeichert am'], $rows);
+
+        return self::SUCCESS;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function snapshotPath(int $userId, string $label): string
+    {
+        return "snapshots/{$userId}/{$label}.json";
+    }
+
+    /** @return string[] */
+    private function labelsFor(int $userId): array
+    {
+        $dir = "snapshots/{$userId}";
+        if (! Storage::exists($dir)) {
+            return [];
+        }
+
+        return collect(Storage::files($dir))
+            ->map(fn ($f) => pathinfo($f, PATHINFO_FILENAME))
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    private function selectLabel(int $userId): ?string
+    {
+        $labels = $this->labelsFor($userId);
+        if ($labels === []) {
+            $this->error('No snapshots available.');
+
+            return null;
+        }
+
+        return select(label: 'Snapshot', options: array_combine($labels, $labels));
+    }
+}

--- a/app/Http/Controllers/Techtree/AdvisorController.php
+++ b/app/Http/Controllers/Techtree/AdvisorController.php
@@ -105,6 +105,13 @@ class AdvisorController extends BaseController
 
         $pathKeys = array_map(fn ($id) => self::PATH_BUILDINGS[$id], $pathBuildingIds);
 
+        // Preview keys for still-open path positions: whichever of the three
+        // path types haven't been resolved yet, in canonical order — NOT a
+        // fixed per-position map, since $pathKeys shifts left as buildings
+        // are placed (bug: position 3 kept previewing 'pilot' even after
+        // pilot was already resolved at position 2).
+        $remainingPreviewKeys = array_values(array_diff(array_values(self::PATH_BUILDINGS), $pathKeys));
+
         $slots = [];
 
         for ($position = 1; $position <= 5; $position++) {
@@ -119,8 +126,8 @@ class AdvisorController extends BaseController
             // All path slots require CC Lv2 minimum; the build-gate in placeBuilding()
             // controls how many path buildings can coexist (CC-Level − 1).
             if ($key === null) {
-                $previewKeys = [2 => 'scientist', 3 => 'pilot', 4 => 'trader'];
-                $previewKey = $previewKeys[$position] ?? null;
+                $previewIndex = $position - 2 - count($pathKeys);
+                $previewKey = $remainingPreviewKeys[$previewIndex] ?? null;
                 $previewCfg = $previewKey ? config("advisors.{$previewKey}") : null;
 
                 $slots[] = [

--- a/public/css/resources.css
+++ b/public/css/resources.css
@@ -35,10 +35,14 @@
     color: #333;
     white-space: nowrap;
     cursor: default;
-    transition: filter 0.15s;
+    transition: box-shadow 0.15s;
 }
+/* Darken via inset shadow, NOT filter: filter on the chip creates a stacking
+ * context and applies to descendants — the .res-popup child would render
+ * grayed out (#fff × 0.94 = #f0f0f0) and trapped below later siblings
+ * (hint-bar) despite its z-index. */
 .res-chip:hover {
-    filter: brightness(0.94);
+    box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.06);
 }
 
 /* No size difference between primary and secondary chips */

--- a/resources/views/components/entity-chip.blade.php
+++ b/resources/views/components/entity-chip.blade.php
@@ -13,59 +13,66 @@
 
     Note: outer element is always <span>. Links live only inside the tooltip to avoid
     nested-<a> invalid HTML when the component is placed inside a link context.
+
+    Positioning: the tooltip clamps horizontally to the viewport and flips
+    from above-chip to below-chip when clipped by the nearest <dialog>
+    ancestor (e.g. sol-modal's overflow:hidden article) — same boundary-clamp
+    pattern as partials/res-popup.blade.php, kept as a separate small x-effect
+    rather than a shared component since the two tooltip systems serve
+    different UX roles (fixed toolbar chips vs. inline glossary terms).
 --}}
 
 @php
     $iconMap = [
-        'building'  => 'bi-hexagon',
-        'knowledge' => 'bi-book',
-        'resource'  => 'bi-layers',
-        'ship'      => 'bi-rocket-takeoff',
-        'advisor'   => 'bi-person-badge',
-        'research'  => 'bi-diagram-3',
+        "building" => "bi-hexagon",
+        "knowledge" => "bi-book",
+        "resource" => "bi-layers",
+        "ship" => "bi-rocket-takeoff",
+        "advisor" => "bi-person-badge",
+        "research" => "bi-diagram-3",
     ];
 
-    $icon    = $iconMap[$type] ?? 'bi-circle';
-    $link    = $tooltip['link'] ?? null;
-    $hasLevel   = isset($tooltip['level']) && $tooltip['level'] !== null && $tooltip['level'] !== '';
-    $hasDesc    = !empty($tooltip['description'] ?? null);
-    $hasMeta    = !empty($tooltip['meta'] ?? null);
-    $hasLink    = !empty($link);
+    $icon = $iconMap[$type] ?? "bi-circle";
+    $link = $tooltip["link"] ?? null;
+    $hasLevel = isset($tooltip["level"]) && $tooltip["level"] !== null && $tooltip["level"] !== "";
+    $hasDesc = !empty($tooltip["description"] ?? null);
+    $hasMeta = !empty($tooltip["meta"] ?? null);
+    $hasLink = !empty($link);
     $hasTooltip = $hasLevel || $hasDesc || $hasMeta || $hasLink;
 @endphp
 
-<span
-    class="entity-chip entity-chip--{{ $type }}"
-    data-chip-type="{{ $type }}"
-    data-chip-key="{{ $entityKey }}"
-    x-data="{ open: false }"
-    @mouseenter="open = true"
-    @mouseleave="open = false"
-    @click.stop="open = !open"
-    @click.away="open = false"
-    role="button"
-    tabindex="0"
-    @keydown.escape="open = false"
-    @keydown.enter.prevent="open = !open"
-    aria-label="{{ $label }}"
-><i class="bi {{ $icon }}" aria-hidden="true"></i>{{ $label }}@if($hasTooltip)<span class="entity-chip-tooltip" x-show="open" x-cloak>
-        <span class="entity-chip-tooltip-name">{{ $label }}</span>
-        @if($hasLevel)
-            <span class="entity-chip-tooltip-row">
-                <span class="entity-chip-tooltip-label">{{ __('entity_chip.label_level') }}</span>
-                <span>{{ $tooltip['level'] }}</span>
-            </span>
-        @endif
-        @if($hasDesc)
-            <span class="entity-chip-tooltip-desc">{{ $tooltip['description'] }}</span>
-        @endif
-        @if($hasMeta)
-            <span class="entity-chip-tooltip-row entity-chip-tooltip-meta">{{ $tooltip['meta'] }}</span>
-        @endif
-        @if($hasLink)
-            <span class="entity-chip-tooltip-link">
-                <i class="bi bi-arrow-right" aria-hidden="true"></i>
-                <a href="{{ e($link) }}">{{ __('entity_chip.label_open_link') }}</a>
-            </span>
-        @endif
-    </span>@endif</span>
+<span class="entity-chip entity-chip--{{ $type }}" data-chip-type="{{ $type }}"
+    data-chip-key="{{ $entityKey }}" x-data="{ open: false }" @mouseenter="open = true" @mouseleave="open = false"
+    @click.stop="open = !open" @click.away="open = false" role="button" tabindex="0" @keydown.escape="open = false"
+    @keydown.enter.prevent="open = !open" aria-label="{{ $label }}">
+    <i class="bi {{ $icon }}" aria-hidden="true"></i>{{ $label }}@if ($hasTooltip)<span class="entity-chip-tooltip" x-show="open" x-cloak
+            x-effect="open && $nextTick(() => {
+            $el.style.marginLeft = ''; $el.style.top = ''; $el.style.bottom = '';
+            const r = $el.getBoundingClientRect();
+            if (r.left < 8) $el.style.marginLeft = (8 - r.left) + 'px';
+            else if (r.right > window.innerWidth - 8) $el.style.marginLeft = (window.innerWidth - 8 - r.right) + 'px';
+            const clip = $el.closest('dialog');
+            const clipTop = clip ? clip.getBoundingClientRect().top : 0;
+            if (r.top < clipTop + 8) { $el.style.bottom = 'auto'; $el.style.top = 'calc(100% + 0.4rem)'; }
+        })">
+            <span class="entity-chip-tooltip-name">{{ $label }}</span>
+            @if ($hasLevel)
+                <span class="entity-chip-tooltip-row">
+                    <span class="entity-chip-tooltip-label">{{ __("entity_chip.label_level") }}</span>
+                    <span>{{ $tooltip["level"] }}</span>
+                </span>
+            @endif
+            @if ($hasDesc)
+                <span class="entity-chip-tooltip-desc">{{ $tooltip["description"] }}</span>
+            @endif
+            @if ($hasMeta)
+                <span class="entity-chip-tooltip-row entity-chip-tooltip-meta">{{ $tooltip["meta"] }}</span>
+            @endif
+            @if ($hasLink)
+                <span class="entity-chip-tooltip-link">
+                    <i class="bi bi-arrow-right" aria-hidden="true"></i>
+                    <a href="{{ e($link) }}">{{ __("entity_chip.label_open_link") }}</a>
+                </span>
+            @endif
+        </span>@endif
+</span>

--- a/resources/views/partials/res-popup.blade.php
+++ b/resources/views/partials/res-popup.blade.php
@@ -1,12 +1,16 @@
 {{--
     Reusable chip popup.
     Variables:
+      $popup_key    — unique string for this chip within the shared `openChip`
+                      state on the nearest ancestor x-data (.res-bar-wrap) —
+                      only one popup can be open at a time, so two adjacent
+                      wide popups never render on top of each other.
       $popup_title  — bold heading (string)
       $popup_desc   — one-sentence description (string)
       $popup_extra  — optional extra HTML rows (raw, server-controlled only)
 --}}
-<div class="res-popup" x-show="$data.open ?? open" x-cloak
-    x-effect="($data.open ?? open) && $nextTick(() => { $el.style.marginLeft = ''; const r = $el.getBoundingClientRect(); if (r.left < 8) $el.style.marginLeft = (8 - r.left) + 'px'; else if (r.right > window.innerWidth - 8) $el.style.marginLeft = (window.innerWidth - 8 - r.right) + 'px'; })">
+<div class="res-popup" x-show="openChip === {{ Illuminate\Support\Js::from($popup_key) }}" x-cloak
+    x-effect="(openChip === {{ Illuminate\Support\Js::from($popup_key) }}) && $nextTick(() => { $el.style.marginLeft = ''; const r = $el.getBoundingClientRect(); if (r.left < 8) $el.style.marginLeft = (8 - r.left) + 'px'; else if (r.right > window.innerWidth - 8) $el.style.marginLeft = (window.innerWidth - 8 - r.right) + 'px'; })">
     <div class="res-popup-header">{{ $popup_title }}</div>
     <div class="res-popup-body">{{ $popup_desc }}</div>
     @if (!empty($popup_extra ?? null))

--- a/resources/views/resources/resourcebar.blade.php
+++ b/resources/views/resources/resourcebar.blade.php
@@ -109,15 +109,17 @@
                 "</div>"
             : null;
     @endphp
-    <div class="res-bar-wrap resource-bar">
+    <div class="res-bar-wrap resource-bar" x-data="{ openChip: null }">
 
         {{-- Sol chip: no border, no max --}}
         @if ($solDisplay !== null)
-            <span class="res-chip res-chip--sol" x-data="{ open: false }" @mouseenter="open=true" @mouseleave="open=false"
-                @click.stop="open=!open" @click.outside="open=false" style="position:relative;cursor:default">
+            <span class="res-chip res-chip--sol" @mouseenter="openChip = 'sol'" @mouseleave="openChip = null"
+                @click.stop="openChip = openChip === 'sol' ? null : 'sol'"
+                @click.outside="openChip === 'sol' && (openChip = null)" style="position:relative;cursor:default">
                 <span class="res-abbr">Sol</span>
                 <span class="res-amount">{{ $solDisplay }}</span>
                 @include("partials.res-popup", [
+                    "popup_key" => "sol",
                     "popup_title" => __("resources.popup_sol_title"),
                     "popup_desc" => __("resources.popup_sol_desc"),
                 ])
@@ -127,12 +129,13 @@
 
         {{-- Credits chip — NX shown in popup --}}
         @if ($crResource !== null)
-            <span class="res-chip res-Cr {{ $nexusChipMod }}" x-data="{ open: false }" @mouseenter="open=true"
-                @mouseleave="open=false" @click.stop="open=!open" @click.outside="open=false"
-                style="position:relative;cursor:default">
+            <span class="res-chip res-Cr {{ $nexusChipMod }}" @mouseenter="openChip = 'cr'" @mouseleave="openChip = null"
+                @click.stop="openChip = openChip === 'cr' ? null : 'cr'"
+                @click.outside="openChip === 'cr' && (openChip = null)" style="position:relative;cursor:default">
                 <span class="res-abbr">CR</span>
                 <span class="res-amount">{{ number_format($crResource["amount"] ?? 0, 0, ",", ".") }}</span>
                 @include("partials.res-popup", [
+                    "popup_key" => "cr",
                     "popup_title" => __("resources.popup_cr_title"),
                     "popup_desc" => __("resources.popup_cr_desc"),
                     "popup_extra" => $crPopupExtra,
@@ -143,8 +146,9 @@
         {{-- Supply chip — shows free/cap (not just cap) so the player sees how much
          headroom is left before new buildings/advisors/research are blocked. --}}
         @if (isset($primary[2]))
-            <span class="res-chip res-Sup" x-data="{ open: false }" @mouseenter="open=true" @mouseleave="open=false"
-                @click.stop="open=!open" @click.outside="open=false" style="position:relative;cursor:default">
+            <span class="res-chip res-Sup" @mouseenter="openChip = 'sup'" @mouseleave="openChip = null"
+                @click.stop="openChip = openChip === 'sup' ? null : 'sup'"
+                @click.outside="openChip === 'sup' && (openChip = null)" style="position:relative;cursor:default">
                 <span class="res-abbr">SUP</span>
                 <span class="res-amount">
                     {{ number_format($supplyBreakdown["free"] ?? ($primary[2]["amount"] ?? 0), 0, ",", ".") }}
@@ -153,6 +157,7 @@
                     @endif
                 </span>
                 @include("partials.res-popup", [
+                    "popup_key" => "sup",
                     "popup_title" => __("resources.popup_sup_title"),
                     "popup_desc" => __("resources.popup_sup_desc"),
                     "popup_extra" => $supplyPopupExtra,
@@ -164,10 +169,12 @@
         @if (isset($trust))
             <span id="resbar-ap-trust"
                 class="ap-chip {{ $trust >= 20 ? "ap-chip--trust-pos" : ($trust < 0 ? "ap-chip--trust-neg" : "ap-chip--trust-neu") }}"
-                x-data="{ open: false }" @mouseenter="open=true" @mouseleave="open=false" @click.stop="open=!open"
-                @click.outside="open=false" style="position:relative;cursor:default">
+                @mouseenter="openChip = 'trust'" @mouseleave="openChip = null"
+                @click.stop="openChip = openChip === 'trust' ? null : 'trust'"
+                @click.outside="openChip === 'trust' && (openChip = null)" style="position:relative;cursor:default">
                 <span>{{ __("resources.res_trust") }} <span class="res-amount">{{ (int) $trust }}</span></span>
                 @include("partials.res-popup", [
+                    "popup_key" => "trust",
                     "popup_title" => __("resources.popup_trust_title"),
                     "popup_desc" => __("resources.popup_trust_desc"),
                 ])
@@ -181,14 +188,18 @@
             @foreach ($secondary as $resId => $resource)
                 @php
                     $abbr = $resource["abbreviation"] ?? "x";
+                    $chipKey = "res_" . strtolower($abbr);
                     $langKey = "popup_" . strtolower($abbr);
                 @endphp
-                <span class="res-chip res-{{ $abbr }}" x-data="{ open: false }" @mouseenter="open=true"
-                    @mouseleave="open=false" @click.stop="open=!open" @click.outside="open=false"
+                <span class="res-chip res-{{ $abbr }}" @mouseenter="openChip = '{{ $chipKey }}'"
+                    @mouseleave="openChip = null"
+                    @click.stop="openChip = openChip === '{{ $chipKey }}' ? null : '{{ $chipKey }}'"
+                    @click.outside="openChip === '{{ $chipKey }}' && (openChip = null)"
                     style="position:relative;cursor:default">
                     <span class="res-abbr">{{ $abbr }}</span>
                     <span class="res-amount">{{ number_format($resource["amount"] ?? 0, 0, ",", ".") }}</span>
                     @include("partials.res-popup", [
+                        "popup_key" => $chipKey,
                         "popup_title" => __("resources." . $langKey . "_title"),
                         "popup_desc" => __("resources." . $langKey . "_desc"),
                     ])
@@ -201,51 +212,56 @@
          actions; on other screens they just reflect the server-rendered values. --}}
         @if (isset($navAp, $constructionAp, $trust))
             <span class="res-divider" aria-hidden="true"></span>
-            <span id="resbar-ap-nav" class="ap-chip ap-chip--nav" x-data="{ open: false }" @mouseenter="open=true"
-                @mouseleave="open=false" @click.stop="open=!open" @click.outside="open=false"
-                style="position:relative;cursor:default">
+            <span id="resbar-ap-nav" class="ap-chip ap-chip--nav" @mouseenter="openChip = 'nav'"
+                @mouseleave="openChip = null" @click.stop="openChip = openChip === 'nav' ? null : 'nav'"
+                @click.outside="openChip === 'nav' && (openChip = null)" style="position:relative;cursor:default">
                 <span>Nav <span class="res-amount">{{ (int) $navAp }}</span> AP</span>
                 @include("partials.res-popup", [
+                    "popup_key" => "nav",
                     "popup_title" => __("resources.popup_nav_ap_title"),
                     "popup_desc" => __("resources.popup_nav_ap_desc"),
                     "popup_extra" => $apPopupExtra($apBreakdown["navigation"] ?? null),
                 ])
             </span>
-            <span id="resbar-ap-build" class="ap-chip ap-chip--build" x-data="{ open: false }" @mouseenter="open=true"
-                @mouseleave="open=false" @click.stop="open=!open" @click.outside="open=false"
-                style="position:relative;cursor:default">
+            <span id="resbar-ap-build" class="ap-chip ap-chip--build" @mouseenter="openChip = 'build'"
+                @mouseleave="openChip = null" @click.stop="openChip = openChip === 'build' ? null : 'build'"
+                @click.outside="openChip === 'build' && (openChip = null)" style="position:relative;cursor:default">
                 <span>Con <span class="res-amount">{{ (int) $constructionAp }}</span> AP</span>
                 @include("partials.res-popup", [
+                    "popup_key" => "build",
                     "popup_title" => __("resources.popup_bau_ap_title"),
                     "popup_desc" => __("resources.popup_bau_ap_desc"),
                     "popup_extra" => $apPopupExtra($apBreakdown["construction"] ?? null),
                 ])
             </span>
-            <span id="resbar-ap-research" class="ap-chip ap-chip--research" x-data="{ open: false }" @mouseenter="open=true"
-                @mouseleave="open=false" @click.stop="open=!open" @click.outside="open=false"
-                style="position:relative;cursor:default">
+            <span id="resbar-ap-research" class="ap-chip ap-chip--research" @mouseenter="openChip = 'research'"
+                @mouseleave="openChip = null" @click.stop="openChip = openChip === 'research' ? null : 'research'"
+                @click.outside="openChip === 'research' && (openChip = null)" style="position:relative;cursor:default">
                 <span>Res <span class="res-amount">{{ (int) ($researchAp ?? 0) }}</span> AP</span>
                 @include("partials.res-popup", [
+                    "popup_key" => "research",
                     "popup_title" => __("resources.popup_research_ap_title"),
                     "popup_desc" => __("resources.popup_research_ap_desc"),
                     "popup_extra" => $apPopupExtra($apBreakdown["research"] ?? null),
                 ])
             </span>
-            <span id="resbar-ap-economy" class="ap-chip ap-chip--economy" x-data="{ open: false }" @mouseenter="open=true"
-                @mouseleave="open=false" @click.stop="open=!open" @click.outside="open=false"
-                style="position:relative;cursor:default">
+            <span id="resbar-ap-economy" class="ap-chip ap-chip--economy" @mouseenter="openChip = 'economy'"
+                @mouseleave="openChip = null" @click.stop="openChip = openChip === 'economy' ? null : 'economy'"
+                @click.outside="openChip === 'economy' && (openChip = null)" style="position:relative;cursor:default">
                 <span>Eco <span class="res-amount">{{ (int) ($economyAp ?? 0) }}</span> AP</span>
                 @include("partials.res-popup", [
+                    "popup_key" => "economy",
                     "popup_title" => __("resources.popup_economy_ap_title"),
                     "popup_desc" => __("resources.popup_economy_ap_desc"),
                     "popup_extra" => $apPopupExtra($apBreakdown["economy"] ?? null),
                 ])
             </span>
-            <span id="resbar-ap-strategy" class="ap-chip ap-chip--strategy" x-data="{ open: false }" @mouseenter="open=true"
-                @mouseleave="open=false" @click.stop="open=!open" @click.outside="open=false"
-                style="position:relative;cursor:default">
+            <span id="resbar-ap-strategy" class="ap-chip ap-chip--strategy" @mouseenter="openChip = 'strategy'"
+                @mouseleave="openChip = null" @click.stop="openChip = openChip === 'strategy' ? null : 'strategy'"
+                @click.outside="openChip === 'strategy' && (openChip = null)" style="position:relative;cursor:default">
                 <span>Str <span class="res-amount">{{ (int) ($strategyAp ?? 0) }}</span> AP</span>
                 @include("partials.res-popup", [
+                    "popup_key" => "strategy",
                     "popup_title" => __("resources.popup_strategy_ap_title"),
                     "popup_desc" => __("resources.popup_strategy_ap_desc"),
                     "popup_extra" => $apPopupExtra($apBreakdown["strategy"] ?? null),


### PR DESCRIPTION
## Summary
Owner-Pain-Point: täglicher Playtest läuft, aber jeder gefundene Blocker zwingt zum kompletten Neustart auf Sol 1 — `game:reset-player` bietet nur 5 feste hand-gebaute Szenarien, keine Fortsetzung des tatsächlichen Runs.

Neuer Dev-Command `game:snapshot {save|restore|list}`:
- **save**: dumpt den kompletten Live-Zustand eines Spielers (Colony, Run, Resources, Buildings, Tiles, Advisors, Ships, Hangar-Missionen, Researches, Colony-Log, User-Resources/-Preferences) als JSON nach `storage/app/private/snapshots/{user_id}/{label}.json`.
- **restore**: wischt den aktuellen Zustand (gleiche Tabellen-/Reihenfolge wie `ResetPlayer`s Wipe-Logik) und spielt den Snapshot zurück.
- **list**: zeigt gespeicherte Snapshots mit Sol/Phase/Zeitstempel.

Workflow: vor riskanter Aktion snapshotten. Blocker gefunden → fixen → `restore` statt neu hochspielen.

Kein Migrations-/Schema-Bedarf (reine JSON-Dateien, dev-only, analog zu `ResetPlayer`s Charakter als Debug-Tool — auch dafür existieren keine PHPUnit-Tests).

**Nebenbei gefixt** (während des Owner-Playtests mit dem Snapshot-Tool ab Sol 1 gefunden, alle unabhängig vom Snapshot-Tool selbst):
- Resourcebar-Chip-Popups: gemeinsamer `openChip`-State statt 11× isoliertem `x-data` (verhindert zwei gleichzeitig offene Popups)
- Resourcebar-Chip-Popups grau + von Hint-Bar verdeckt: `.res-chip:hover { filter }` erzeugte ungewollten Stacking Context + tönte Kind-Elemente ab — jetzt `box-shadow` statt `filter`
- Berater-Screen zeigte "Raumfahrer" doppelt nach Hangar-Bau: Pfad-Slot-Preview war an feste Position statt an tatsächlich offene Pfade gebunden
- Entity-Chip-Tooltip (Glossar-Begriffe) clippte im `sol-modal`: gleiches Boundary-Clamp-Pattern wie Resourcebar-Popups ergänzt, jetzt auch mit Flip-nach-unten

## Test plan
- [x] `php artisan test` — 669 passed, 1 skipped, unverändert (1 vorbestehender unabhängiger Fehler)
- [x] `./bin/pint --test` + `npx prettier --check`
- [x] Live gegen echten Bart-Run (Sol 97, Phase 2): `save` → Credits mutiert → `restore` → korrekt zurück, Row-Counts identisch, alle Screens 200
- [x] **Owner-Playtest heute (2026-07-09), 3 Szenarien, alle bestanden:**
  - Roundtrip (Sol 3 → spielen → restore) → exakter State-Match (Credits/Regolith/Organika/Buildings/Tick)
  - Cross-Run-Restore (aktueller Run → `before-test`, alter Sol-97-Run) → korrekter Run-Wechsel inkl. Run-ID, alle Screens 200
  - Rück-Restore zum aktuellen Run → sauber
- [x] Alle 4 nebenbei gefixten Popup/UI-Bugs live per Playwright + Owner-Screenshot-Vergleich verifiziert

https://claude.ai/code/session_01N6Jcf582UpFXjcPo1KCWY1
