### PR TITLE
chore: Magic Number 25 (Kommandozentrale) benannt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-09
+
+- **Cleanup:** Magic Number `25` (Kommandozentrale-Building-ID, Sonderfall "immer an Tile 0,0 verankert" statt tile_x/y-platziert) in `colony-hexgrid.js::initHexGrid()` als benannte Konstante `CC_BUILDING_ID` extrahiert.
+
 ## 2026-07-08 (3)
 
 - **Fix: Entity-Chip-Tooltip clippte in Modals.** Owner-Playtest-Fund (Berater-Einstellen-Dialog): der Raumfahrer-Glossar-Chip öffnet sein Tooltip fix nach oben (`bottom: calc(100% + 0.4rem)`), ohne Boundary-Check — im `sol-modal` (`overflow: hidden` Article) wurde der obere Teil abgeschnitten und überlappte sichtbar die Modal-Kopfzeile. Fix (`components/entity-chip.blade.php`): gleiches Boundary-Clamp-Pattern wie `res-popup` (horizontales Clamping + jetzt zusätzlich vertikales Flip auf "unten öffnen", wenn der nächste `<dialog>`-Vorfahre das Tooltip oben clippen würde). Bewusst kein Merge der beiden Popup-Systeme (unterschiedliche UX-Rollen: Toolbar-Chips vs. Glossar-Begriffe im Fließtext) — nur das Positionierungs-Pattern geteilt. Per Playwright verifiziert (schmaler Viewport, Tooltip öffnet sauber nach unten, keine Überlappung mehr).

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -856,6 +856,10 @@ function hidePressProgress(group) {
 
 // ── SVG hex grid renderer ─────────────────────────────────────────────────────
 
+// Kommandozentrale (config/buildings.php: commandCenter) — the one building
+// anchored at the colony's fixed origin tile instead of a player-placed tile_x/y.
+const CC_BUILDING_ID = 25;
+
 function initHexGrid(container, tiles, opts = {}) {
     if (!container || tiles.length === 0) return;
 
@@ -868,7 +872,7 @@ function initHexGrid(container, tiles, opts = {}) {
     const buildingsByTile = new Map();
     if (opts.buildings) {
         for (const b of opts.buildings) {
-            if (b.building_id === 25) {
+            if (b.building_id === CC_BUILDING_ID) {
                 buildingsByTile.set('0,0', b);
             } else if (b.tile_x !== null && b.tile_y !== null) {
                 buildingsByTile.set(`${b.tile_x},${b.tile_y}`, b);


### PR DESCRIPTION
## Summary
- `colony-hexgrid.js::initHexGrid()` hatte einen hartcodierten `25` für den Sonderfall "Kommandozentrale sitzt immer an Tile 0,0 statt an tile_x/y" — als `CC_BUILDING_ID`-Konstante mit erklärendem Kommentar extrahiert.
- Kleiner Cleanup-Fund aus [[project_tech_debt_building_id_magic_number]], nicht Teil eines größeren Refactors.

## Test plan
- [x] `php artisan test` — 669 passed, unverändert (1 vorbestehender unabhängiger Fehler)
- [x] Live per Playwright verifiziert: CC-Kachel rendert weiterhin korrekt auf der Hex-Grid-Kolonieansicht

https://claude.ai/code/session_01N6Jcf582UpFXjcPo1KCWY1