### PR TITLE
feat: Kolonisten-Zulage — Credits gegen Vertrauen ausschütten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-07-10 (2)
+
+Owner-Playtest der Kolonisten-Zulage (Sol 3–5) fand 5 Lücken, alle gefixt:
+
+- **Credits-Chip-Flash unsichtbar:** Animation feuerte korrekt, lief aber während der Bestätigungs-Dialog noch offen war — dessen `<dialog>`-Backdrop verdunkelt die ganze Seite inkl. Resourcebar. Dialog schließt jetzt zuerst, dann flasht der Chip sichtbar.
+- **Zulage fehlte in der Sol-Übersicht:** Log-Eintrag nutzte den aktuellen statt den Ziel-Tick (Off-by-one gegen `SolReportService::eventsAtTick()`, die den bereits inkrementierten Tick liest). Sol-Report zeigt jetzt eine eigene Zeile "Kolonisten-Zulage: −X Cr — +Y Vertrauen" in der Ereignisse-Gruppe.
+- **Trust-Anstieg nicht sichtbar:** Mechanik selbst funktionierte korrekt (Trust-Beitrag kam an), reine Sichtbarkeitslücke — mit obigem Fix behoben. Wirkt weiterhin nur 1 Sol (wie andere Trust-Events), das ist Design, kein Bug.
+- **Nexus-Einkommen nicht als Zahlung erkennbar (vorbestehender Gap, mit gefixt):** passive Credits (Galaktischer-Rat-Subvention + Relaisvergütung) hatten nie einen Log-Eintrag. Sol-Report zeigt jetzt "Nexus-Subvention & Relaisvergütung: +X Cr" direkt neben der Credits-Zeile.
+- **Zulage-Button schwer erreichbar:** saß in der scrollbaren Info-Bar unter dem Hex-Grid. Jetzt als fixierter Floating-Button unten links, immer sichtbar ohne Scrollen (ui-specialist-Konsultation).
+
+Alle 5 Fixes end-to-end über den echten `/sol/next`-Endpoint verifiziert (nicht nur Unit-Tests) — Barts laufender Playtest-Stand dabei per `game:snapshot` gesichert/wiederhergestellt, unangetastet.
+
 ## 2026-07-10
 
 - **Neu: Kolonisten-Zulage.** Neue Spieleraktion (GDD §14): Credits direkt an die Kolonisten ausschütten, 3 Stufen (100/300/600 Cr → +2/+3/+4 Vertrauen, degressive Cr/Punkt-Effizienz), wirkt als Trust-Event ab dem nächsten Sol. Max. 1 Zulage pro Sol (Guard in `TrustService::hasEventThisTick()`). Ersetzt das nie implementierte "Steuern"-Konzept — Nexus zahlt der Kolonie eh Geld (Relaisvergütung), der Spieler entscheidet jetzt aktiv, wie viel davon an die Kolonisten weitergeht. Button in der Canvas-Info-Bar der Kolonieansicht, neuer Dialog + `POST /colony/stipend`. 6 neue Feature-Tests, live per Playwright verifiziert.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-10
+
+- **Neu: Kolonisten-Zulage.** Neue Spieleraktion (GDD §14): Credits direkt an die Kolonisten ausschütten, 3 Stufen (100/300/600 Cr → +2/+3/+4 Vertrauen, degressive Cr/Punkt-Effizienz), wirkt als Trust-Event ab dem nächsten Sol. Max. 1 Zulage pro Sol (Guard in `TrustService::hasEventThisTick()`). Ersetzt das nie implementierte "Steuern"-Konzept — Nexus zahlt der Kolonie eh Geld (Relaisvergütung), der Spieler entscheidet jetzt aktiv, wie viel davon an die Kolonisten weitergeht. Button in der Canvas-Info-Bar der Kolonieansicht, neuer Dialog + `POST /colony/stipend`. 6 neue Feature-Tests, live per Playwright verifiziert.
+
 ## 2026-07-09
 
 - **Cleanup:** Magic Number `25` (Kommandozentrale-Building-ID, Sonderfall "immer an Tile 0,0 verankert" statt tile_x/y-platziert) in `colony-hexgrid.js::initHexGrid()` als benannte Konstante `CC_BUILDING_ID` extrahiert.

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -904,11 +904,27 @@ class GameTick extends Command
                 ->where('building_id', BuildingId::Housing->value)
                 ->value('level');
 
-            $total = $nexusSubsidy + ($housingLevel * $taxPerHousing);
+            $housingTax = $housingLevel * $taxPerHousing;
+            $total = $nexusSubsidy + $housingTax;
 
             DB::table('user_resources')
                 ->where('user_id', $colony->user_id)
                 ->increment('credits', $total);
+
+            if ($total > 0) {
+                $this->eventService->createEvent([
+                    'user' => $colony->user_id,
+                    'tick' => $tick,
+                    'event' => 'colony.passive_credits',
+                    'area' => 'colony',
+                    'parameters' => json_encode([
+                        'colony_id' => $colony->id,
+                        'subsidy' => $nexusSubsidy,
+                        'housing_tax' => $housingTax,
+                        'total' => $total,
+                    ]),
+                ]);
+            }
 
             $processed++;
         }

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -15,11 +15,13 @@ use App\Services\OnboardingTriggerService;
 use App\Services\ResourcesService;
 use App\Services\Techtree\PersonellService;
 use App\Services\TickService;
+use App\Services\TrustService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 class ColonyController extends BaseController
@@ -34,6 +36,7 @@ class ColonyController extends BaseController
         private readonly MerchantService $merchantService,
         private readonly EventService $eventService,
         private readonly ResourcesService $resourcesService,
+        private readonly TrustService $trustService,
     ) {
         parent::__construct($tick);
     }
@@ -826,6 +829,59 @@ class ColonyController extends BaseController
             'cost' => $totalCost,
             'credits' => $credits,
             'compounds' => $compounds,
+        ]);
+    }
+
+    /**
+     * Kolonisten-Zulage (GDD §14) — spend Credits to fire a one-shot Trust
+     * event. Max one tier per colony per Sol (different stipend event_keys
+     * don't dedupe against each other in TrustService's same-key collapse).
+     */
+    public function purchaseStipend(Request $request): JsonResponse
+    {
+        $tiers = config('game.stipend.tiers', []);
+
+        $data = $request->validate([
+            'tier' => ['required', 'string', Rule::in(array_keys($tiers))],
+        ]);
+
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $tierCfg = $tiers[$data['tier']];
+        $cost = (int) $tierCfg['cost'];
+        $eventKey = (string) $tierCfg['event_key'];
+        $allStipendKeys = array_column($tiers, 'event_key');
+
+        // fireEvent()'s default (tick+1) is what the *next* GameTick run reads
+        // (TrustService::eventContribution matches tick exactly) — computed
+        // once so the guard and the insert agree on the same target tick.
+        $targetTick = $this->getTick() + 1;
+
+        if ($this->trustService->hasEventThisTick($colony->id, $targetTick, $allStipendKeys)) {
+            return response()->json(['ok' => false, 'error' => 'stipend_already_used', 'message' => __('colony.stipend_already_used')]);
+        }
+
+        if (! $this->resourcesService->check([['resource_id' => ResourcesService::RES_CREDITS, 'amount' => $cost]], $colony->id)) {
+            return response()->json(['ok' => false, 'error' => 'stipend_no_credits', 'message' => __('colony.stipend_no_credits')]);
+        }
+
+        $this->resourcesService->payCosts([['resource_id' => ResourcesService::RES_CREDITS, 'amount' => $cost]], $colony->id);
+        $this->trustService->fireEvent($colony->id, $eventKey, $targetTick);
+
+        $this->eventService->createEvent([
+            'user' => Auth::id(),
+            'tick' => $this->getTick(),
+            'event' => 'colony.stipend_purchased',
+            'area' => 'colony',
+            'parameters' => json_encode(['colony_id' => $colony->id, 'tier' => $data['tier'], 'cost' => $cost]),
+        ]);
+
+        $credits = (int) (DB::table('user_resources')->where('user_id', $colony->user_id)->value('credits') ?? 0);
+
+        return response()->json([
+            'ok' => true,
+            'tier' => $data['tier'],
+            'cost' => $cost,
+            'credits' => $credits,
         ]);
     }
 

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -867,9 +867,13 @@ class ColonyController extends BaseController
         $this->resourcesService->payCosts([['resource_id' => ResourcesService::RES_CREDITS, 'amount' => $cost]], $colony->id);
         $this->trustService->fireEvent($colony->id, $eventKey, $targetTick);
 
+        // Logged at $targetTick (not the current tick) so it surfaces in the
+        // Sol-Report of the Sol it actually takes effect on — SolReportService
+        // reads colony_log at the just-processed (post-increment) tick, which
+        // is exactly $targetTick once "Sol beenden" is clicked.
         $this->eventService->createEvent([
             'user' => Auth::id(),
-            'tick' => $this->getTick(),
+            'tick' => $targetTick,
             'event' => 'colony.stipend_purchased',
             'area' => 'colony',
             'parameters' => json_encode(['colony_id' => $colony->id, 'tier' => $data['tier'], 'cost' => $cost]),

--- a/app/Services/SolReportService.php
+++ b/app/Services/SolReportService.php
@@ -126,7 +126,7 @@ class SolReportService
         }
 
         $groups[] = $this->productionGroup($colonyId, $userId, $before);
-        $groups[] = $this->colonyGroup($colonyId, $userId, $before, $forceShow);
+        $groups[] = $this->colonyGroup($colonyId, $userId, $before, $events, $forceShow);
 
         $finale = $this->finale($run);
         if ($finale === null) {
@@ -238,6 +238,20 @@ class SolReportService
             ];
         }
 
+        // Kolonisten-Zulage (GDD §14) — logged at its target tick (see
+        // ColonyController::purchaseStipend), so it lands in the Sol-Report of
+        // the Sol it actually takes effect on.
+        foreach ($events['colony.stipend_purchased'] ?? [] as $params) {
+            $tier = $params['tier'] ?? 'small';
+            $cost = (int) ($params['cost'] ?? 0);
+            $trustBonus = (int) config("game.trust.events.stipend_{$tier}", 0);
+            $lines[] = [
+                'label' => __('colony.sol_report_stipend'),
+                'detail' => __('colony.sol_report_stipend_detail', ['cost' => $cost, 'trust' => $trustBonus]),
+                'tone' => 'good',
+            ];
+        }
+
         if (empty($lines)) {
             return null;
         }
@@ -319,7 +333,7 @@ class SolReportService
 
     // ── Group 4: colony & personnel ───────────────────────────────────────────
 
-    private function colonyGroup(int $colonyId, int $userId, array $before, bool &$forceShow): array
+    private function colonyGroup(int $colonyId, int $userId, array $before, array $events, bool &$forceShow): array
     {
         $lines = [];
 
@@ -349,6 +363,17 @@ class SolReportService
             'from' => $creditsFrom,
             'to' => $creditsAfter,
         ];
+
+        // Passive Nexus income breakdown (Galaktischer Rat subsidy +
+        // Relaisvergütung per Wohnhabitat-Level, GDD §3) — otherwise the
+        // Credits delta above has no visible source.
+        foreach ($events['colony.passive_credits'] ?? [] as $params) {
+            $lines[] = [
+                'label' => __('colony.sol_report_passive_credits'),
+                'detail' => '+'.(int) ($params['total'] ?? 0).' Cr',
+                'tone' => 'good',
+            ];
+        }
 
         // Advisor promotions (rank increased over the Sol) — emotional beat.
         $afterRanks = DB::table('advisors')

--- a/app/Services/TrustService.php
+++ b/app/Services/TrustService.php
@@ -176,6 +176,24 @@ class TrustService
         ]);
     }
 
+    /**
+     * Whether any of the given event types already has a trust_events row for
+     * this colony at the given tick. Used to enforce "max one stipend tier per
+     * Sol" (GDD §14) — different stipend event_keys do not dedupe against each
+     * other in eventContribution()'s same-key collapse, so this guard is a
+     * separate rule the calling code must apply before firing.
+     *
+     * @param  string[]  $eventTypes
+     */
+    public function hasEventThisTick(int $colonyId, int $tick, array $eventTypes): bool
+    {
+        return DB::table('trust_events')
+            ->where('colony_id', $colonyId)
+            ->where('tick', $tick)
+            ->whereIn('event_type', $eventTypes)
+            ->exists();
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
     private function buildingContribution(int $colonyId): int

--- a/config/game.php
+++ b/config/game.php
@@ -72,6 +72,17 @@ return [
         'compound_import_price' => 90,
     ],
 
+    // Kolonisten-Zulage (GDD §14) — player-triggered Credits→Trust action.
+    // Trust deltas live in trust.events.stipend_* below (single source of truth);
+    // this block only maps the UI-facing tier key to its Credits cost and event_key.
+    'stipend' => [
+        'tiers' => [
+            'small' => ['cost' => 100, 'event_key' => 'stipend_small'],
+            'medium' => ['cost' => 300, 'event_key' => 'stipend_medium'],
+            'large' => ['cost' => 600, 'event_key' => 'stipend_large'],
+        ],
+    ],
+
     // Manual building repair — Regolith cost per click (1 SP), on top of 1 Construction-AP.
     // CommandCenter + Harvester are exempt (AP-only, bootstrap anchor against decay spiral).
     'repair' => [
@@ -204,6 +215,9 @@ return [
             'nexus_credit' => -5,  // trust penalty when ship is acquired on Nexus-Kredit
             'well_fed' => 1,       // colony's Organika stock covered the food need this Sol
             'encounter_won' => 2,  // successful protective/aid action (e.g. mission_aid_transport)
+            'stipend_small' => 2,  // Kolonisten-Zulage (GDD §14) — see stipend.tiers above
+            'stipend_medium' => 3,
+            'stipend_large' => 4,
         ],
     ],
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -187,7 +187,7 @@ php artisan game:tick --tick=N  # erzwingt Tick-Nummer N (nur für Tests)
 | 4. Vertrauen | Vertrauenswert neu berechnen (inkl. Hunger-Malus), `colony_resources` aktualisieren (§14) |
 | 5. Beratung & Events | Advisor-Ticks, Bar-Angebote, Händler-Spawn, Run-Checks (Phasen, Objectives, Fail State) |
 
-> Die genaue Schritt-Reihenfolge innerhalb jeder Phase ist in `app/Console/Commands/GameTick.php` (Docblock) kanonisch festgehalten.
+> **Phase ≠ Schritt:** Die Nummerierung 1–5 (3a) in dieser Tabelle ist eine grobe, spielerorientierte Gruppierung — kein 1:1-Bezug zu den feingranularen Schritt-Nummern in `GameTick.php` (die z.B. bei Supply-Cap „Schritt 7" heißen, §6). Die genaue Schritt-Reihenfolge innerhalb jeder Phase ist in `app/Console/Commands/GameTick.php` (Docblock) kanonisch festgehalten — dort steht auch die maßgebliche Nummer, falls ein anderer GDD-Abschnitt einen konkreten Schritt referenziert.
 
 ---
 
@@ -943,7 +943,7 @@ Erfahrenere Berater erholen sich schneller — und haben schon durch den `rank_d
 
 > **Designabsicht:** Burnout ist ein seltenes, aber echtes Risiko, das den Spieler dazu bringt, einen Backup-Plan für den Ausfall eines Beraters zu haben. Experten sind robuster, aber teurer — das macht Rang-Aufstieg strategisch wertvoller als nur "mehr AP pro Sol".
 
-> **Implementierungsstand:** Die Burnout-Wahrscheinlichkeits-Formel ist noch nicht implementiert. `unavailable_until_tick` existiert in der DB und wird gecheckt; die probabilistische Prüfung folgt nach dem ersten Playtest (Phase 4+).
+> **Implementierungsstand:** Die Burnout-Wahrscheinlichkeits-Formel ist noch nicht implementiert. `unavailable_until_tick` existiert in der DB und wird gecheckt; die probabilistische Prüfung folgt nach dem ersten Playtest (Phase 4+). Ein `config/game.php → advisors.burnout`-Block existiert bewusst noch nicht — die Richtwerte oben (`base_chance`, `growth_factor`, `threshold`, `rank_dampener`, `recovery_ticks`) sind das Design für die spätere Config, kein fehlender Verweis.
 
 ---
 
@@ -1067,28 +1067,7 @@ Das System wirkt unbesiedelt und nach Frontier — Begegnungen sind selten aber 
 
 **Erscheinungsfrequenz pro Run:** 3–5 Piratensonden-Events, 1–3 Schmuggler, 0–1 schwere Wächter (prozedurale Verteilung bei Run-Generierung).
 
-### Reisender Händler
-
-Ein reisender Händler erscheint gelegentlich im System für eine begrenzte Anzahl Sole. Er bietet seltene Waren an — keine Standardressourcen, sondern Shortcuts und Chancen die im normalen Spielverlauf nicht erreichbar sind.
-
-**Erscheinungsfrequenz:** Erstmals ab Sol 15–20 (Kolonie soll sich erst etablieren). Danach alle 10–15 Sole zufällig. Ergibt ~6–7 Besuche pro 100-Sol-Run. Ist der Händler weg, ist er weg — Roguelike-Druck.
-
-**Inventar:** 3–4 Items pro Besuch (Mobile-optimiert, kein Scrollen nötig).
-
-**Preisstruktur:** Alles in Credits. Kein Tauschhandel in Phase 3. Exotics/Tausch für Phase 4+ denkbar.
-
-**Schwierigkeitsskalierung:** Höhere Preise auf schwierigeren Runs — nicht schlechteres Sortiment (das wäre frustrierend).
-
-**Item-Kategorien:**
-
-| Kategorie | Beschreibung | Seltenheit |
-|-----------|-------------|-----------|
-| **AP-Paket (flexibel)** | Sofortiger AP-Schub eines Typs (z.B. +20 Construction-AP) — Spieler wählt beim Kauf wofür er sie ausgibt. Teurer als gezieltes Paket | gelegentlich |
-| **AP-Paket (gezielt)** | AP-Schub für ein konkretes Gebäude oder eine Kenntnis — günstiger, aber Ziel ist fixiert | gelegentlich |
-| **Schiff** | Gebrauchtes Schiff mit Eigenname — ersetzt ein bestehendes Schiff (Hangar bleibt konstant). Phase 4+: besondere Eigenschaften denkbar | selten |
-| **Information** | Alle versteckten Event-Spots im System sofort enthüllt | selten |
-| **Einmal-Item** | Reparatur-Kit, Vertrauens-Schub, Credits-Notfallkredit | häufig |
-| **Exotics** | Platzhalter Phase 4+ | sehr selten |
+> **Reisender Händler umgezogen (Juli 2026):** Die Beschreibung stand hier fälschlich unter dem "GESTRICHEN"-Banner dieses Abschnitts, obwohl der Reisender Händler eine aktive, unabhängig von der Systemkarte weiterhin implementierte Mechanik ist (`MerchantService`, `GameTick.php` Schritt 11, `config/game.php → merchant`). Vollständige Beschreibung jetzt in §12 Handel, Kanal 3.
 
 ### Multiplayer
 
@@ -1308,11 +1287,13 @@ Beispiele für Sekundäreffekte (konkrete Werte folgen nach erstem Playtest):
 | geology | advisor_engineer | −10% Gebäudekosten |
 | geology | advisor_trader | +10% Rohstoff-Verkaufspreis |
 | health | advisor_scientist | +1 Analyse-AP/Sol |
-| defense | advisor_pilot | −1 AP-Kosten für Angriff |
+| defense | advisor_pilot | −1 Navigation-AP-Kosten für Schutzmissionen (z.B. Umkreis-Patrouille) |
 | trade | advisor_trader | +15% Handelsgewinn |
-| cartography | advisor_pilot | +1 Bewegungsreichweite |
+| cartography | advisor_pilot | +1 zusätzlich aufgedecktes Tile pro Erkundung |
 
 > **TODO Design:** Vollständige 7×5-Matrix (alle Kenntnisse × alle Berater) ausarbeiten — nach erstem Playtest, wenn klar ist welche Kombinationen strategisch interessant sind.
+>
+> **Korrektur (Juli 2026):** Die ursprünglichen Platzhalterwerte für `defense`/`advisor_pilot` ("AP-Kosten für Angriff") und `cartography`/`advisor_pilot` ("Bewegungsreichweite") referenzierten die 2026-06-20 gestrichene Flotten-/Systemkarten-Mechanik (Angriffsorder, Flottenbewegung). Durch zivile Äquivalente ersetzt (Schutzmissions-AP, Tile-Erkundung) — weiterhin nur Platzhalter, keine finalen Werte.
 
 ### Berater-Zuweisung
 
@@ -1613,6 +1594,35 @@ Nexus schickt auf Anfrage offizielle Handelsschiffe. Immer verfügbar — auch o
 2. Credits-Betrag wird sofort eingefroren (reserviert)
 3. Nach Lieferzeit: INNN-Ereignis "Nexus-Lieferung eingetroffen", Ressourcen gutgeschrieben, Credits abgebucht
 4. Kann nur 1 offene Anfrage gleichzeitig haben
+
+---
+
+### Kanal 3: Reisender Händler (selten, hochwertig)
+
+> **Umgezogen aus §8a (Juli 2026):** Diese Beschreibung stand zuvor unter dem "GESTRICHEN"-Banner der (entfernten) Systemansicht — obwohl der Reisender Händler unabhängig davon eine aktive, implementierte Mechanik ist. Implementiert über `MerchantService` + `config/game.php → merchant`; Spawn-Check läuft in `GameTick.php` Schritt 11.
+
+Ein reisender Händler erscheint gelegentlich bei der Kolonie für eine begrenzte Anzahl Sole. Er bietet seltene Waren an — keine Standardressourcen, sondern Shortcuts und Chancen die im normalen Spielverlauf nicht erreichbar sind.
+
+**Erscheinungsfrequenz:** Erstmals ab Sol 15–20 (Kolonie soll sich erst etablieren). Danach alle 10–15 Sole zufällig. Ergibt ~6–7 Besuche pro 100-Sol-Run. Ist der Händler weg, ist er weg — Roguelike-Druck.
+
+**Inventar:** 3–4 Items pro Besuch (Mobile-optimiert, kein Scrollen nötig).
+
+**Preisstruktur:** Alles in Credits. Kein Tauschhandel in Phase 3. Exotics/Tausch für Phase 4+ denkbar.
+
+**Schwierigkeitsskalierung:** Höhere Preise auf schwierigeren Runs — nicht schlechteres Sortiment (das wäre frustrierend).
+
+**Item-Kategorien:**
+
+| Kategorie | Beschreibung | Seltenheit |
+|-----------|-------------|-----------|
+| **AP-Paket (flexibel)** | Sofortiger AP-Schub eines Typs (z.B. +20 Construction-AP) — Spieler wählt beim Kauf wofür er sie ausgibt. Teurer als gezieltes Paket | gelegentlich |
+| **AP-Paket (gezielt)** | AP-Schub für ein konkretes Gebäude oder eine Kenntnis — günstiger, aber Ziel ist fixiert | gelegentlich |
+| **Schiff** | Gebrauchtes Schiff mit Eigenname — ersetzt ein bestehendes Schiff (Hangar bleibt konstant). Phase 4+: besondere Eigenschaften denkbar | selten |
+| **Information** | Alle noch unerkundeten Tiles der Exploration Zone sofort aufgedeckt (`colony_tiles.is_explored`) | selten |
+| **Einmal-Item** | Reparatur-Kit, Vertrauens-Schub, Credits-Notfallkredit | häufig |
+| **Exotics** | Platzhalter Phase 4+ | sehr selten |
+
+> **Config-Nacharbeit (nicht GDD — für game-developer/backend-coder):** `config/game.php → merchant.items.information.label` heißt noch **"Systemkarte vollständig"** — ein rein kosmetischer Restverweis auf die 2026-06-20 gestrichene Systemkarte. Geprüft: `MerchantService::applyItemEffect()` setzt bereits korrekt `colony_tiles.is_explored = true` für die Kolonie (Exploration Zone) — die Wirkung ist **nicht** kaputt, nur das Label ist veraltet. Label an die obige Formulierung anpassen (kein Balance-Risiko, reiner Text-Fix).
 
 ---
 
@@ -2055,7 +2065,31 @@ Alle anderen Kenntnisse (construction, cartography, geology, trade) haben keinen
 
 ### Einflussfaktoren: Relaisvergütung
 
-Die Relaisvergütung (§3) ist eine reine Nexus-Einnahme ohne Vertrauenseffekt — sie fließt von Nexus an die Kolonie, nicht umgekehrt, und stellt daher keine Belastung der Kolonisten dar. Ein gesonderter Abzugs-/Steuermechanismus mit Vertrauensmalus wurde ursprünglich erwogen (das frühere "Steuern"-Konzept), ist aber hinfällig und wird nicht weiterverfolgt.
+Die Relaisvergütung (§3) ist eine reine Nexus-Einnahme **ohne automatischen Vertrauenseffekt** — sie fließt von Nexus an die Kolonie, nicht umgekehrt, und stellt für sich genommen keine Belastung der Kolonisten dar. Ein gesonderter passiver Abzugs-/Steuermechanismus mit Vertrauensmalus wurde ursprünglich erwogen (das frühere "Steuern"-Konzept), ist aber hinfällig und wird nicht weiterverfolgt — der Platzhalter-Begriff "Steuern" ist damit erledigt: nicht umbenannt, sondern die Mechanik dahinter gestrichen.
+
+Was sich ändert: Der Spieler kann eingenommene Credits — ob aus Relaisvergütung, Handel oder Reserven — jetzt **aktiv** in Vertrauen zurückverwandeln. Das ist kein passiver Nebeneffekt der Relaisvergütung selbst, sondern eine eigene, bewusst gewählte Aktion — siehe **Kolonisten-Zulage** im nächsten Abschnitt.
+
+### Einflussfaktoren: Kolonisten-Zulage (Spieleraktion)
+
+Aktive Aktion des Direktors: Ein Teil der Kolonie-Credits kann jederzeit direkt an die Kolonisten ausgeschüttet werden — eine spürbare, bewusst gewählte Ausgabe, die zeigt, dass es der Siedlung wirtschaftlich gut genug geht, um sie unmittelbar zu beteiligen. Anders als Vertrauensgebäude oder Kenntnisse (permanente Dauerboni) ist die Zulage ein **reaktiver Hebel**: kein Dauerzustand, sondern eine situative Entscheidung — z. B. um vor einem kritischen Sol (Nexus-Meilenstein §15, drohende Vertrauens-Fail-Schwelle §15) Vertrauen zu stabilisieren, auf Kosten von Credits, die sonst in Ausbau, Berater-Upkeep oder Handel geflossen wären.
+
+**Staffelung:**
+
+| Stufe | Kosten | Vertrauens-Bonus | Event-Key | Credits/Punkt |
+|-------|--------|-------------------|-----------|----------------|
+| Klein | 100 Credits | +2 Vertrauen | `stipend_small` | 50 |
+| Mittel | 300 Credits | +3 Vertrauen | `stipend_medium` | 100 |
+| Groß | 600 Credits | +4 Vertrauen | `stipend_large` | 150 |
+
+Die Wirkung folgt der Standard-Event-Logik (siehe "Einflussfaktoren: Ereignisse" unten): genau **1 Sol**, danach verworfen.
+
+**Nur eine Zulage pro Sol.** Die drei Stufen sind unterschiedliche Event-Keys (nicht Varianten desselben Keys) — das bestehende Dedup in `TrustService::eventContribution` fasst nur *gleiche* Keys zusammen und summiert *unterschiedliche* Keys auf. Ohne zusätzliche Sperre könnten "Klein" + "Groß" im selben Sol also zu +6 Vertrauen kombiniert werden. Das ist **nicht gewollt** und muss bei der Implementierung als eigene Regel ergänzt werden: pro Kolonie und Sol ist höchstens eine Zulagen-Stufe auslösbar (Fire-Time-Guard im Service, nicht im bestehenden Event-Dedup). Dieser Punkt ist ein expliziter Implementierungs-Hinweis, kein bereits vorhandenes Verhalten.
+
+**Kein Cooldown über mehrere Sole hinweg.** Die Staffelung ist bewusst **degressiv** (Credits pro Vertrauenspunkt steigen von 50 auf 150) — je größer die Ausschüttung, desto ineffizienter pro Credit. Das macht tägliches Wiederholen unattraktiv, ohne eine künstliche Sperre zu benötigen: Wer jeden Sol die kleine Stufe zieht, zahlt 100 Credits/Sol für einen wiederkehrenden +2-Bonus — spürbar gegenüber der Relaisvergütung (20–120 Cr/Sol, abhängig vom Wohnhabitat-Level) und dem Berater-Upkeep (50 Cr/Sol, Rang 2), aber nicht kostenlos. Zum Vergleich: der seltene Händler-Artikel "Vertrauensschub" (§12, `trust_boost`) liefert einmalig +15 Vertrauen für 600 Credits (40 Cr/Punkt) — die Kolonisten-Zulage ist bewusst *weniger* effizient pro Credit, da sie jederzeit verfügbar ist und die übrigen Vertrauensfaktoren (Gebäude, Kenntnisse, Verpflegung) nicht verdrängen soll.
+
+**Rationale:** Die Zulage gibt dem Spieler einen direkten, jederzeit verfügbaren Hebel auf Vertrauen — aber zu einem Preis, der die Entscheidung "Vertrauen jetzt sichern" gegen "Credits in Ausbau/Handel investieren" tatsächlich schwer macht. Die degressive Staffelung verhindert, dass die große Stufe zur Standardwahl wird; die Einmal-pro-Sol-Regel verhindert Kombination innerhalb eines Sols. Zusammen ersetzt das einen Cooldown, ohne die Reaktionsfreiheit des Spielers einzuschränken.
+
+> ⚠️ BALANCE CONCERN: Ohne harten Mehr-Sol-Cooldown ist die Kolonisten-Zulage im Lategame (hohe Credits-Reserven) potenziell ein "Vertrauen auf Knopfdruck"-Ventil, das die -20-Fail-Schwelle (§15) entschärft. Nach dem ersten Playtest prüfen, ob ein Soft-Cap (z. B. max. 1 Zulagen-Event pro N Sole) nötig wird, falls Spieler die Mechanik nutzen, um Krisen risikofrei auszusitzen statt echte Ursachen (Hunger, Decay, Militarisierung) zu beheben.
 
 ### Einflussfaktoren: Verpflegung (Organika)
 
@@ -2111,6 +2145,16 @@ Events sind nach Kategorie gruppiert. Alle Effekte wirken exakt 1 Sol (werden na
 | `encounter_won` | Zwischenfall erfolgreich gelöst/abgewehrt | +2 |
 | `encounter_lost` | Zwischenfall eskaliert / Kolonie wurde beschädigt | -4 |
 | `colony_threatened` | Kolonie akut bedroht (kritischer Zwischenfall) | -5 |
+
+**Spieleraktionen:**
+
+| Event-Key | Beschreibung | Vertrauenseffekt |
+|-----------|-------------|------------------|
+| `stipend_small` | Kolonisten-Zulage, Stufe Klein (100 Cr) | +2 |
+| `stipend_medium` | Kolonisten-Zulage, Stufe Mittel (300 Cr) | +3 |
+| `stipend_large` | Kolonisten-Zulage, Stufe Groß (600 Cr) | +4 |
+
+Details, Kosten-Rationale und die Einmal-pro-Sol-Regel siehe "Einflussfaktoren: Kolonisten-Zulage (Spieleraktion)" weiter oben.
 
 > **TODO:** Exakte Vertrauenswerte für Begegnungs-Events nach §9-Ausarbeitung kalibrieren. Event-Keys sind in `TrustService` als `game.trust.events.*` angelegt (CLAUDE.md Korrekturen-Sektion); Werte nach erstem Playtest festsetzen. Der **Sicherheits-Hub** dämpft diese drei Events (+ `building_level_down`) um 25 % wenn aktiv — das macht ihre genauen Werte doppelt relevant.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,10 +69,12 @@ Abgeschlossen (2026-07-01): Architekturentscheidungen dokumentiert (`docs/adr/00
 
 ### Offene GDD / Design-TODOs
 
-- [ ] GDD §2 vs §6: Supply-Cap Tick-Schritt — Widerspruch, §2-Tabelle nennt Schritt 3, §6 + Code (`GameTick.php`) nennen Schritt 7. Eine Stelle korrigieren.
-- [ ] GDD §13: Burnout-Config-Block — `config/game.php → advisors.burnout` existiert nicht. Ergänzen oder GDD-Referenz entfernen.
-- [ ] GDD §14/Koloniebeiträge: Platzhalter-Begriff "Steuern" passt nicht zum Kleinkolonie-Konzept (kein Imperium). Begriff + prozentuales Malus-System neu denken, bevor implementiert wird. Alternativen: "Koloniebeiträge", "Abgaben", "Nexus-Quote".
-- [ ] GDD §9 "Begegnungen & Gefahren" + Merchant-Item-Kategorie `encounter_prep`: referenzieren noch Fleet-basierte Encounters (Flotte/Systemkarte seit 2026-06-20 gestrichen). Eigener GDD-Pass zum Bereinigen, nicht blockierend.
+Abgeschlossen (2026-07-10, game-designer): alle 4 Punkte geprüft und im GDD bereinigt.
+
+- [x] GDD §2 vs §6: Supply-Cap Tick-Schritt. §2s "Phase 3" war eine grobe Gruppierung, kein Widerspruch zu §6/Code (Schritt 7) — beide bereits konsistent. §2 um eine Phase-≠-Schritt-Klarstellung ergänzt.
+- [x] GDD §13: Burnout-Config-Block. Kein echter fehlender Verweis — GDD markiert die Formel bereits explizit als "noch nicht implementiert (Phase 4+)" und referenziert keinen nicht-existenten Config-Pfad. Klarstellung ergänzt, keine Config geschrieben (Feature bewusst aufgeschoben).
+- [x] GDD §14/Koloniebeiträge: "Steuern"-Konzept ist im GDD bereits als **verworfen** (nicht umbenannt) dokumentiert, ersetzt durch die undramatische Relaisvergütung. Abweichung von der ursprünglichen Design-Notiz ("Begriff klären, nicht verwerfen") — Owner-Rückfrage empfohlen, siehe Bericht.
+- [x] GDD §9/Merchant Fleet-Referenzen: §9 selbst war bereits sauber. `encounter_prep` ist keine Merchant-Item-Kategorie (die sind `ap_flex/ap_targeted/information/repair_kit/trust_boost`) — es ist ein Almanach-Bonustyp (§17) und referenziert bereits das neue §9-Kolonistengefahr-System, keine Flotten-Mechanik. Die Prämisse dieses ROADMAP-Punkts war insofern doppelt ungenau. Tatsächlicher Fund: Reisender Händler (aktive Mechanik) stand fälschlich unter dem "GESTRICHEN"-Banner der alten Systemansicht (§8a) — nach §12 Handel (neuer "Kanal 3") verschoben, Wortlaut von "im System" auf Exploration Zone korrigiert. Zusätzlich zwei tote Platzhalter-Werte (Angriffs-AP, Bewegungsreichweite) in der Kenntnisse-Beispieltabelle durch zivile Äquivalente ersetzt.
 
 ---
 
@@ -82,9 +84,14 @@ Abgeschlossen (2026-07-01): Architekturentscheidungen dokumentiert (`docs/adr/00
 - Tile-abhängige Harvester-Produktionsrate (aktuell feste Rate ×10/Level)
 - Berater-Traits (Draft — siehe Memory)
 - Berater Außendienst-Mechanik für weitere Typen (nach Playtest evaluieren)
-- Begegnungen & Gefahren (GDD §9) — konkrete Events + Encounter-Screens (siehe auch GDD-Bereinigung oben)
+- Begegnungen & Gefahren (GDD §9) — konkrete Events + Encounter-Screens
 - Forschung / Techtree-Screen: Kenntnisse-Freischalt-Flow
 - Play-by-Mail-Multiplayer (3–4 Spieler, variable Tick-Zeiten) — optionale spätere Iteration. Architektur in ADR 0003 festgelegt (siehe oben); Rest (Games/TurnOrders/Resolution-Engine/KI) zurückgestellt bis aktiv angegangen.
+
+### Neu gefunden bei GDD-Aufräumpass (2026-07-10, technisch, nicht blockierend)
+
+- `config/game.php → merchant.items.information.label` heißt noch "Systemkarte vollständig" (Restverweis auf die 2026-06-20 gestrichene Systemkarte) — rein kosmetisch, geprüft: `MerchantService` setzt bereits korrekt `colony_tiles.is_explored`, die Wirkung ist nicht kaputt. Label-Text anpassen. Siehe GDD §12 Kanal 3.
+- Tick-Schritt-Nummerierung in `GameTick.php` (Docblock) ist selbst lückenhaft/inkonsistent (springt 0→4→6, Food-Consumption-Schritt fehlt ganz) und mehrere GDD-Stellen (§8b, §13, §14, §15) referenzieren daraus veraltete Schrittnummern (z.B. "Tick-Schritt 7" für Advisor Ticks, tatsächlich Schritt 9). Docblock zuerst durch game-developer korrigieren/vervollständigen, danach GDD-Referenzen in einem eigenen Pass nachziehen.
 
 ---
 

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -186,6 +186,19 @@ return [
     'nexus_import_no_credits' => 'Nicht genug Credits für diesen Import.',
     'nexus_import_error' => 'Import fehlgeschlagen.',
 
+    // ── Kolonisten-Zulage (GDD §14) ──────────────────────────────────────────
+
+    'stipend_button' => 'Kolonisten-Zulage',
+    'stipend_dialog_title' => 'Kolonisten-Zulage',
+    'stipend_dialog_hint' => 'Credits direkt an die Kolonisten ausschütten — wirkt ab dem nächsten Sol auf das Vertrauen.',
+    'stipend_tier_small' => 'Klein',
+    'stipend_tier_medium' => 'Mittel',
+    'stipend_tier_large' => 'Groß',
+    'stipend_success' => 'Zulage gebucht (:cost Cr) — wirkt ab dem nächsten Sol.',
+    'stipend_error' => 'Zulage fehlgeschlagen.',
+    'stipend_already_used' => 'Für diesen Sol wurde bereits eine Zulage ausgeschüttet.',
+    'stipend_no_credits' => 'Nicht genug Credits für diese Zulage.',
+
     // ── Generic UI actions ───────────────────────────────────────────────────
 
     'close' => 'Schließen',

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -301,6 +301,9 @@ return [
 
     // Ereignisse
     'sol_report_event_merchant' => 'Reisender Händler im System',
+    'sol_report_passive_credits' => 'Nexus-Subvention & Relaisvergütung',
+    'sol_report_stipend' => 'Kolonisten-Zulage',
+    'sol_report_stipend_detail' => '-:cost Cr — +:trust Vertrauen',
 
     // Produktion
     'sol_report_no_production' => 'Die Förderanlagen stehen still — kein Regolith, kein Fortschritt. Industriegebäude prüfen.',

--- a/lang/en/colony.php
+++ b/lang/en/colony.php
@@ -186,6 +186,19 @@ return [
     'nexus_import_no_credits' => 'Not enough Credits for this import.',
     'nexus_import_error' => 'Import failed.',
 
+    // ── Colonist Stipend (GDD §14) ───────────────────────────────────────────
+
+    'stipend_button' => 'Colonist Stipend',
+    'stipend_dialog_title' => 'Colonist Stipend',
+    'stipend_dialog_hint' => 'Pay out Credits directly to the colonists — boosts Trust starting next Sol.',
+    'stipend_tier_small' => 'Small',
+    'stipend_tier_medium' => 'Medium',
+    'stipend_tier_large' => 'Large',
+    'stipend_success' => 'Stipend paid (:cost Cr) — takes effect next Sol.',
+    'stipend_error' => 'Stipend failed.',
+    'stipend_already_used' => 'A stipend has already been paid out this Sol.',
+    'stipend_no_credits' => 'Not enough Credits for this stipend.',
+
     // ── Generic UI actions ────────────────────────────────────────────────────
 
     'close' => 'Close',

--- a/lang/en/colony.php
+++ b/lang/en/colony.php
@@ -301,6 +301,9 @@ return [
 
     // Events
     'sol_report_event_merchant' => 'Travelling Merchant in system',
+    'sol_report_passive_credits' => 'Nexus Subsidy & Relay Fee',
+    'sol_report_stipend' => 'Colonist Stipend',
+    'sol_report_stipend_detail' => '-:cost Cr — +:trust Trust',
 
     // Production
     'sol_report_no_production' => 'The extraction plants are idle — no Regolith, no progress. Check industrial buildings.',

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -327,6 +327,15 @@ button.btn-sol:hover,
 /* ── Hex page layout ─────────────────────────────────────────────────────── */
 
 /*
+ * Reserve clear space below the layout so the viewport-fixed .stipend-fab
+ * never overlaps the last row of sidebar content when the page's natural
+ * (document) bottom edge is close to the fixed button.
+ */
+.hex-page {
+    padding-bottom: 4rem;
+}
+
+/*
  * Two-column grid: canvas area fills remaining space, sidebar is fixed-width.
  * min-height accounts for header (~44px) + resource bar (~38px) + 2px border = ~84px.
  */
@@ -432,6 +441,39 @@ button.btn-sol:hover,
 }
 
 .info-bar-btn:hover {
+    border-color: #aaa;
+    background: #f5f5f7;
+}
+
+/* ── Kolonisten-Zulage FAB (GDD §14) ─────────────────────────────────────── */
+
+/*
+ * Viewport-fixed trigger for the stipend dialog. Used to live inside
+ * .canvas-info-bar (below the canvas), which can scroll out of view on short
+ * viewports — both mobile and desktop windows with little vertical space
+ * (Owner-Feedback, real playtest). Fixed positioning guarantees it's always
+ * reachable without scrolling. Bottom-left avoids the top-right .colony-toast,
+ * the bottom-center .colony-levelup-notice, and the bottom-right
+ * .first-visit-popup used on other screens.
+ */
+.stipend-fab {
+    position: fixed;
+    bottom: 1rem;
+    left: 1rem;
+    z-index: 400;
+    padding: 0.55rem 1rem;
+    background: #fff;
+    border: 1px solid #d0d4db;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--color-anthracite, #333);
+    cursor: pointer;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
+    white-space: nowrap;
+}
+
+.stipend-fab:hover {
     border-color: #aaa;
     background: #f5f5f7;
 }

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -436,6 +436,34 @@ button.btn-sol:hover,
     background: #f5f5f7;
 }
 
+/* ── Kolonisten-Zulage dialog (GDD §14) ──────────────────────────────────── */
+
+.stipend-tiers {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0 1rem 1rem;
+}
+
+.stipend-tier-btn {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.6rem 0.9rem;
+    background: #fff;
+    border: 1px solid #d0d4db;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    color: #333;
+    cursor: pointer;
+    text-align: left;
+}
+
+.stipend-tier-btn:hover {
+    border-color: #aaa;
+    background: #f5f5f7;
+}
+
 .hex-legend {
     font-size: 0.8rem;
     color: #4a4f5a;

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -413,6 +413,21 @@ function colonyHexView(config) {
             }
         },
 
+        // Kolonisten-Zulage (GDD §14) — trust effect only applies from the next
+        // Sol onward (TrustService writes the stored trust value only during
+        // GameTick), so only the Credits chip is synced immediately here.
+        async doPurchaseStipend(tier) {
+            const res = await this.post(this.routes.stipend, { tier });
+            if (res.ok) {
+                this.syncResbarAmount('.res-Cr', res.credits);
+                this.flashResChip('.res-Cr');
+                this.showToast((this.i18n.stipendSuccess ?? '').replace(':cost', res.cost), 'info');
+                this.$refs.stipendDialog.close();
+            } else {
+                this.showToast(res.message ?? res.error ?? this.i18n.stipendError, 'error');
+            }
+        },
+
         // ── Harvester relocation ──────────────────────────────────────────────
 
         startHarvesterMove() {

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -419,10 +419,13 @@ function colonyHexView(config) {
         async doPurchaseStipend(tier) {
             const res = await this.post(this.routes.stipend, { tier });
             if (res.ok) {
+                // Close the dialog FIRST — its native <dialog> backdrop dims the
+                // whole page (incl. the resourcebar), so flashing while it's
+                // still open makes the flash invisible.
+                this.$refs.stipendDialog.close();
                 this.syncResbarAmount('.res-Cr', res.credits);
                 this.flashResChip('.res-Cr');
                 this.showToast((this.i18n.stipendSuccess ?? '').replace(':cost', res.cost), 'info');
-                this.$refs.stipendDialog.close();
             } else {
                 this.showToast(res.message ?? res.error ?? this.i18n.stipendError, 'error');
             }

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -109,7 +109,10 @@
 
                 <div x-ref="hexgrid" class="hex-canvas"></div>
 
-                {{-- Info bar: phase progress + legend — always visible below canvas --}}
+                {{-- Info bar: phase progress + legend — always visible below canvas.
+                 The stipend button used to live here too, but this bar sits below the
+                 canvas and can scroll out of view on short viewports (see .stipend-fab
+                 below for the always-visible replacement). --}}
                 <div class="canvas-info-bar">
                     <template x-if="phaseProgress">
                         <button class="info-bar-btn" @click="$refs.phaseDialog.showModal()"
@@ -124,10 +127,6 @@
                             </template>
                         </button>
                     </template>
-
-                    <button class="info-bar-btn" @click="$refs.stipendDialog.showModal()">
-                        {{ __("colony.stipend_button") }}
-                    </button>
 
                     <details class="hex-legend">
                         <summary class="info-bar-btn">{{ __("colony.legend_title") }}</summary>
@@ -586,6 +585,14 @@
                 </footer>
             </article>
         </dialog>
+
+        {{-- Kolonisten-Zulage FAB — fixed to the viewport bottom-left so the action
+         stays reachable without scrolling, regardless of canvas/sidebar height
+         (Owner-Feedback: .canvas-info-bar sits below the canvas and can require
+         scrolling on short viewports). Lives at the x-data root so $refs resolves. --}}
+        <button type="button" class="stipend-fab" @click="$refs.stipendDialog.showModal()">
+            {{ __("colony.stipend_button") }}
+        </button>
 
         {{-- Action / AP-limit toast (Triggers 4 + 5) --}}
         <div class="colony-toast" :class="`colony-toast--${toastType}`" x-show="toastVisible" x-transition

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -54,6 +54,7 @@
                 investBuilding: '{{ route("colony.building.invest") }}',
                 repairBuilding: '{{ route("colony.building.repair") }}',
                 nexusImport: '{{ route("colony.nexus.import") }}',
+                stipend: '{{ route("colony.stipend") }}',
             },
             i18n: {
                 explore: '{{ __("colony.explore") }}',
@@ -77,6 +78,8 @@
                 networkError: @json(__("colony.network_error")),
                 nexusImportSuccess: @json(__("colony.nexus_import_success")),
                 nexusImportError: @json(__("colony.nexus_import_error")),
+                stipendSuccess: @json(__("colony.stipend_success")),
+                stipendError: @json(__("colony.stipend_error")),
             },
         };
     </script>
@@ -121,6 +124,10 @@
                             </template>
                         </button>
                     </template>
+
+                    <button class="info-bar-btn" @click="$refs.stipendDialog.showModal()">
+                        {{ __("colony.stipend_button") }}
+                    </button>
 
                     <details class="hex-legend">
                         <summary class="info-bar-btn">{{ __("colony.legend_title") }}</summary>
@@ -535,6 +542,28 @@
                         </template>
                     </ul>
                 </template>
+            </article>
+        </dialog>
+
+        {{-- Kolonisten-Zulage dialog — 3 tiers, Credits→Trust one-shot event (GDD §14) --}}
+        <dialog x-ref="stipendDialog" class="sol-modal" @click.self="$refs.stipendDialog.close()">
+            <article>
+                <header>
+                    <button aria-label="{{ __("colony.cancel") }}" rel="prev"
+                        @click="$refs.stipendDialog.close()"></button>
+                    <h3>{{ __("colony.stipend_dialog_title") }}</h3>
+                </header>
+                <p>{{ __("colony.stipend_dialog_hint") }}</p>
+                <div class="stipend-tiers">
+                    @foreach (config("game.stipend.tiers") as $tierKey => $tierCfg)
+                        <button class="stipend-tier-btn" @click="doPurchaseStipend('{{ $tierKey }}')">
+                            <strong>{{ __("colony.stipend_tier_{$tierKey}") }}</strong>
+                            <span>{{ $tierCfg["cost"] }}
+                                Cr — +{{ config("game.trust.events.{$tierCfg["event_key"]}") }}
+                                {{ __("resources.res_trust") }}</span>
+                        </button>
+                    @endforeach
+                </div>
             </article>
         </dialog>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -77,6 +77,9 @@ Route::middleware(['auth', 'run.started'])->prefix('colony')->name('colony.')->g
     // Nexus direct import — Werkstoffe (compounds) against Credits, gated by Uplink Lv1
     Route::post('/nexus/import-compounds', [ColonyController::class, 'nexusImportCompounds'])->name('nexus.import');
 
+    // Kolonisten-Zulage — spend Credits for a one-shot Trust event (max 1 tier/Sol)
+    Route::post('/stipend', [ColonyController::class, 'purchaseStipend'])->name('stipend');
+
     // Onboarding hint actions (AJAX)
     Route::post('/hint/dismiss', [ColonyController::class, 'dismissHint'])->name('hint.dismiss');
 

--- a/tests/Feature/Colony/StipendTest.php
+++ b/tests/Feature/Colony/StipendTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Feature\Colony;
+
+use App\Models\User;
+use App\Services\TickService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Kolonisten-Zulage (GDD §14) — spend Credits for a one-shot Trust event.
+ *
+ * Rules under test:
+ *  - Each tier spends the configured Credits and fires the configured trust_events
+ *    row at tick (current+1) — the tick TrustService::calculateAndStore() will read
+ *    on the *next* Sol, not the current one.
+ *  - Only one stipend tier may be purchased per colony per Sol — a second purchase
+ *    in the same tick is rejected, regardless of which tier was already used.
+ *  - Insufficient Credits rejects with no DB writes.
+ *  - The guard is per-tick only — a new Sol allows another purchase.
+ *
+ * Fixture: Colony 1 (Springfield), user_id=3 (Bart), fixed tick 100.
+ */
+class StipendTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const BART_USER_ID = 3;
+
+    private TickService $tickService;
+
+    private int $tick = 100;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        $this->tickService = $this->app->make(TickService::class);
+        $this->tickService->setTickCount($this->tick);
+
+        DB::table('user_resources')->where('user_id', self::BART_USER_ID)->update(['credits' => 5000]);
+    }
+
+    private function bart(): User
+    {
+        return User::where('user_id', self::BART_USER_ID)->firstOrFail();
+    }
+
+    private function credits(): int
+    {
+        return (int) DB::table('user_resources')->where('user_id', self::BART_USER_ID)->value('credits');
+    }
+
+    private function stipendEventCount(int $tick): int
+    {
+        return DB::table('trust_events')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('tick', $tick)
+            ->whereIn('event_type', ['stipend_small', 'stipend_medium', 'stipend_large'])
+            ->count();
+    }
+
+    private function purchase(string $tier)
+    {
+        return $this->actingAs($this->bart())->postJson(route('colony.stipend'), ['tier' => $tier]);
+    }
+
+    public function test_stipend_small_spends_credits_and_fires_trust_event(): void
+    {
+        $credits = $this->credits();
+
+        $this->purchase('small')->assertOk()->assertJsonPath('ok', true)->assertJsonPath('cost', 100);
+
+        $this->assertSame($credits - 100, $this->credits());
+        $this->assertDatabaseHas('trust_events', [
+            'colony_id' => self::COLONY_ID,
+            'tick' => $this->tick + 1,
+            'event_type' => 'stipend_small',
+        ]);
+    }
+
+    public function test_stipend_medium_and_large_use_correct_cost_and_event_key(): void
+    {
+        $this->purchase('medium')->assertOk()->assertJsonPath('ok', true)->assertJsonPath('cost', 300);
+        $this->assertDatabaseHas('trust_events', ['colony_id' => self::COLONY_ID, 'tick' => $this->tick + 1, 'event_type' => 'stipend_medium']);
+
+        // New Sol so "large" isn't blocked by the same-tick guard.
+        $this->tickService->setTickCount($this->tick + 1);
+
+        $this->purchase('large')->assertOk()->assertJsonPath('ok', true)->assertJsonPath('cost', 600);
+        $this->assertDatabaseHas('trust_events', ['colony_id' => self::COLONY_ID, 'tick' => $this->tick + 2, 'event_type' => 'stipend_large']);
+    }
+
+    public function test_stipend_second_tier_same_tick_is_rejected(): void
+    {
+        $this->purchase('small')->assertOk()->assertJsonPath('ok', true);
+        $credits = $this->credits();
+
+        $this->purchase('large')->assertOk()->assertJsonPath('ok', false)->assertJsonPath('error', 'stipend_already_used');
+
+        $this->assertSame($credits, $this->credits(), 'no Credits deducted on a rejected second purchase');
+        $this->assertSame(1, $this->stipendEventCount($this->tick + 1), 'only the first stipend event was recorded');
+    }
+
+    public function test_stipend_rejects_insufficient_credits(): void
+    {
+        DB::table('user_resources')->where('user_id', self::BART_USER_ID)->update(['credits' => 50]);
+
+        $this->purchase('small')->assertOk()->assertJsonPath('ok', false)->assertJsonPath('error', 'stipend_no_credits');
+
+        $this->assertSame(50, $this->credits());
+        $this->assertSame(0, $this->stipendEventCount($this->tick + 1));
+    }
+
+    public function test_stipend_invalid_tier_returns_validation_error(): void
+    {
+        $this->purchase('huge')->assertStatus(422);
+    }
+
+    public function test_stipend_allowed_again_next_tick(): void
+    {
+        $this->purchase('small')->assertOk()->assertJsonPath('ok', true);
+
+        $this->tickService->setTickCount($this->tick + 1);
+
+        $this->purchase('small')->assertOk()->assertJsonPath('ok', true);
+        $this->assertSame(1, $this->stipendEventCount($this->tick + 1));
+        $this->assertSame(1, $this->stipendEventCount($this->tick + 2));
+    }
+}

--- a/tests/Feature/SolReportTest.php
+++ b/tests/Feature/SolReportTest.php
@@ -188,6 +188,32 @@ class SolReportTest extends TestCase
         $this->assertTrue($report['force_show']);
     }
 
+    public function test_stipend_purchase_shows_in_events_group(): void
+    {
+        $run = $this->setRunTick(7);
+        $before = $this->snapshot($run);
+
+        DB::table('colony_log')->insert([
+            'user' => self::BART_ID,
+            'tick' => 7,
+            'event' => 'colony.stipend_purchased',
+            'area' => 'colony',
+            'parameters' => json_encode(['colony_id' => self::COLONY_ID, 'tier' => 'medium', 'cost' => 300]),
+            'created_at' => now(),
+            'is_read' => 1,
+        ]);
+
+        $report = $this->service()->buildReport($run, $before, false);
+
+        $events = $this->groupByKey($report, 'events');
+        $this->assertNotNull($events, 'Expected an events group when a stipend was purchased');
+        $line = collect($events['lines'])->first(fn ($l) => $l['label'] === __('colony.sol_report_stipend'));
+        $this->assertNotNull($line, 'Expected a stipend line in the events group');
+        $this->assertSame('good', $line['tone']);
+        $this->assertStringContainsString('300', $line['detail']);
+        $this->assertStringContainsString((string) config('game.trust.events.stipend_medium'), $line['detail']);
+    }
+
     public function test_wear_without_level_down_shows_single_neutral_line(): void
     {
         $run = $this->setRunTick(3);
@@ -247,6 +273,30 @@ class SolReportTest extends TestCase
                 && str_ends_with($l['detail'], 'Cr'));
         $this->assertNotNull($creditsLine, 'Expected a credits line in the colony group');
         $this->assertSame('neutral', $creditsLine['tone']);
+    }
+
+    public function test_passive_credits_shows_breakdown_in_colony_group(): void
+    {
+        $run = $this->setRunTick(7);
+        $before = $this->snapshot($run);
+
+        DB::table('colony_log')->insert([
+            'user' => self::BART_ID,
+            'tick' => 7,
+            'event' => 'colony.passive_credits',
+            'area' => 'colony',
+            'parameters' => json_encode(['colony_id' => self::COLONY_ID, 'subsidy' => 30, 'housing_tax' => 40, 'total' => 70]),
+            'created_at' => now(),
+            'is_read' => 1,
+        ]);
+
+        $report = $this->service()->buildReport($run, $before, false);
+        $colony = $this->groupByKey($report, 'colony');
+
+        $line = collect($colony['lines'])->first(fn ($l) => $l['label'] === __('colony.sol_report_passive_credits'));
+        $this->assertNotNull($line, 'Expected a passive-credits breakdown line in the colony group');
+        $this->assertSame('+70 Cr', $line['detail']);
+        $this->assertSame('good', $line['tone']);
     }
 
     public function test_finale_on_completed_run_replaces_run_group(): void


### PR DESCRIPTION
## Summary
- Neue Spieleraktion (GDD §14): Credits direkt an die Kolonisten ausschütten, 3 Stufen mit degressiver Cr/Punkt-Effizienz (100/300/600 Cr → +2/+3/+4 Vertrauen).
- Wirkt als Trust-Event ab dem nächsten Sol. Max. 1 Zulage pro Kolonie und Sol (neuer Guard `TrustService::hasEventThisTick()` — unterschiedliche Event-Keys deduplizieren sonst nicht gegeneinander).
- Ersetzt das nie implementierte "Steuern"-Konzept — passte narrativ nicht zur Frontier-Kolonie (Kolonisten hätten nie zusätzlich etwas abgegeben). Owner-Idee: Nexus zahlt eh (Relaisvergütung), Spieler entscheidet aktiv, wie viel weitergeht.
- Button + Dialog in der Kolonieansicht (Canvas-Info-Bar), neue Route `POST /colony/stipend`.

## Test plan
- [x] `php artisan test` — 675 passed (669 Basis + 6 neu), unverändert 1 vorbestehender Fehler
- [x] `./bin/pint --test` + `npx prettier --check` (Blade doppelt formatiert)
- [x] Live per Playwright verifiziert: Dialog öffnet, Kauf zieht Credits sofort ab (Chip-Flash), zweiter Kauf im selben Sol wird korrekt abgelehnt (Toast, keine Credits-Änderung)
- [x] 6 neue Feature-Tests: Kosten/Event pro Stufe, Once-per-Sol-Guard, Insufficient-Credits, Invalid-Tier-Validierung, Guard löst sich am neuen Sol

https://claude.ai/code/session_01N6Jcf582UpFXjcPo1KCWY1