### PR TITLE
feat: Kommandozentrale-Dashboard — Kolonie-Übersicht als eigener Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-11 (2)
+
+- **Kommandozentrale: Ressourcen-Chips statt Plaintext.** Owner-Feedback nach erstem Blick aufs Dashboard: Credits-/AP-/Vertrauens-Beträge sollten wie in der Resourcebar als Chips aussehen. Kolonisten-Zulage-Kosten (`.res-chip.res-Cr`), Vertrauens-Bonus (`.ap-chip--trust-pos`), Nexus-Schuld, Berater-AP-Beitrag (`.ap-chip--build/nav/research/economy/strategy`) und Vertrauens-Ereignis-Delta nutzen jetzt dieselben global geladenen Chip-Klassen wie die Resourcebar — keine neue CSS nötig, nur Wiederverwendung.
+
 ## 2026-07-11
 
 - **Neu: Kommandozentrale-Screen (Kolonie-Dashboard).** Owner-Feedback: Phasenziele- und Kolonisten-Zulage-Popups "klebten" auf dem Hex-Grid-Screen. Neuer, immer erreichbarer Screen (Analogie zu Hangar/Cantina — Screen als Gebäude-Interface, hier CC), der beide ohne Popup direkt zeigt plus 5 neue Widgets: Run-Fortschritt/Sol-Countdown (inkl. Nexus-Schuld-Warnbalken), Wartungsstau, Netto-Sol-Bilanz (letzter Sol, neu gecacht), Berater-Kurzübersicht, Vertrauens-Ereignisse (letzte 5). `ColonyController::computePhaseProgress()` nach `ColonyService::getPhaseProgress()` gehoben (war zuvor dupliziert in `SolReportService`) — jetzt eine gemeinsame Quelle für beide Screens. 11 neue Feature-Tests, live per Playwright verifiziert (inkl. Zulage-Kauf-Flow auf dem neuen Screen).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2026-07-10 (3)
+## 2026-07-11
 
 - **Neu: Kommandozentrale-Screen (Kolonie-Dashboard).** Owner-Feedback: Phasenziele- und Kolonisten-Zulage-Popups "klebten" auf dem Hex-Grid-Screen. Neuer, immer erreichbarer Screen (Analogie zu Hangar/Cantina — Screen als Gebäude-Interface, hier CC), der beide ohne Popup direkt zeigt plus 5 neue Widgets: Run-Fortschritt/Sol-Countdown (inkl. Nexus-Schuld-Warnbalken), Wartungsstau, Netto-Sol-Bilanz (letzter Sol, neu gecacht), Berater-Kurzübersicht, Vertrauens-Ereignisse (letzte 5). `ColonyController::computePhaseProgress()` nach `ColonyService::getPhaseProgress()` gehoben (war zuvor dupliziert in `SolReportService`) — jetzt eine gemeinsame Quelle für beide Screens. 11 neue Feature-Tests, live per Playwright verifiziert (inkl. Zulage-Kauf-Flow auf dem neuen Screen).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-10 (3)
+
+- **Neu: Kommandozentrale-Screen (Kolonie-Dashboard).** Owner-Feedback: Phasenziele- und Kolonisten-Zulage-Popups "klebten" auf dem Hex-Grid-Screen. Neuer, immer erreichbarer Screen (Analogie zu Hangar/Cantina — Screen als Gebäude-Interface, hier CC), der beide ohne Popup direkt zeigt plus 5 neue Widgets: Run-Fortschritt/Sol-Countdown (inkl. Nexus-Schuld-Warnbalken), Wartungsstau, Netto-Sol-Bilanz (letzter Sol, neu gecacht), Berater-Kurzübersicht, Vertrauens-Ereignisse (letzte 5). `ColonyController::computePhaseProgress()` nach `ColonyService::getPhaseProgress()` gehoben (war zuvor dupliziert in `SolReportService`) — jetzt eine gemeinsame Quelle für beide Screens. 11 neue Feature-Tests, live per Playwright verifiziert (inkl. Zulage-Kauf-Flow auf dem neuen Screen).
+
 ## 2026-07-10 (2)
 
 Owner-Playtest der Kolonisten-Zulage (Sol 3–5) fand 5 Lücken, alle gefixt:

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers\Colony;
 
 use App\Enums\BuildingId;
 use App\Http\Controllers\BaseController;
-use App\Models\Advisor;
-use App\Models\Colony;
 use App\Services\ColonyService;
 use App\Services\ColonyTileService;
 use App\Services\EventService;
@@ -167,7 +165,7 @@ class ColonyController extends BaseController
             ? $this->merchantService->getItemsForVisit($merchantVisit->id)->values()->toArray()
             : [];
 
-        $phaseProgress = $this->computePhaseProgress($colony);
+        $phaseProgress = $this->colonyService->getPhaseProgress($colony);
 
         return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'navAp', 'constructionAp', 'researchAp', 'economyAp', 'strategyAp', 'activeHint', 'supplyCapFull', 'trust', 'regolith', 'werkstoffe', 'freeSupply', 'currentSol', 'solLimit', 'merchantVisit', 'merchantItems', 'phaseProgress'));
     }
@@ -649,7 +647,7 @@ class ColonyController extends BaseController
                 'leveled_up' => true,
                 'tiles' => $tiles,
                 'activeHint' => $this->resolveHint($colony->id),
-                'phase_progress' => $this->computePhaseProgress($colony),
+                'phase_progress' => $this->colonyService->getPhaseProgress($colony),
                 ...$this->currentAp($colony->id),
             ]);
         }
@@ -667,7 +665,7 @@ class ColonyController extends BaseController
             'leveled_up' => $leveledUp,
             'nav_unlocked' => $navUnlocked,
             'activeHint' => $this->resolveHint($colony->id),
-            ...($leveledUp ? ['phase_progress' => $this->computePhaseProgress($colony)] : []),
+            ...($leveledUp ? ['phase_progress' => $this->colonyService->getPhaseProgress($colony)] : []),
             ...$this->currentAp($colony->id),
         ]);
     }
@@ -985,88 +983,5 @@ class ColonyController extends BaseController
         $overrides = ['bar' => 'cantina'];
 
         return $overrides[$key] ?? strtolower(preg_replace('/([A-Z])/', '-$1', $key));
-    }
-
-    private function computePhaseProgress(Colony $colony): array
-    {
-        $run = DB::table('runs')
-            ->where('colony_id', $colony->id)
-            ->where('status', 'active')
-            ->select('id', 'phase', 'current_tick')
-            ->first();
-
-        if (! $run) {
-            return ['phase' => 1, 'criteria' => []];
-        }
-
-        $colonyId = $colony->id;
-        $ccId = config('buildings.commandCenter.id', 25);
-
-        if ((int) $run->phase === 1) {
-            $ccLevel = (int) (DB::table('colony_buildings')
-                ->where('colony_id', $colonyId)
-                ->where('building_id', $ccId)
-                ->value('level') ?? 0);
-
-            $buildingsLv2 = DB::table('colony_buildings')
-                ->where('colony_id', $colonyId)
-                ->where('building_id', '!=', $ccId)
-                ->where('level', '>=', 2)
-                ->count();
-
-            $advisorCount = Advisor::where('colony_id', $colonyId)
-                ->where(function ($q) use ($run): void {
-                    $q->whereNull('unavailable_until_tick')
-                        ->orWhere('unavailable_until_tick', '<', $run->current_tick);
-                })
-                ->count();
-
-            return [
-                'phase' => 1,
-                'criteria' => [
-                    [
-                        'key' => 'cc_level',
-                        'label' => __('colony.sol_report_phase1_cc'),
-                        'current' => min($ccLevel, 3),
-                        'target' => 3,
-                        'done' => $ccLevel >= 3,
-                    ],
-                    [
-                        'key' => 'buildings_lv2',
-                        'label' => __('colony.sol_report_phase1_buildings'),
-                        'current' => min($buildingsLv2, 2),
-                        'target' => 2,
-                        'done' => $buildingsLv2 >= 2,
-                    ],
-                    [
-                        'key' => 'advisors',
-                        'label' => __('colony.sol_report_phase1_advisors'),
-                        'current' => min($advisorCount, 3),
-                        'target' => 3,
-                        'done' => $advisorCount >= 3,
-                    ],
-                ],
-            ];
-        }
-
-        $objectives = DB::table('run_objectives')
-            ->where('run_id', $run->id)
-            ->orderBy('id')
-            ->get(['task_key', 'current_value', 'target_value', 'completed_at'])
-            ->map(function ($obj): array {
-                $revealed = (int) $obj->current_value > 0 || $obj->completed_at !== null;
-
-                return [
-                    'revealed' => $revealed,
-                    'label' => $revealed ? __('run.'.$obj->task_key) : null,
-                    'current' => (int) $obj->current_value,
-                    'target' => (int) $obj->target_value,
-                    'done' => $obj->completed_at !== null,
-                ];
-            })
-            ->values()
-            ->all();
-
-        return ['phase' => 2, 'objectives' => $objectives];
     }
 }

--- a/app/Http/Controllers/Colony/CommandCenterController.php
+++ b/app/Http/Controllers/Colony/CommandCenterController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Controllers\Colony;
+
+use App\Http\Controllers\BaseController;
+use App\Models\Run;
+use App\Services\ColonyService;
+use App\Services\Techtree\PersonellService;
+use App\Services\TickService;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\View\View;
+
+/**
+ * CommandCenterController — Kommandozentrale dashboard (GDD, Owner-Konzept
+ * 2026-07-10). Bundles colony-overview data that was previously scattered
+ * across popups (Phasenziele, Kolonisten-Zulage) or nowhere visible at all
+ * (Run-Fortschritt, Wartungsstau, Netto-Sol-Bilanz, Berater-Kurzübersicht,
+ * Vertrauens-Ereignisse) into one always-accessible screen (no build-gate —
+ * the CC exists from Sol 1).
+ */
+class CommandCenterController extends BaseController
+{
+    public function __construct(
+        TickService $tick,
+        private readonly ColonyService $colonyService,
+        private readonly PersonellService $personellService,
+    ) {
+        parent::__construct($tick);
+    }
+
+    public function index(): View
+    {
+        $colony = $this->colonyService->getPrimeColony(Auth::id());
+        $run = Run::where('colony_id', $colony->id)->where('status', 'active')->first();
+
+        $phaseProgress = $this->colonyService->getPhaseProgress($colony);
+        $stipendTiers = config('game.stipend.tiers', []);
+
+        $solLimit = $run?->getTickLimit() ?? (int) config('game.run.tick_limit', 100);
+        $currentSol = $this->currentSol();
+        $nexusDebt = (int) ($run?->nexus_debt ?? 0);
+        $nexusDebtMax = 12000; // see resourcebar.blade.php — same magic number, no config key yet
+        $nexusPct = $nexusDebtMax > 0 ? ($nexusDebt / $nexusDebtMax) * 100 : 0;
+        $nexusDebtTone = match (true) {
+            $nexusPct >= 95 => 'danger',
+            $nexusPct >= 80 => 'warning',
+            default => 'neutral',
+        };
+
+        $totalBuildings = DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('level', '>=', 1)
+            ->count();
+
+        $repairThreshold = (int) config('game.onboarding.hint_repair_urgent_sp', 3);
+        $damagedBuildings = DB::table('colony_buildings')
+            ->join('buildings', 'colony_buildings.building_id', '=', 'buildings.id')
+            ->where('colony_buildings.colony_id', $colony->id)
+            ->where('colony_buildings.level', '>=', 1)
+            ->where('colony_buildings.status_points', '<=', $repairThreshold)
+            ->select(
+                'colony_buildings.building_id',
+                'colony_buildings.instance_id',
+                'colony_buildings.status_points',
+                'colony_buildings.tile_x',
+                'colony_buildings.tile_y',
+                'buildings.name as building_key',
+                'buildings.max_status_points',
+            )
+            ->get()
+            ->map(fn ($b) => [
+                'label' => __('techtree.'.$b->building_key),
+                'status_points' => (int) $b->status_points,
+                'max_status_points' => (int) $b->max_status_points,
+                'tile_x' => $b->tile_x,
+                'tile_y' => $b->tile_y,
+            ])
+            ->values();
+
+        $lastSolDeltas = Cache::get("colony:{$colony->id}:last_sol_deltas");
+
+        $advisorTypeByPersonellId = collect(config('advisors', []))
+            ->mapWithKeys(fn ($cfg, $key) => [$cfg['id'] => $key]);
+        $advisors = $this->personellService->getColonyAdvisors($colony->id)
+            ->map(function ($advisor) use ($advisorTypeByPersonellId) {
+                $typeKey = $advisorTypeByPersonellId[$advisor->personell_id] ?? null;
+
+                return [
+                    'name' => $typeKey ? __('advisors.'.$typeKey) : '?',
+                    'rank' => (int) $advisor->rank,
+                    'rank_name' => match ((int) $advisor->rank) {
+                        1 => 'Junior',
+                        2 => 'Senior',
+                        3 => 'Experte',
+                        default => '?',
+                    },
+                    'ap_per_tick' => $advisor->getApPerTick(),
+                    'ap_type' => $typeKey ? (config("advisors.{$typeKey}.ap_type") ?? '') : '',
+                ];
+            })
+            ->values();
+
+        $trustEvents = DB::table('trust_events')
+            ->where('colony_id', $colony->id)
+            ->orderByDesc('tick')
+            ->orderByDesc('id')
+            ->limit(5)
+            ->get(['tick', 'event_type'])
+            ->map(fn ($row) => [
+                'tick' => (int) $row->tick,
+                'description' => __('trust.event_'.$row->event_type),
+                'delta' => (int) config('game.trust.events.'.$row->event_type, 0),
+            ])
+            ->values();
+
+        return view('colony.command_center', compact(
+            'phaseProgress',
+            'stipendTiers',
+            'solLimit',
+            'currentSol',
+            'nexusDebt',
+            'nexusDebtMax',
+            'nexusDebtTone',
+            'totalBuildings',
+            'damagedBuildings',
+            'lastSolDeltas',
+            'advisors',
+            'trustEvents',
+        ));
+    }
+}

--- a/app/Http/Controllers/SolController.php
+++ b/app/Http/Controllers/SolController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -46,6 +47,15 @@ class SolController extends Controller
 
         Artisan::call('game:tick', ['--run' => $run->id]);
         $run->refresh();
+
+        // Kommandozentrale-Dashboard "Netto-Sol-Bilanz" widget — the before/after
+        // diff is only computable right now (colony state isn't snapshotted
+        // anywhere persistent), so cache it for the dashboard to read later.
+        Cache::put(
+            "colony:{$run->colony_id}:last_sol_deltas",
+            $this->solReportService->netDeltas((int) $run->colony_id, (int) $run->user_id, $before),
+            now()->addDays(2),
+        );
 
         $this->eventService->createEvent([
             'user' => Auth::id(),

--- a/app/Services/ColonyService.php
+++ b/app/Services/ColonyService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\Advisor;
 use App\Models\Colony;
 use App\Services\Concerns\ValidatesId;
 use Illuminate\Support\Collection;
@@ -112,5 +113,93 @@ class ColonyService
         ]);
 
         return Colony::findOrFail($nextId);
+    }
+
+    /**
+     * Phase-1/Phase-2 progress toward advancing the run. Shared by the
+     * Kommandozentrale dashboard and SolReportService (end-of-Sol report) —
+     * single source of truth so both screens agree on the same criteria/objectives.
+     */
+    public function getPhaseProgress(Colony $colony): array
+    {
+        $run = DB::table('runs')
+            ->where('colony_id', $colony->id)
+            ->where('status', 'active')
+            ->select('id', 'phase', 'current_tick')
+            ->first();
+
+        if (! $run) {
+            return ['phase' => 1, 'criteria' => []];
+        }
+
+        $colonyId = $colony->id;
+        $ccId = config('buildings.commandCenter.id', 25);
+
+        if ((int) $run->phase === 1) {
+            $ccLevel = (int) (DB::table('colony_buildings')
+                ->where('colony_id', $colonyId)
+                ->where('building_id', $ccId)
+                ->value('level') ?? 0);
+
+            $buildingsLv2 = DB::table('colony_buildings')
+                ->where('colony_id', $colonyId)
+                ->where('building_id', '!=', $ccId)
+                ->where('level', '>=', 2)
+                ->count();
+
+            $advisorCount = Advisor::where('colony_id', $colonyId)
+                ->where(function ($q) use ($run): void {
+                    $q->whereNull('unavailable_until_tick')
+                        ->orWhere('unavailable_until_tick', '<', $run->current_tick);
+                })
+                ->count();
+
+            return [
+                'phase' => 1,
+                'criteria' => [
+                    [
+                        'key' => 'cc_level',
+                        'label' => __('colony.sol_report_phase1_cc'),
+                        'current' => min($ccLevel, 3),
+                        'target' => 3,
+                        'done' => $ccLevel >= 3,
+                    ],
+                    [
+                        'key' => 'buildings_lv2',
+                        'label' => __('colony.sol_report_phase1_buildings'),
+                        'current' => min($buildingsLv2, 2),
+                        'target' => 2,
+                        'done' => $buildingsLv2 >= 2,
+                    ],
+                    [
+                        'key' => 'advisors',
+                        'label' => __('colony.sol_report_phase1_advisors'),
+                        'current' => min($advisorCount, 3),
+                        'target' => 3,
+                        'done' => $advisorCount >= 3,
+                    ],
+                ],
+            ];
+        }
+
+        $objectives = DB::table('run_objectives')
+            ->where('run_id', $run->id)
+            ->orderBy('id')
+            ->get(['task_key', 'current_value', 'target_value', 'completed_at'])
+            ->map(function ($obj): array {
+                $revealed = (int) $obj->current_value > 0 || $obj->completed_at !== null;
+
+                return [
+                    'revealed' => $revealed,
+                    'label' => $revealed ? __('run.'.$obj->task_key) : null,
+                    'current' => (int) $obj->current_value,
+                    'target' => (int) $obj->target_value,
+                    'done' => $obj->completed_at !== null,
+                ];
+            })
+            ->values()
+            ->all();
+
+        return ['phase' => 2, 'objectives' => $objectives];
     }
 }

--- a/app/Services/SolReportService.php
+++ b/app/Services/SolReportService.php
@@ -2,7 +2,6 @@
 
 namespace App\Services;
 
-use App\Models\Advisor;
 use App\Models\Run;
 use Illuminate\Support\Facades\DB;
 
@@ -52,6 +51,10 @@ class SolReportService
         self::RES_ORGANICS => 'res_organika',
     ];
 
+    public function __construct(
+        private readonly ColonyService $colonyService,
+    ) {}
+
     /**
      * Capture the "before" state of a colony for later diffing.
      *
@@ -92,6 +95,36 @@ class SolReportService
             'buildings' => $buildings,
             'advisors' => $advisors,
             'phase' => $phase,
+        ];
+    }
+
+    /**
+     * Net Regolith/Werkstoffe/Organika/Credits/Trust change over the just-
+     * completed Sol — the same before/after diff as productionGroup()/
+     * colonyGroup(), flattened to scalars. Called by SolController::next()
+     * right after the tick to populate the Kommandozentrale dashboard's
+     * "Netto-Sol-Bilanz" widget (cached, since this diff is only computable
+     * at the moment of the Sol transition — colony state isn't snapshotted
+     * anywhere else).
+     *
+     * @param  array  $before  Snapshot taken before the tick (see snapshot()).
+     */
+    public function netDeltas(int $colonyId, int $userId, array $before): array
+    {
+        $afterResources = DB::table('colony_resources')
+            ->where('colony_id', $colonyId)
+            ->pluck('amount', 'resource_id')
+            ->map(fn ($a) => (int) $a)
+            ->all();
+
+        $creditsAfter = (int) (DB::table('user_resources')->where('user_id', $userId)->value('credits') ?? 0);
+
+        return [
+            'regolith' => ($afterResources[self::RES_REGOLITH] ?? 0) - (int) ($before['resources'][self::RES_REGOLITH] ?? 0),
+            'werkstoffe' => ($afterResources[self::RES_COMPOUNDS] ?? 0) - (int) ($before['resources'][self::RES_COMPOUNDS] ?? 0),
+            'organika' => ($afterResources[self::RES_ORGANICS] ?? 0) - (int) ($before['resources'][self::RES_ORGANICS] ?? 0),
+            'credits' => $creditsAfter - (int) ($before['credits'] ?? 0),
+            'trust' => ($afterResources[self::RES_TRUST] ?? 0) - (int) ($before['trust'] ?? 0),
         ];
     }
 
@@ -479,87 +512,14 @@ class SolReportService
 
     // ── Phase progress (Screen 2) ───────────────────────────────────────────────
 
+    /**
+     * Delegates to ColonyService::getPhaseProgress() — the shared source of
+     * truth for phase criteria/objectives (also used by the Kommandozentrale
+     * dashboard). Was a local reimplementation before both screens needed it.
+     */
     private function phaseProgress(Run $run): array
     {
-        if ($run->phase === 1 || $run->phase === null) {
-            return $this->phase1Progress($run);
-        }
-
-        return $this->phase2Progress($run);
-    }
-
-    private function phase1Progress(Run $run): array
-    {
-        $ccId = config('buildings.commandCenter.id', 25);
-        $colonyId = (int) $run->colony_id;
-
-        $ccLevel = (int) (DB::table('colony_buildings')
-            ->where('colony_id', $colonyId)
-            ->where('building_id', $ccId)
-            ->value('level') ?? 0);
-
-        $buildingsLv2 = DB::table('colony_buildings')
-            ->where('colony_id', $colonyId)
-            ->where('building_id', '!=', $ccId)
-            ->where('level', '>=', 2)
-            ->count();
-
-        $advisorCount = Advisor::where('colony_id', $colonyId)
-            ->where(function ($q) use ($run): void {
-                $q->whereNull('unavailable_until_tick')
-                    ->orWhere('unavailable_until_tick', '<', $run->current_tick);
-            })
-            ->count();
-
-        return [
-            'phase' => 1,
-            'criteria' => [
-                [
-                    'key' => 'cc_level',
-                    'label' => __('colony.sol_report_phase1_cc'),
-                    'current' => min($ccLevel, 3),
-                    'target' => 3,
-                    'done' => $ccLevel >= 3,
-                ],
-                [
-                    'key' => 'buildings_lv2',
-                    'label' => __('colony.sol_report_phase1_buildings'),
-                    'current' => min($buildingsLv2, 2),
-                    'target' => 2,
-                    'done' => $buildingsLv2 >= 2,
-                ],
-                [
-                    'key' => 'advisors',
-                    'label' => __('colony.sol_report_phase1_advisors'),
-                    'current' => min($advisorCount, 3),
-                    'target' => 3,
-                    'done' => $advisorCount >= 3,
-                ],
-            ],
-        ];
-    }
-
-    private function phase2Progress(Run $run): array
-    {
-        $objectives = $run->objectives()
-            ->get(['task_key', 'current_value', 'target_value', 'completed_at']);
-
-        $items = $objectives->map(function ($obj): array {
-            $revealed = (int) $obj->current_value > 0 || $obj->completed_at !== null;
-
-            return [
-                'revealed' => $revealed,
-                'label' => $revealed ? __('run.'.$obj->task_key) : null,
-                'current' => (int) $obj->current_value,
-                'target' => (int) $obj->target_value,
-                'done' => $obj->completed_at !== null,
-            ];
-        })->values()->all();
-
-        return [
-            'phase' => 2,
-            'objectives' => $items,
-        ];
+        return $this->colonyService->getPhaseProgress($run->colony);
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/lang/de/command_center.php
+++ b/lang/de/command_center.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'nav_label' => 'Kommandozentrale',
+    'title' => 'Kommandozentrale — Nouron',
+
+    // Phasenziele (Widget 1)
+    'widget_phase_title' => 'Phasenziele',
+
+    // Kolonisten-Zulage (Widget 2) — reuses colony.stipend_* strings (button/dialog
+    // text was already defined for the old FAB/dialog, unchanged here).
+
+    // Run-Fortschritt (Widget 3)
+    'widget_run_title' => 'Run-Fortschritt',
+    'widget_run_sol' => 'Sol :current von :limit',
+    'widget_run_remaining' => ':count Sole verbleibend',
+    'widget_run_nexus_debt' => 'Nexus-Schuld',
+
+    // Wartungsstau (Widget 4)
+    'widget_maintenance_title' => 'Wartungsstau',
+    'widget_maintenance_none' => 'Keine kritisch beschädigten Gebäude.',
+    'widget_maintenance_count' => ':count von :total Gebäuden kritisch beschädigt',
+    'widget_maintenance_status' => 'Status :sp / :max',
+
+    // Netto-Sol-Bilanz (Widget 5)
+    'widget_balance_title' => 'Netto-Sol-Bilanz',
+    'widget_balance_none' => 'Noch keine Daten — beende deinen ersten Sol.',
+    'widget_balance_intro' => 'Veränderung im letzten Sol:',
+
+    // Berater-Kurzübersicht (Widget 6)
+    'widget_advisors_title' => 'Berater',
+    'widget_advisors_none' => 'Noch keine Berater angestellt.',
+    'widget_advisors_count' => ':count Berater aktiv',
+    'widget_advisors_link' => 'Zum Berater-Screen',
+
+    // Vertrauens-Ereignisse (Widget 7)
+    'widget_trust_events_title' => 'Vertrauens-Ereignisse',
+    'widget_trust_events_none' => 'Noch keine Ereignisse.',
+    'widget_trust_events_sol' => 'Sol :sol',
+];

--- a/lang/de/trust.php
+++ b/lang/de/trust.php
@@ -18,4 +18,9 @@ return [
     'event_encounter_lost' => 'Eigene Schiffe wurden bei einem Zwischenfall beschädigt – die Kolonisten sind besorgt.',
     'event_colony_threatened' => 'Die Kolonie wurde direkt bedroht – die Bewohner sind verunsichert.',
     'event_treaty_signed' => 'Ein Friedensvertrag wurde unterzeichnet.',
+    'event_nexus_credit' => 'Ein Schiff wurde auf Nexus-Kredit angefordert – die Verschuldung drückt auf die Stimmung.',
+    'event_well_fed' => 'Die Kolonie war gut versorgt.',
+    'event_stipend_small' => 'Kolonisten-Zulage (Klein) ausgeschüttet.',
+    'event_stipend_medium' => 'Kolonisten-Zulage (Mittel) ausgeschüttet.',
+    'event_stipend_large' => 'Kolonisten-Zulage (Groß) ausgeschüttet.',
 ];

--- a/lang/en/command_center.php
+++ b/lang/en/command_center.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'nav_label' => 'Command Center',
+    'title' => 'Command Center — Nouron',
+
+    // Phase objectives (Widget 1)
+    'widget_phase_title' => 'Phase Objectives',
+
+    // Colonist Stipend (Widget 2) — reuses colony.stipend_* strings (button/dialog
+    // text was already defined for the old FAB/dialog, unchanged here).
+
+    // Run progress (Widget 3)
+    'widget_run_title' => 'Run Progress',
+    'widget_run_sol' => 'Sol :current of :limit',
+    'widget_run_remaining' => ':count Sols remaining',
+    'widget_run_nexus_debt' => 'Nexus Debt',
+
+    // Maintenance backlog (Widget 4)
+    'widget_maintenance_title' => 'Maintenance Backlog',
+    'widget_maintenance_none' => 'No critically damaged buildings.',
+    'widget_maintenance_count' => ':count of :total buildings critically damaged',
+    'widget_maintenance_status' => 'Status :sp / :max',
+
+    // Net Sol balance (Widget 5)
+    'widget_balance_title' => 'Net Sol Balance',
+    'widget_balance_none' => 'No data yet — end your first Sol.',
+    'widget_balance_intro' => 'Change over the last Sol:',
+
+    // Advisor overview (Widget 6)
+    'widget_advisors_title' => 'Advisors',
+    'widget_advisors_none' => 'No advisors hired yet.',
+    'widget_advisors_count' => ':count advisors active',
+    'widget_advisors_link' => 'Go to Advisors',
+
+    // Trust events (Widget 7)
+    'widget_trust_events_title' => 'Trust Events',
+    'widget_trust_events_none' => 'No events yet.',
+    'widget_trust_events_sol' => 'Sol :sol',
+];

--- a/lang/en/trust.php
+++ b/lang/en/trust.php
@@ -18,4 +18,9 @@ return [
     'event_encounter_lost' => 'Own ships were damaged in an incident — colonists are concerned.',
     'event_colony_threatened' => 'The colony was directly threatened — residents are unsettled.',
     'event_treaty_signed' => 'A peace agreement was signed.',
+    'event_nexus_credit' => 'A ship was requested on Nexus credit — the debt weighs on morale.',
+    'event_well_fed' => 'The colony was well provisioned.',
+    'event_stipend_small' => 'Colonist Stipend (Small) paid out.',
+    'event_stipend_medium' => 'Colonist Stipend (Medium) paid out.',
+    'event_stipend_large' => 'Colonist Stipend (Large) paid out.',
 ];

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -327,15 +327,6 @@ button.btn-sol:hover,
 /* ── Hex page layout ─────────────────────────────────────────────────────── */
 
 /*
- * Reserve clear space below the layout so the viewport-fixed .stipend-fab
- * never overlaps the last row of sidebar content when the page's natural
- * (document) bottom edge is close to the fixed button.
- */
-.hex-page {
-    padding-bottom: 4rem;
-}
-
-/*
  * Two-column grid: canvas area fills remaining space, sidebar is fixed-width.
  * min-height accounts for header (~44px) + resource bar (~38px) + 2px border = ~84px.
  */
@@ -441,67 +432,6 @@ button.btn-sol:hover,
 }
 
 .info-bar-btn:hover {
-    border-color: #aaa;
-    background: #f5f5f7;
-}
-
-/* ── Kolonisten-Zulage FAB (GDD §14) ─────────────────────────────────────── */
-
-/*
- * Viewport-fixed trigger for the stipend dialog. Used to live inside
- * .canvas-info-bar (below the canvas), which can scroll out of view on short
- * viewports — both mobile and desktop windows with little vertical space
- * (Owner-Feedback, real playtest). Fixed positioning guarantees it's always
- * reachable without scrolling. Bottom-left avoids the top-right .colony-toast,
- * the bottom-center .colony-levelup-notice, and the bottom-right
- * .first-visit-popup used on other screens.
- */
-.stipend-fab {
-    position: fixed;
-    bottom: 1rem;
-    left: 1rem;
-    z-index: 400;
-    padding: 0.55rem 1rem;
-    background: #fff;
-    border: 1px solid #d0d4db;
-    border-radius: 999px;
-    font-size: 0.8rem;
-    font-weight: 700;
-    color: var(--color-anthracite, #333);
-    cursor: pointer;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15);
-    white-space: nowrap;
-}
-
-.stipend-fab:hover {
-    border-color: #aaa;
-    background: #f5f5f7;
-}
-
-/* ── Kolonisten-Zulage dialog (GDD §14) ──────────────────────────────────── */
-
-.stipend-tiers {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    padding: 0 1rem 1rem;
-}
-
-.stipend-tier-btn {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.6rem 0.9rem;
-    background: #fff;
-    border: 1px solid #d0d4db;
-    border-radius: 8px;
-    font-size: 0.85rem;
-    color: #333;
-    cursor: pointer;
-    text-align: left;
-}
-
-.stipend-tier-btn:hover {
     border-color: #aaa;
     background: #f5f5f7;
 }
@@ -730,62 +660,6 @@ button.btn-sol:hover,
 .tile-panel-empty p {
     margin: 0;
     font-size: 0.85rem;
-}
-
-/* ── Phase progress dialog criteria list ─────────────────────────────────── */
-
-.phase-dialog-criteria {
-    list-style: none;
-    margin: 0;
-    padding: 0 1rem 0.5rem 1.25rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.6rem;
-}
-
-.phase-criteria {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-}
-
-.phase-criteria__item {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    font-size: 0.76rem;
-    color: #555;
-    min-width: 0; /* allow flex children to shrink below content size */
-}
-
-.phase-criteria__item--done {
-    color: #2a7d4f;
-}
-
-.phase-criteria__check {
-    flex-shrink: 0;
-    font-size: 0.7rem;
-    width: 1em;
-    text-align: center;
-    color: #bbb;
-}
-
-.phase-criteria__item--done .phase-criteria__check {
-    color: #2a7d4f;
-}
-
-.phase-criteria__label {
-    flex: 1;
-}
-
-.phase-criteria__count {
-    flex-shrink: 0;
-    font-size: 0.7rem;
-    color: #aaa;
-    font-variant-numeric: tabular-nums;
 }
 
 /* ── Status chips ────────────────────────────────────────────────────────── */

--- a/public/css/command_center.css
+++ b/public/css/command_center.css
@@ -1,0 +1,197 @@
+/* ── Kommandozentrale dashboard ──────────────────────────────────────────── */
+
+.cc-dashboard {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    padding: 1rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+@media (max-width: 767px) {
+    .cc-dashboard {
+        grid-template-columns: 1fr;
+        padding: 0.75rem;
+    }
+}
+
+.cc-card {
+    background: #ffffff;
+    border: 1px solid #e4e4ef;
+    border-radius: 8px;
+    padding: 1rem 1.1rem;
+    display: block;
+}
+
+.cc-card-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #1a1a1e;
+    margin: 0 0 0.6rem;
+}
+
+.cc-card-hint {
+    font-size: 0.8rem;
+    color: #6b6b7a;
+    margin: 0 0 0.4rem;
+}
+
+.cc-stat {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #333;
+    margin: 0 0 0.4rem;
+}
+
+.cc-card-link {
+    display: inline-block;
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: #3a5a7a;
+    text-decoration: none;
+}
+
+.cc-card-link:hover {
+    text-decoration: underline;
+}
+
+/* ── Generic stat list (Wartungsstau, Netto-Sol-Bilanz, Berater, Trust-Events) ── */
+
+.cc-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.cc-list-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.8rem;
+    color: #444;
+}
+
+.cc-list-item-good {
+    color: #2a7d4f;
+    font-weight: 600;
+}
+
+.cc-list-item-danger {
+    color: var(--color-accent, #8c2030);
+    font-weight: 600;
+}
+
+/* ── Nexus debt bar (Run-Fortschritt widget) ─────────────────────────────── */
+
+.cc-nexus-debt {
+    margin-top: 0.6rem;
+}
+
+.cc-nexus-debt-label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: #6b6b7a;
+    margin-bottom: 0.3rem;
+}
+
+.cc-nexus-debt-bar {
+    height: 6px;
+    border-radius: 3px;
+    background: #eceef2;
+    overflow: hidden;
+}
+
+.cc-nexus-debt-bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: #6b6b7a;
+}
+
+.cc-nexus-debt-bar-fill--warning {
+    background: #d4a017;
+}
+
+.cc-nexus-debt-bar-fill--danger {
+    background: var(--color-accent, #8c2030);
+}
+
+/* ── Phase progress criteria list (moved from colony.css — was the phase-progress
+ * dialog on the Kolonie-View, now lives here as a dashboard widget) ────────── */
+
+.phase-dialog-criteria {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.phase-criteria__item {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: #555;
+    min-width: 0;
+}
+
+.phase-criteria__item--done {
+    color: #2a7d4f;
+}
+
+.phase-criteria__check {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    width: 1em;
+    text-align: center;
+    color: #bbb;
+}
+
+.phase-criteria__item--done .phase-criteria__check {
+    color: #2a7d4f;
+}
+
+.phase-criteria__label {
+    flex: 1;
+}
+
+.phase-criteria__count {
+    flex-shrink: 0;
+    font-size: 0.7rem;
+    color: #aaa;
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── Kolonisten-Zulage tiers (moved from colony.css — was the FAB dialog on the
+ * Kolonie-View, now a dashboard widget, GDD §14) ────────────────────────────── */
+
+.stipend-tiers {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.stipend-tier-btn {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.6rem 0.9rem;
+    background: #fff;
+    border: 1px solid #d0d4db;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    color: #333;
+    cursor: pointer;
+    text-align: left;
+}
+
+.stipend-tier-btn:hover {
+    border-color: #aaa;
+    background: #f5f5f7;
+}

--- a/public/css/command_center.css
+++ b/public/css/command_center.css
@@ -195,3 +195,9 @@
     border-color: #aaa;
     background: #f5f5f7;
 }
+
+.cc-chip-row {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -329,7 +329,6 @@ function colonyHexView(config) {
                 this.updateBuilding(res.building);
                 this.updateAp(res);
                 this.updateHint(res);
-                if ('phase_progress' in res) this.phaseProgress = res.phase_progress;
                 if (res.leveled_up) {
                     this.showLevelupNotice(res.building.label);
                     if (this.selectedTile) this.selectedTile = { ...this.selectedTile };
@@ -410,24 +409,6 @@ function colonyHexView(config) {
                 );
             } else {
                 this.showToast(res.message ?? res.error ?? this.i18n.nexusImportError, 'error');
-            }
-        },
-
-        // Kolonisten-Zulage (GDD §14) — trust effect only applies from the next
-        // Sol onward (TrustService writes the stored trust value only during
-        // GameTick), so only the Credits chip is synced immediately here.
-        async doPurchaseStipend(tier) {
-            const res = await this.post(this.routes.stipend, { tier });
-            if (res.ok) {
-                // Close the dialog FIRST — its native <dialog> backdrop dims the
-                // whole page (incl. the resourcebar), so flashing while it's
-                // still open makes the flash invisible.
-                this.$refs.stipendDialog.close();
-                this.syncResbarAmount('.res-Cr', res.credits);
-                this.flashResChip('.res-Cr');
-                this.showToast((this.i18n.stipendSuccess ?? '').replace(':cost', res.cost), 'info');
-            } else {
-                this.showToast(res.message ?? res.error ?? this.i18n.stipendError, 'error');
             }
         },
 

--- a/public/js/command_center.js
+++ b/public/js/command_center.js
@@ -1,0 +1,79 @@
+// Kommandozentrale dashboard — Alpine component. Deliberately small: only the
+// Kolonisten-Zulage action needs client-side interaction (rest of the screen
+// is server-rendered). Copied from colonyHexView() in colony-hexgrid.js
+// (toast/HTTP/resourcebar-sync helpers) rather than reusing that component
+// directly — it's tightly coupled to the hex-grid canvas (see initHexGrid()
+// call in its init()), which this screen doesn't have.
+function commandCenter(config = {}) {
+    return {
+        routes: config.routes ?? {},
+        i18n: config.i18n ?? {},
+
+        toastMessage: '',
+        toastVisible: false,
+        toastType: 'error', // 'error' | 'info'
+        _toastTimer: null,
+
+        // Kolonisten-Zulage (GDD §14) — trust effect only applies from the next
+        // Sol onward (TrustService writes the stored trust value only during
+        // GameTick), so only the Credits chip is synced immediately here.
+        async doPurchaseStipend(tier) {
+            const res = await this.post(this.routes.stipend, { tier });
+            if (res.ok) {
+                this.syncResbarAmount('.res-Cr', res.credits);
+                this.flashResChip('.res-Cr');
+                this.showToast((this.i18n.stipendSuccess ?? '').replace(':cost', res.cost), 'info');
+            } else {
+                this.showToast(res.message ?? res.error ?? this.i18n.stipendError, 'error');
+            }
+        },
+
+        // ── Toast notifications ───────────────────────────────────────────────
+
+        showToast(message, type = 'error') {
+            if (this._toastTimer) clearTimeout(this._toastTimer);
+            this.toastMessage = message;
+            this.toastType = type;
+            this.toastVisible = true;
+            this._toastTimer = setTimeout(() => {
+                this.toastVisible = false;
+            }, 3500);
+        },
+
+        // ── Resourcebar sync (server-rendered, not reactive — direct DOM patch) ──
+
+        syncResbarAmount(selector, value) {
+            const el = document.querySelector(`${selector} .res-amount`);
+            if (el) el.textContent = value.toLocaleString('de-DE');
+        },
+
+        flashResChip(selector) {
+            const chip = document.querySelector(selector);
+            if (!chip) return;
+            chip.classList.remove('res-chip--flash');
+            void chip.offsetWidth;
+            chip.classList.add('res-chip--flash');
+            setTimeout(() => chip.classList.remove('res-chip--flash'), 600);
+        },
+
+        // ── HTTP helpers ──────────────────────────────────────────────────────
+
+        get(url) {
+            return fetch(url, {
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            }).then((r) => r.json());
+        },
+
+        post(url, data) {
+            return fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]')?.content ?? '',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                body: JSON.stringify(data),
+            }).then((r) => r.json());
+        },
+    };
+}

--- a/resources/views/colony/command_center.blade.php
+++ b/resources/views/colony/command_center.blade.php
@@ -1,0 +1,187 @@
+@extends("layouts.colony")
+@section("title", __("command_center.title"))
+
+@push("styles")
+    <link rel="stylesheet" href="{{ asset("css/command_center.css") }}">
+@endpush
+
+@push("scripts")
+    <script src="{{ asset("js/command_center.js") }}"></script>
+@endpush
+
+@section("content")
+    <script>
+        window.__commandCenterData = {
+            routes: {
+                stipend: "{{ route("colony.stipend") }}",
+            },
+            i18n: {
+                stipendSuccess: @json(__("colony.stipend_success")),
+                stipendError: @json(__("colony.stipend_error")),
+            },
+        };
+    </script>
+
+    <div class="cc-dashboard" x-data="commandCenter(window.__commandCenterData)" x-cloak>
+
+        {{-- Widget 1: Phasenziele --}}
+        <article class="cc-card">
+            <h3 class="cc-card-title">{{ __("command_center.widget_phase_title") }}</h3>
+            @if ($phaseProgress["phase"] === 1)
+                <ul class="phase-dialog-criteria">
+                    @foreach ($phaseProgress["criteria"] as $c)
+                        <li class="phase-criteria__item @if ($c["done"]) phase-criteria__item--done @endif">
+                            <span class="phase-criteria__check">{{ $c["done"] ? "✓" : "○" }}</span>
+                            <span class="phase-criteria__label">{{ $c["label"] }}</span>
+                            @unless ($c["done"])
+                                <span class="phase-criteria__count">{{ $c["current"] }}/{{ $c["target"] }}</span>
+                            @endunless
+                        </li>
+                    @endforeach
+                </ul>
+            @else
+                <ul class="phase-dialog-criteria">
+                    @foreach ($phaseProgress["objectives"] as $obj)
+                        <li
+                            class="phase-criteria__item @if ($obj["done"]) phase-criteria__item--done @endif">
+                            <span class="phase-criteria__check">{{ $obj["done"] ? "✓" : "○" }}</span>
+                            <span class="phase-criteria__label">
+                                {{ $obj["revealed"] ? $obj["label"] : __("colony.sol_report_phase2_objective_hidden") }}
+                            </span>
+                            @if (!$obj["done"] && $obj["revealed"])
+                                <span class="phase-criteria__count">{{ $obj["current"] }}/{{ $obj["target"] }}</span>
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </article>
+
+        {{-- Widget 2: Kolonisten-Zulage --}}
+        <article class="cc-card">
+            <h3 class="cc-card-title">{{ __("colony.stipend_dialog_title") }}</h3>
+            <p class="cc-card-hint">{{ __("colony.stipend_dialog_hint") }}</p>
+            <div class="stipend-tiers">
+                @foreach ($stipendTiers as $tierKey => $tierCfg)
+                    <button class="stipend-tier-btn" @click="doPurchaseStipend('{{ $tierKey }}')">
+                        <strong>{{ __("colony.stipend_tier_{$tierKey}") }}</strong>
+                        <span>{{ $tierCfg["cost"] }}
+                            Cr — +{{ config("game.trust.events.{$tierCfg["event_key"]}") }}
+                            {{ __("resources.res_trust") }}</span>
+                    </button>
+                @endforeach
+            </div>
+        </article>
+
+        {{-- Widget 3: Run-Fortschritt / Sol-Countdown --}}
+        <article class="cc-card">
+            <h3 class="cc-card-title">{{ __("command_center.widget_run_title") }}</h3>
+            <p class="cc-stat">{{ __("command_center.widget_run_sol", ["current" => $currentSol, "limit" => $solLimit]) }}
+            </p>
+            <p class="cc-card-hint">
+                {{ __("command_center.widget_run_remaining", ["count" => max(0, $solLimit - $currentSol)]) }}</p>
+            <div class="cc-nexus-debt">
+                <div class="cc-nexus-debt-label">
+                    <span>{{ __("command_center.widget_run_nexus_debt") }}</span>
+                    <span>{{ number_format($nexusDebt, 0, ",", ".") }} / {{ number_format($nexusDebtMax, 0, ",", ".") }}
+                        Cr</span>
+                </div>
+                <div class="cc-nexus-debt-bar">
+                    <div class="cc-nexus-debt-bar-fill cc-nexus-debt-bar-fill--{{ $nexusDebtTone }}"
+                        style="width: {{ min(100, $nexusDebtMax > 0 ? ($nexusDebt / $nexusDebtMax) * 100 : 0) }}%"></div>
+                </div>
+            </div>
+        </article>
+
+        {{-- Widget 4: Wartungsstau --}}
+        <article class="cc-card">
+            <h3 class="cc-card-title">{{ __("command_center.widget_maintenance_title") }}</h3>
+            @if ($damagedBuildings->isEmpty())
+                <p class="cc-card-hint">{{ __("command_center.widget_maintenance_none") }}</p>
+            @else
+                <p class="cc-stat">
+                    {{ __("command_center.widget_maintenance_count", ["count" => $damagedBuildings->count(), "total" => $totalBuildings]) }}
+                </p>
+                <ul class="cc-list">
+                    @foreach ($damagedBuildings as $b)
+                        <li class="cc-list-item">
+                            <span>{{ $b["label"] }} ({{ $b["tile_x"] }}, {{ $b["tile_y"] }})</span>
+                            <span class="cc-list-item-danger">
+                                {{ __("command_center.widget_maintenance_status", ["sp" => $b["status_points"], "max" => $b["max_status_points"]]) }}
+                            </span>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </article>
+
+        {{-- Widget 5: Netto-Sol-Bilanz --}}
+        <article class="cc-card">
+            <h3 class="cc-card-title">{{ __("command_center.widget_balance_title") }}</h3>
+            @if ($lastSolDeltas === null)
+                <p class="cc-card-hint">{{ __("command_center.widget_balance_none") }}</p>
+            @else
+                <p class="cc-card-hint">{{ __("command_center.widget_balance_intro") }}</p>
+                <ul class="cc-list">
+                    @foreach (["regolith" => "res_regolith", "werkstoffe" => "res_werkstoffe", "organika" => "res_organika", "credits" => "res_credits", "trust" => "res_trust"] as $key => $langKey)
+                        @php $delta = $lastSolDeltas[$key] ?? 0; @endphp
+                        <li class="cc-list-item">
+                            <span>{{ __("resources.{$langKey}") }}</span>
+                            <span
+                                class="{{ $delta > 0 ? "cc-list-item-good" : ($delta < 0 ? "cc-list-item-danger" : "") }}">
+                                {{ $delta > 0 ? "+" : "" }}{{ $delta }}
+                            </span>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </article>
+
+        {{-- Widget 6: Berater-Kurzübersicht --}}
+        <article class="cc-card">
+            <h3 class="cc-card-title">{{ __("command_center.widget_advisors_title") }}</h3>
+            @if ($advisors->isEmpty())
+                <p class="cc-card-hint">{{ __("command_center.widget_advisors_none") }}</p>
+            @else
+                <p class="cc-stat">{{ __("command_center.widget_advisors_count", ["count" => $advisors->count()]) }}</p>
+                <ul class="cc-list">
+                    @foreach ($advisors as $a)
+                        <li class="cc-list-item">
+                            <span>{{ $a["name"] }} ({{ $a["rank_name"] }})</span>
+                            <span>+{{ $a["ap_per_tick"] }}
+                                {{ ["construction" => "Con", "research" => "Res", "navigation" => "Nav", "economy" => "Eco", "strategy" => "Str"][$a["ap_type"]] ?? "" }}
+                                AP</span>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+            <a href="{{ route("advisors.index") }}"
+                class="cc-card-link">{{ __("command_center.widget_advisors_link") }}</a>
+        </article>
+
+        {{-- Widget 7: Vertrauens-Ereignisse --}}
+        <article class="cc-card">
+            <h3 class="cc-card-title">{{ __("command_center.widget_trust_events_title") }}</h3>
+            @if ($trustEvents->isEmpty())
+                <p class="cc-card-hint">{{ __("command_center.widget_trust_events_none") }}</p>
+            @else
+                <ul class="cc-list">
+                    @foreach ($trustEvents as $e)
+                        <li class="cc-list-item">
+                            <span>{{ __("command_center.widget_trust_events_sol", ["sol" => $e["tick"] + 1]) }}
+                                — {{ $e["description"] }}</span>
+                            <span
+                                class="{{ $e["delta"] > 0 ? "cc-list-item-good" : ($e["delta"] < 0 ? "cc-list-item-danger" : "") }}">
+                                {{ $e["delta"] > 0 ? "+" : "" }}{{ $e["delta"] }}
+                            </span>
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </article>
+
+        {{-- Action / feedback toast (mirrors colony-hexgrid.js's .colony-toast) --}}
+        <div class="colony-toast" :class="`colony-toast--${toastType}`" x-show="toastVisible" x-transition
+            x-text="toastMessage" aria-live="polite" role="status"></div>
+    </div>
+@endsection

--- a/resources/views/colony/command_center.blade.php
+++ b/resources/views/colony/command_center.blade.php
@@ -65,9 +65,15 @@
                 @foreach ($stipendTiers as $tierKey => $tierCfg)
                     <button class="stipend-tier-btn" @click="doPurchaseStipend('{{ $tierKey }}')">
                         <strong>{{ __("colony.stipend_tier_{$tierKey}") }}</strong>
-                        <span>{{ $tierCfg["cost"] }}
-                            Cr — +{{ config("game.trust.events.{$tierCfg["event_key"]}") }}
-                            {{ __("resources.res_trust") }}</span>
+                        <span class="cc-chip-row">
+                            <span class="res-chip res-Cr">
+                                <span class="res-abbr">CR</span>
+                                <span class="res-amount">{{ $tierCfg["cost"] }}</span>
+                            </span>
+                            <span
+                                class="ap-chip ap-chip--trust-pos">+{{ config("game.trust.events.{$tierCfg["event_key"]}") }}
+                                {{ __("resources.res_trust") }}</span>
+                        </span>
                     </button>
                 @endforeach
             </div>
@@ -83,8 +89,11 @@
             <div class="cc-nexus-debt">
                 <div class="cc-nexus-debt-label">
                     <span>{{ __("command_center.widget_run_nexus_debt") }}</span>
-                    <span>{{ number_format($nexusDebt, 0, ",", ".") }} / {{ number_format($nexusDebtMax, 0, ",", ".") }}
-                        Cr</span>
+                    <span class="res-chip res-Cr {{ $nexusDebtTone !== "neutral" ? "res-chip--{$nexusDebtTone}" : "" }}">
+                        <span class="res-abbr">CR</span>
+                        <span class="res-amount">{{ number_format($nexusDebt, 0, ",", ".") }}
+                            / {{ number_format($nexusDebtMax, 0, ",", ".") }}</span>
+                    </span>
                 </div>
                 <div class="cc-nexus-debt-bar">
                     <div class="cc-nexus-debt-bar-fill cc-nexus-debt-bar-fill--{{ $nexusDebtTone }}"
@@ -145,12 +154,27 @@
             @else
                 <p class="cc-stat">{{ __("command_center.widget_advisors_count", ["count" => $advisors->count()]) }}</p>
                 <ul class="cc-list">
+                    @php
+                        $apChipClass = [
+                            "construction" => "ap-chip--build",
+                            "research" => "ap-chip--research",
+                            "navigation" => "ap-chip--nav",
+                            "economy" => "ap-chip--economy",
+                            "strategy" => "ap-chip--strategy",
+                        ];
+                        $apAbbr = [
+                            "construction" => "Con",
+                            "research" => "Res",
+                            "navigation" => "Nav",
+                            "economy" => "Eco",
+                            "strategy" => "Str",
+                        ];
+                    @endphp
                     @foreach ($advisors as $a)
                         <li class="cc-list-item">
                             <span>{{ $a["name"] }} ({{ $a["rank_name"] }})</span>
-                            <span>+{{ $a["ap_per_tick"] }}
-                                {{ ["construction" => "Con", "research" => "Res", "navigation" => "Nav", "economy" => "Eco", "strategy" => "Str"][$a["ap_type"]] ?? "" }}
-                                AP</span>
+                            <span class="ap-chip {{ $apChipClass[$a["ap_type"]] ?? "" }}">+{{ $a["ap_per_tick"] }}
+                                {{ $apAbbr[$a["ap_type"]] ?? "" }} AP</span>
                         </li>
                     @endforeach
                 </ul>
@@ -171,7 +195,7 @@
                             <span>{{ __("command_center.widget_trust_events_sol", ["sol" => $e["tick"] + 1]) }}
                                 — {{ $e["description"] }}</span>
                             <span
-                                class="{{ $e["delta"] > 0 ? "cc-list-item-good" : ($e["delta"] < 0 ? "cc-list-item-danger" : "") }}">
+                                class="ap-chip {{ $e["delta"] > 0 ? "ap-chip--trust-pos" : ($e["delta"] < 0 ? "ap-chip--trust-neg" : "ap-chip--trust-neu") }}">
                                 {{ $e["delta"] > 0 ? "+" : "" }}{{ $e["delta"] }}
                             </span>
                         </li>

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -54,7 +54,6 @@
                 investBuilding: '{{ route("colony.building.invest") }}',
                 repairBuilding: '{{ route("colony.building.repair") }}',
                 nexusImport: '{{ route("colony.nexus.import") }}',
-                stipend: '{{ route("colony.stipend") }}',
             },
             i18n: {
                 explore: '{{ __("colony.explore") }}',
@@ -78,8 +77,6 @@
                 networkError: @json(__("colony.network_error")),
                 nexusImportSuccess: @json(__("colony.nexus_import_success")),
                 nexusImportError: @json(__("colony.nexus_import_error")),
-                stipendSuccess: @json(__("colony.stipend_success")),
-                stipendError: @json(__("colony.stipend_error")),
             },
         };
     </script>
@@ -109,25 +106,10 @@
 
                 <div x-ref="hexgrid" class="hex-canvas"></div>
 
-                {{-- Info bar: phase progress + legend — always visible below canvas.
-                 The stipend button used to live here too, but this bar sits below the
-                 canvas and can scroll out of view on short viewports (see .stipend-fab
-                 below for the always-visible replacement). --}}
+                {{-- Info bar: legend — always visible below canvas. Phase progress +
+                 Kolonisten-Zulage moved to the Kommandozentrale dashboard (own screen,
+                 no popup — see routes/web.php colony.command_center). --}}
                 <div class="canvas-info-bar">
-                    <template x-if="phaseProgress">
-                        <button class="info-bar-btn" @click="$refs.phaseDialog.showModal()"
-                            :title="phaseProgress.phase === 1 ? '{{ __("colony.phase1_progress_title") }}' :
-                                '{{ __("colony.phase2_progress_title") }}'">
-                            <template x-if="phaseProgress.phase === 1">
-                                <span x-text="`P1 — ${phaseProgress.criteria.filter(c => c.done).length}/3`"></span>
-                            </template>
-                            <template x-if="phaseProgress.phase === 2">
-                                <span
-                                    x-text="`P2 — ${phaseProgress.objectives.filter(o => o.done).length}/${phaseProgress.objectives.length}`"></span>
-                            </template>
-                        </button>
-                    </template>
-
                     <details class="hex-legend">
                         <summary class="info-bar-btn">{{ __("colony.legend_title") }}</summary>
                         <ul class="hex-legend__list">
@@ -501,71 +483,6 @@
 
         </div>
 
-        {{-- Phase progress dialog -----------------------------------------------
-         Opened by the .phase-btn floating button on the canvas.
-    --}}
-        <dialog x-ref="phaseDialog" class="sol-modal" @click.self="$refs.phaseDialog.close()">
-            <article>
-                <header>
-                    <button aria-label="{{ __("colony.cancel") }}" rel="prev"
-                        @click="$refs.phaseDialog.close()"></button>
-                    <template x-if="phaseProgress && phaseProgress.phase === 1">
-                        <h3>{{ __("colony.phase1_progress_title") }}</h3>
-                    </template>
-                    <template x-if="phaseProgress && phaseProgress.phase === 2">
-                        <h3>{{ __("colony.phase2_progress_title") }}</h3>
-                    </template>
-                </header>
-                <template x-if="phaseProgress && phaseProgress.phase === 1">
-                    <ul class="phase-dialog-criteria">
-                        <template x-for="c in phaseProgress.criteria" :key="c.key">
-                            <li class="phase-criteria__item" :class="{ 'phase-criteria__item--done': c.done }">
-                                <span class="phase-criteria__check" x-text="c.done ? '✓' : '○'"></span>
-                                <span class="phase-criteria__label" x-text="c.label"></span>
-                                <span class="phase-criteria__count" x-show="!c.done"
-                                    x-text="`${c.current}/${c.target}`"></span>
-                            </li>
-                        </template>
-                    </ul>
-                </template>
-                <template x-if="phaseProgress && phaseProgress.phase === 2">
-                    <ul class="phase-dialog-criteria">
-                        <template x-for="(obj, idx) in phaseProgress.objectives" :key="idx">
-                            <li class="phase-criteria__item" :class="{ 'phase-criteria__item--done': obj.done }">
-                                <span class="phase-criteria__check" x-text="obj.done ? '✓' : '○'"></span>
-                                <span class="phase-criteria__label"
-                                    x-text="obj.revealed ? obj.label : '{{ __("colony.sol_report_phase2_objective_hidden") }}'"></span>
-                                <span class="phase-criteria__count" x-show="!obj.done && obj.revealed"
-                                    x-text="`${obj.current}/${obj.target}`"></span>
-                            </li>
-                        </template>
-                    </ul>
-                </template>
-            </article>
-        </dialog>
-
-        {{-- Kolonisten-Zulage dialog — 3 tiers, Credits→Trust one-shot event (GDD §14) --}}
-        <dialog x-ref="stipendDialog" class="sol-modal" @click.self="$refs.stipendDialog.close()">
-            <article>
-                <header>
-                    <button aria-label="{{ __("colony.cancel") }}" rel="prev"
-                        @click="$refs.stipendDialog.close()"></button>
-                    <h3>{{ __("colony.stipend_dialog_title") }}</h3>
-                </header>
-                <p>{{ __("colony.stipend_dialog_hint") }}</p>
-                <div class="stipend-tiers">
-                    @foreach (config("game.stipend.tiers") as $tierKey => $tierCfg)
-                        <button class="stipend-tier-btn" @click="doPurchaseStipend('{{ $tierKey }}')">
-                            <strong>{{ __("colony.stipend_tier_{$tierKey}") }}</strong>
-                            <span>{{ $tierCfg["cost"] }}
-                                Cr — +{{ config("game.trust.events.{$tierCfg["event_key"]}") }}
-                                {{ __("resources.res_trust") }}</span>
-                        </button>
-                    @endforeach
-                </div>
-            </article>
-        </dialog>
-
         {{-- Event discovery popup ------------------------------------------------
          Uses the native <dialog> element (PicoCSS styles it out of the box).
          x-effect watches eventDiscovery and calls the DOM API to open/close,
@@ -585,14 +502,6 @@
                 </footer>
             </article>
         </dialog>
-
-        {{-- Kolonisten-Zulage FAB — fixed to the viewport bottom-left so the action
-         stays reachable without scrolling, regardless of canvas/sidebar height
-         (Owner-Feedback: .canvas-info-bar sits below the canvas and can require
-         scrolling on short viewports). Lives at the x-data root so $refs resolves. --}}
-        <button type="button" class="stipend-fab" @click="$refs.stipendDialog.showModal()">
-            {{ __("colony.stipend_button") }}
-        </button>
 
         {{-- Action / AP-limit toast (Triggers 4 + 5) --}}
         <div class="colony-toast" :class="`colony-toast--${toastType}`" x-show="toastVisible" x-transition

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -33,9 +33,13 @@
                         request()->routeIs("colony.*") &&
                         !request()->routeIs("colony.bar*") &&
                         !request()->routeIs("colony.merchant*") &&
-                        !request()->routeIs("colony.hangar*"),
+                        !request()->routeIs("colony.hangar*") &&
+                        !request()->routeIs("colony.command_center*"),
                 ])><i
                             class="bi bi-hexagon"></i><span class="nav-label"> Kolonie</span></a></li>
+                <li><a href="{{ route("colony.command_center") }}" @class(["active" => request()->routeIs("colony.command_center*")])><i
+                            class="bi bi-diagram-2"></i><span class="nav-label">
+                            {{ __("command_center.nav_label") }}</span></a></li>
                 <li><a href="{{ route("advisors.index") }}" @class(["active" => request()->routeIs("advisors.*")])><i
                             class="bi bi-people"></i><span class="nav-label"> Berater</span></a></li>
                 @if ($sciencelabBuilt ?? false)
@@ -112,9 +116,16 @@
                                 request()->routeIs("colony.*") &&
                                 !request()->routeIs("colony.bar*") &&
                                 !request()->routeIs("colony.merchant*") &&
-                                !request()->routeIs("colony.hangar*"),
+                                !request()->routeIs("colony.hangar*") &&
+                                !request()->routeIs("colony.command_center*"),
                         ])>
                             <i class="bi bi-hexagon"></i> Kolonie
+                        </a>
+                        <a href="{{ route("colony.command_center") }}" @class([
+                            "nav-flyout-item",
+                            "active" => request()->routeIs("colony.command_center*"),
+                        ])>
+                            <i class="bi bi-diagram-2"></i> {{ __("command_center.nav_label") }}
                         </a>
                         <a href="{{ route("advisors.index") }}" @class([
                             "nav-flyout-item",
@@ -149,7 +160,8 @@
                             <span class="nav-flyout-item nav-link-locked">
                                 <i class="bi bi-cup-hot"></i>
                                 <span>Cantina
-                                    <small class="nav-flyout-locked-hint">{{ __("colony.nav_cantina_locked") }}</small>
+                                    <small
+                                        class="nav-flyout-locked-hint">{{ __("colony.nav_cantina_locked") }}</small>
                                 </span>
                             </span>
                         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Colony\BarController;
 use App\Http\Controllers\Colony\ColonyController;
+use App\Http\Controllers\Colony\CommandCenterController;
 use App\Http\Controllers\Colony\HangarController;
 use App\Http\Controllers\Colony\MerchantController;
 use App\Http\Controllers\CommLog\CommLogController;
@@ -63,6 +64,9 @@ Route::middleware('auth')->prefix('user')->name('user.')->group(function () {
 Route::middleware(['auth', 'run.started'])->prefix('colony')->name('colony.')->group(function () {
     Route::get('/view', [ColonyController::class, 'hexview'])->name('view');
     Route::patch('/name', [ColonyController::class, 'rename'])->name('rename');
+
+    // Kommandozentrale dashboard — always accessible, no build-gate (CC exists from Sol 1)
+    Route::get('/command-center', [CommandCenterController::class, 'index'])->name('command_center');
 
     // Tile actions (AJAX)
     Route::post('/tile/explore', [ColonyController::class, 'exploreTile'])->name('tile.explore');

--- a/tests/Feature/Colony/CommandCenterTest.php
+++ b/tests/Feature/Colony/CommandCenterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature\Colony;
+
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * CommandCenterTest — the Kommandozentrale dashboard (Owner-Konzept 2026-07-10).
+ * Bundles 7 widgets: Phasenziele, Kolonisten-Zulage, Run-Fortschritt, Wartungsstau,
+ * Netto-Sol-Bilanz, Berater-Kurzübersicht, Vertrauens-Ereignisse.
+ *
+ * Fixture: Bart (user_id=3) owns colony_id=1 (Springfield).
+ */
+class CommandCenterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const BART_USER_ID = 3;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function bart(): User
+    {
+        return User::find(self::BART_USER_ID);
+    }
+
+    public function test_index_loads_successfully(): void
+    {
+        $this->actingAs($this->bart())
+            ->get(route('colony.command_center'))
+            ->assertOk()
+            ->assertViewIs('colony.command_center');
+    }
+
+    public function test_nav_link_is_always_accessible_no_lock_gate(): void
+    {
+        // Unlike Hangar/Cantina, the Kommandozentrale route has no build-gate —
+        // it must be reachable even on a fresh colony with no path buildings.
+        $this->actingAs($this->bart())
+            ->get(route('colony.command_center'))
+            ->assertOk();
+    }
+
+    public function test_phase_progress_widget_shows_criteria(): void
+    {
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertOk();
+        $response->assertViewHas('phaseProgress', function ($phaseProgress) {
+            return $phaseProgress['phase'] === 1 && count($phaseProgress['criteria']) === 3;
+        });
+    }
+
+    public function test_stipend_tiers_are_passed_to_view(): void
+    {
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('stipendTiers', function ($tiers) {
+            return array_keys($tiers) === ['small', 'medium', 'large'];
+        });
+    }
+
+    public function test_maintenance_widget_shows_no_buildings_when_none_damaged(): void
+    {
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('damagedBuildings', fn ($buildings) => $buildings->isEmpty());
+    }
+
+    public function test_maintenance_widget_lists_critically_damaged_buildings(): void
+    {
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', 27)
+            ->update(['status_points' => 2]);
+
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('damagedBuildings', function ($buildings) {
+            return $buildings->count() === 1 && $buildings->first()['status_points'] === 2;
+        });
+    }
+
+    public function test_net_balance_widget_shows_no_data_before_first_sol_ends(): void
+    {
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('lastSolDeltas', fn ($deltas) => $deltas === null);
+    }
+
+    public function test_net_balance_widget_shows_cached_deltas_after_sol_ends(): void
+    {
+        Cache::put('colony:'.self::COLONY_ID.':last_sol_deltas', [
+            'regolith' => 10, 'werkstoffe' => 0, 'organika' => -5, 'credits' => 40, 'trust' => 2,
+        ], now()->addDay());
+
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('lastSolDeltas', fn ($deltas) => $deltas['credits'] === 40 && $deltas['trust'] === 2);
+    }
+
+    public function test_advisors_widget_shows_active_advisor(): void
+    {
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('advisors', function ($advisors) {
+            return $advisors->count() === 1 && $advisors->first()['rank_name'] === 'Junior';
+        });
+    }
+
+    public function test_trust_events_widget_shows_recent_events(): void
+    {
+        DB::table('trust_events')->insert([
+            ['colony_id' => self::COLONY_ID, 'tick' => 5, 'event_type' => 'stipend_small'],
+            ['colony_id' => self::COLONY_ID, 'tick' => 4, 'event_type' => 'well_fed'],
+        ]);
+
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('trustEvents', function ($events) {
+            return $events->count() === 2 && $events->first()['tick'] === 5;
+        });
+    }
+
+    public function test_run_progress_widget_shows_sol_and_nexus_debt(): void
+    {
+        $response = $this->actingAs($this->bart())->get(route('colony.command_center'));
+
+        $response->assertViewHas('currentSol');
+        $response->assertViewHas('solLimit');
+        $response->assertViewHas('nexusDebt');
+    }
+}


### PR DESCRIPTION
## Summary
- Owner-Feedback: Phasenziele-/Kolonisten-Zulage-Popups "klebten" auf dem Hex-Grid-Screen. Neuer, immer erreichbarer Screen "Kommandozentrale" (Analogie zu Hangar/Cantina), der beide ohne Popup zeigt — plus 5 neue Widgets nach game-designer-Konzept (vom Owner bestätigt): Run-Fortschritt/Sol-Countdown, Wartungsstau, Netto-Sol-Bilanz, Berater-Kurzübersicht, Vertrauens-Ereignisse.
- `ColonyController::computePhaseProgress()` war bereits in `SolReportService` dupliziert — auf `ColonyService::getPhaseProgress()` gehoben (eine Quelle für beide Screens).
- Netto-Sol-Bilanz brauchte neue (minimale) Persistenz — `SolReportService::netDeltas()` + `Cache::put()` in `SolController::next()`, kein Migration nötig.
- Alte FAB/Dialoge + zugehöriges CSS aus `hexview.blade.php`/`colony.css` entfernt.

**Basiert auf** #214 (noch nicht gemerged) — dieser Branch zweigt von `feat/kolonisten-zulage` ab, da der neue Screen direkt auf der Zulage-Funktion aufbaut (verschiebt sie vom Popup auf den neuen Screen).

## Test plan
- [x] `php artisan test` — 688 passed (677 Basis + 11 neu), unverändert 1 vorbestehender Fehler
- [x] `./bin/pint --test` + `npx prettier --check` (Blade doppelt formatiert)
- [x] 11 neue Feature-Tests: alle 7 Widgets liefern erwartete Datenform, Netto-Sol-Bilanz "keine Daten"/"echte Deltas", Nav ohne Lock-Gate erreichbar
- [x] Live per Playwright verifiziert: alle 7 Widgets zeigen echte Daten, Zulage-Kauf funktioniert identisch (Credits-Sync, Toast), Hex-Grid-Screen zeigt keine Popups/FAB mehr, Nav-Link korrekt aktiv

https://claude.ai/code/session_01N6Jcf582UpFXjcPo1KCWY1