### PR TITLE
fix: Hangar/Konsul-Ökonomie — Credits-Balance für Phase-1-Abschluss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2026-07-19
+
+Balance-Ticket Hangar/Konsul-Ökonomie (Playtest-Bot-Befund, siehe 2026-07-17 (2)) angegangen:
+
+- **Relaisvergütung umgehängt:** Housing → Uplink Station (`config/game.php: credits.relay_bonus_per_uplink_level`). Housing hat thematisch keinen Bezug zu Nexus-Relais/Sensor-Infrastruktur; Uplink Station (CC Lv2+, schon Gate für Deep-Scan/Direct-Import/Händlerfrequenz) ist die richtige Verankerung. `BuildingId::UplinkStation` (54) ergänzt.
+- **Advisor-Upkeep abgeflacht:** `[1=>10, 2=>50, 3=>160]` → `[1=>10, 2=>30, 3=>80]` Cr/Tick. Die alte Kurve machte 3 Berater auf Rang 2 (150 Cr/Tick Upkeep vs. 30 Cr/Tick Nexus-Zuschuss) strukturell unwirtschaftlich — kollabierte unabhängig vom Spielverhalten, weil laufender Upkeep (anders als die Beförderungsgebühr) nicht Credits-gated ist.
+- **Rang-Schwellen gestreckt:** `rank_thresholds` `[1=>10, 2=>20]` → `[1=>15, 2=>45]` active_ticks — mehr Zeit, Einkommensinfrastruktur (Uplink Station, Handelsvertrag) aufzubauen, bevor Upkeep steigt.
+- **Neues Einkommen "Handelsvertrag":** `credits.consul_contract_income_per_rank = [1=>10, 2=>25, 3=>45]` — Cr/Tick, wenn ein Konsul (Trader-Berater) der Kolonie zugewiesen ist UND die Cantina (Bar) gebaut ist. Schließt die Lücke, dass Bar/Cantina bisher keinen reinen Credits-Einkommenstyp bot (alle bestehenden Angebote setzen bereits vorhandenen Ressourcen-/Credits-Überschuss voraus, der nie entstand).
+- Events als Einkommensquelle bewusst zurückgestellt (Owner-Entscheidung).
+
+Playtest-Bot-Ergebnis vorher/nachher: `phase2_start_sol=-` (nie erreicht) → `phase2_start_sol=49`. Bot läuft weiterhin bis `time_limit` (Sol 95) aus, aber Phase 2 ist jetzt erreichbar — echter Fortschritt gegenüber dem strukturellen Totalkollaps davor.
+
+GDD §3/§12/§13/§18 aktualisiert (game-designer-Review). Betroffene Tests angepasst: `GameTickCreditsTest`, `GameTickAdvisorTest`, `AdvisorPromotionCostTest`, `PersonellServiceTest`, `SolReportTest`. `docs/GDD.md`-Balance-Concern bei `task_credit_reserve` von "Nach Playtest kalibrieren" auf finale Entscheidung mit Break-even-Rechnung aktualisiert.
+
+Nicht gefixt (eigenes Ticket, außerhalb Scope): `app/Console/Commands/ResetPlayer.php` setzt in mehreren Dev-Szenarien `rank`/`active_ticks`-Kombinationen hart, die mit den neuen Schwellen inkonsistent sind (z.B. rank=1 mit active_ticks=50 würde sofort promoten) — bereits unter den alten Schwellen leicht inkonsistent, kein Regressionsrisiko durch dieses Ticket.
+
+Komplette Suite grün: 723 Tests, 0 Failures.
+
 ## 2026-07-18
 
 PR #217 (Vorarbeiten Playtest-Bot) gemerged. Zweiter Ultrareview-Durchgang auf PR #218 (Playtest-Bot, jetzt gegen master statt #217) — 8 Funde, u.a. fehlendes `defaultTestSuite` in `phpunit.xml` (ein blankes `bin/phpunit` lief bislang alle Suiten inkl. der bewusst roten `playtest`-Tests mit) und `repair_critical`, das kein Construction-AP vor dem Feuern prüfte. Details siehe PR-Diskussion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Balance-Ticket Hangar/Konsul-Ökonomie (Playtest-Bot-Befund, siehe 2026-07-17 (2
 - **Rang-Schwellen gestreckt:** `rank_thresholds` `[1=>10, 2=>20]` → `[1=>15, 2=>45]` active_ticks — mehr Zeit, Einkommensinfrastruktur (Uplink Station, Handelsvertrag) aufzubauen, bevor Upkeep steigt.
 - **Neues Einkommen "Handelsvertrag":** `credits.consul_contract_income_per_rank = [1=>10, 2=>25, 3=>45]` — Cr/Tick, wenn ein Konsul (Trader-Berater) der Kolonie zugewiesen ist UND die Cantina (Bar) gebaut ist. Schließt die Lücke, dass Bar/Cantina bisher keinen reinen Credits-Einkommenstyp bot (alle bestehenden Angebote setzen bereits vorhandenen Ressourcen-/Credits-Überschuss voraus, der nie entstand).
 - Events als Einkommensquelle bewusst zurückgestellt (Owner-Entscheidung).
+- **Review-Nachtrag:** Hartcodierte Config-Fallbacks für `advisor.upkeep`/`rank_thresholds` in `GameTick` und `AdvisorController` auf die neuen Werte angeglichen (waren nur bei fehlendem Config-Key wirksam); veralteter Schwellen-Kommentar in `AdvisorPromotionCostTest` korrigiert.
 
 Playtest-Bot-Ergebnis vorher/nachher: `phase2_start_sol=-` (nie erreicht) → `phase2_start_sol=49`. Bot läuft weiterhin bis `time_limit` (Sol 95) aus, aber Phase 2 ist jetzt erreichbar — echter Fortschritt gegenüber dem strukturellen Totalkollaps davor.
 

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -887,9 +887,22 @@ class GameTick extends Command
      * Awards passive Credits income to every player colony per tick.
      *
      * Formula (GDD §3):
-     *   nexus    = game.credits.nexus_subsidy        (flat, if CC level > 0)
-     *   housing  = housingComplex.level × game.credits.tax_per_housing
-     *   total    = nexus + housing
+     *   nexus    = game.credits.nexus_subsidy               (flat, if CC level > 0)
+     *   relay    = uplinkStation.level × game.credits.relay_bonus_per_uplink_level
+     *   contract = consul_contract_income_per_rank[konsulRank]  (Konsul assigned + Cantina built)
+     *   total    = nexus + relay + contract
+     *
+     * "Relaisvergütung" is anchored on Uplink Station, not Housing — colonists'
+     * living quarters have no thematic connection to Nexus relay/sensor capacity,
+     * and Uplink Station already gates every other Nexus-facing mechanic
+     * (deep-scan cost, direct import, merchant frequency). Uplink Station is a
+     * single instance (is_instanced=0), so a plain level lookup is correct here —
+     * no summing across instances needed, unlike Housing.
+     *
+     * "Handelsvertrag" requires a Konsul (trader advisor) assigned to the colony AND
+     * the Cantina (Bar building) at level >= 1 — the Konsul brokers trade deals
+     * through it. 0 with no Konsul assigned; an intended cost of that advisor slot
+     * choice, not a bug (GDD §12 Kanal 1).
      *
      * Colonies without a CC (level = 0) are skipped — the Nexus subsidy only flows
      * once the colony is operational.  NPC colonies (user_id = null) are skipped.
@@ -899,7 +912,8 @@ class GameTick extends Command
     private function generatePassiveCredits(int $tick): int
     {
         $nexusSubsidy = (int) config('game.credits.nexus_subsidy', 30);
-        $taxPerHousing = (int) config('game.credits.tax_per_housing', 20);
+        $relayBonusPerLevel = (int) config('game.credits.relay_bonus_per_uplink_level', 20);
+        $contractIncomePerRank = config('game.credits.consul_contract_income_per_rank', [1 => 10, 2 => 25, 3 => 45]);
 
         $colonies = Colony::whereNotNull('user_id')->get();
         $processed = 0;
@@ -914,13 +928,29 @@ class GameTick extends Command
                 continue; // no CC → colony not operational → no subsidy
             }
 
-            $housingLevel = (int) DB::table('colony_buildings')
+            $uplinkLevel = (int) DB::table('colony_buildings')
                 ->where('colony_id', $colony->id)
-                ->where('building_id', BuildingId::Housing->value)
+                ->where('building_id', BuildingId::UplinkStation->value)
                 ->value('level');
 
-            $housingTax = $housingLevel * $taxPerHousing;
-            $total = $nexusSubsidy + $housingTax;
+            $relayBonus = $uplinkLevel * $relayBonusPerLevel;
+
+            $cantinaLevel = (int) DB::table('colony_buildings')
+                ->where('colony_id', $colony->id)
+                ->where('building_id', BuildingId::Bar->value)
+                ->value('level');
+
+            $contract = 0;
+            if ($cantinaLevel > 0) {
+                $konsulRank = (int) DB::table('advisors')
+                    ->where('colony_id', $colony->id)
+                    ->where('personell_id', config('advisors.trader.id', 92))
+                    ->value('rank');
+
+                $contract = (int) ($contractIncomePerRank[$konsulRank] ?? 0);
+            }
+
+            $total = $nexusSubsidy + $relayBonus + $contract;
 
             DB::table('user_resources')
                 ->where('user_id', $colony->user_id)
@@ -935,7 +965,8 @@ class GameTick extends Command
                     'parameters' => json_encode([
                         'colony_id' => $colony->id,
                         'subsidy' => $nexusSubsidy,
-                        'housing_tax' => $housingTax,
+                        'relay_bonus' => $relayBonus,
+                        'contract' => $contract,
                         'total' => $total,
                     ]),
                 ]);

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -996,7 +996,7 @@ class GameTick extends Command
      */
     private function deductAdvisorUpkeep(int $tick): int
     {
-        $upkeepByRank = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
+        $upkeepByRank = config('game.advisor.upkeep', [1 => 10, 2 => 30, 3 => 80]);
 
         $advisors = Advisor::whereNotNull('colony_id')->with('colony')->get();
 
@@ -1074,7 +1074,7 @@ class GameTick extends Command
             ->whereNotNull('colony_id')
             ->increment('active_ticks');
 
-        $thresholds = config('game.advisor.rank_thresholds', [1 => 10, 2 => 20]);
+        $thresholds = config('game.advisor.rank_thresholds', [1 => 15, 2 => 45]);
         $promotionCosts = config('game.advisor.promotion_costs', [2 => 150, 3 => 400]);
 
         foreach ($thresholds as $fromRank => $ticks) {

--- a/app/Console/Commands/GameTickDryRun.php
+++ b/app/Console/Commands/GameTickDryRun.php
@@ -96,6 +96,7 @@ class GameTickDryRun extends Command
 
         $ccLevel = (int) ($buildings->get(25)?->level ?? 0);
         $housingLevel = (int) ($buildings->get(28)?->level ?? 0);
+        $uplinkLevel = (int) ($buildings->get(54)?->level ?? 0);
 
         // ── Supply cap ────────────────────────────────────────────────────
         $capCC = (int) config('buildings.commandCenter.supply_cap', 10);
@@ -114,22 +115,33 @@ class GameTickDryRun extends Command
         // ── Credits ───────────────────────────────────────────────────────
         $credits = (int) ($colony->credits ?? 0);
         $nexus = $ccLevel > 0 ? (int) config('game.credits.nexus_subsidy', 30) : 0;
-        $housingIncome = $housingLevel * (int) config('game.credits.tax_per_housing', 20);
+        $relayBonus = $uplinkLevel * (int) config('game.credits.relay_bonus_per_uplink_level', 20);
+        $cantinaLevel = (int) ($buildings->get(52)?->level ?? 0);
 
         $advisors = DB::table('advisors')
             ->where('colony_id', $cid)
             ->whereNotNull('colony_id')
-            ->select('rank')
+            ->select('rank', 'personell_id')
             ->get();
-        $upkeepMap = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
+        $upkeepMap = config('game.advisor.upkeep', [1 => 10, 2 => 30, 3 => 80]);
         $upkeep = $advisors->sum(fn ($a) => $upkeepMap[$a->rank] ?? 10);
 
-        $creditsDelta = $nexus + $housingIncome - $upkeep;
+        $contract = 0;
+        if ($cantinaLevel > 0) {
+            $konsul = $advisors->firstWhere('personell_id', config('advisors.trader.id', 92));
+            $contractMap = config('game.credits.consul_contract_income_per_rank', [1 => 10, 2 => 25, 3 => 45]);
+            $contract = $konsul ? (int) ($contractMap[$konsul->rank] ?? 0) : 0;
+        }
+
+        $creditsDelta = $nexus + $relayBonus + $contract - $upkeep;
         $creditsNew = $credits + $creditsDelta;
 
         $incomeStr = "+{$nexus} nexus";
-        if ($housingIncome > 0) {
-            $incomeStr .= " +{$housingIncome} housing";
+        if ($relayBonus > 0) {
+            $incomeStr .= " +{$relayBonus} relay";
+        }
+        if ($contract > 0) {
+            $incomeStr .= " +{$contract} contract";
         }
         if ($upkeep > 0) {
             $incomeStr .= " -{$upkeep} upkeep";

--- a/app/Enums/BuildingId.php
+++ b/app/Enums/BuildingId.php
@@ -21,4 +21,5 @@ enum BuildingId: int
     case Sciencelab = 31;
     case Hangar = 44;
     case Bar = 52;
+    case UplinkStation = 54;
 }

--- a/app/Http/Controllers/Techtree/AdvisorController.php
+++ b/app/Http/Controllers/Techtree/AdvisorController.php
@@ -91,8 +91,8 @@ class AdvisorController extends BaseController
      */
     private function buildSlots(Collection $advisors, array $slotInfo, int $currentTick, int $colonyId): array
     {
-        $rankThresholds = config('game.advisor.rank_thresholds', [1 => 10, 2 => 20]);
-        $upkeepMap = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
+        $rankThresholds = config('game.advisor.rank_thresholds', [1 => 15, 2 => 45]);
+        $upkeepMap = config('game.advisor.upkeep', [1 => 10, 2 => 30, 3 => 80]);
         $apPerRank = config('game.advisor.ap_per_rank', [1 => 4]);
         $ccLevel = $slotInfo['cc_level'];
 
@@ -304,7 +304,7 @@ class AdvisorController extends BaseController
         $slotInfo = $this->personellService->getAdvisorSlotInfo($colonyId);
         $slots = $this->buildSlots($advisors, $slotInfo, $currentTick, $colonyId);
 
-        $upkeepMap = config('game.advisor.upkeep', [1 => 10, 2 => 50, 3 => 160]);
+        $upkeepMap = config('game.advisor.upkeep', [1 => 10, 2 => 30, 3 => 80]);
         $pageData = [
             'slots' => $slots,
             'slotInfo' => $slotInfo,

--- a/app/Services/SolReportService.php
+++ b/app/Services/SolReportService.php
@@ -414,7 +414,7 @@ class SolReportService
         ];
 
         // Passive Nexus income breakdown (Galaktischer Rat subsidy +
-        // Relaisvergütung per Wohnhabitat-Level, GDD §3) — otherwise the
+        // Relaisvergütung per Uplink-Station-Level, GDD §3) — otherwise the
         // Credits delta above has no visible source.
         foreach ($events['colony.passive_credits'] ?? [] as $params) {
             $lines[] = [

--- a/config/game.php
+++ b/config/game.php
@@ -143,7 +143,10 @@ return [
     // Advisor rank-up: cumulative active_ticks required per rank (rank => ticks).
     // Configurable so balancing can be adjusted after first playtest (see GDD §8).
     'advisor' => [
-        'rank_thresholds' => [1 => 10, 2 => 20],
+        // Stretched 2026-07-19 (was [1=>10, 2=>20]) — gives the colony time to build
+        // income infrastructure (Uplink Station, Konsul-Handelsvertrag) before upkeep
+        // escalates. See GDD §18 task_credit_reserve.
+        'rank_thresholds' => [1 => 15, 2 => 45],
         'ap_per_rank' => [1 => 4, 2 => 7, 3 => 12],
         // One-time Credits cost when advisor is promoted to this rank (keyed by target rank).
         // If user cannot afford it the promotion is deferred until next tick (ROADMAP Phase 3a).
@@ -154,7 +157,10 @@ return [
         // Credits deducted from the owning user each tick per active advisor (GDD §12).
         // Processed in GameTick after passive Credits income to prevent false-negative
         // deficits when income and upkeep fire in the same tick.
-        'upkeep' => [1 => 10, 2 => 50, 3 => 160],
+        // Flattened 2026-07-19 (was [1=>10, 2=>50, 3=>160]) — the old Rang-2 cliff made
+        // 3 advisors at rank 2 cost 150 Cr/Tick against ~30-70 Cr/Tick income, a
+        // structural collapse no player action could prevent (GDD §18 task_credit_reserve).
+        'upkeep' => [1 => 10, 2 => 30, 3 => 80],
     ],
 
     // Passive Credits income per tick (GDD §3).
@@ -162,8 +168,20 @@ return [
     'credits' => [
         // Flat Cr/Tick subsidy from the Nexus for every colony that has CC > 0.
         'nexus_subsidy' => 30,
-        // Cr/Tick per housing level (sum of all housingComplex instances in the colony).
-        'tax_per_housing' => 20,
+        // "Relaisvergütung" — Cr/Tick per Uplink Station level, paid by the Nexus for
+        // the relay/sensor infrastructure the station hosts on its network (GDD §3).
+        // Not housing-based: colonists' living quarters have no thematic connection
+        // to Nexus relay capacity, and Uplink Station (CC Lv2+, single instance) is
+        // the building that already gates every other Nexus-facing mechanic
+        // (deep-scan cost, direct import, merchant frequency).
+        'relay_bonus_per_uplink_level' => 20,
+        // "Handelsvertrag" — Cr/Tick flat income while a Konsul (trader advisor,
+        // personell_id 92) is assigned to the colony AND the Cantina (Bar, building_id
+        // 52) is built (level >= 1). Keyed by the Konsul's current rank. Represents the
+        // Konsul actively brokering trade deals through the Cantina (GDD §12 Kanal 1).
+        // 0 with no Konsul assigned — an intended cost of skipping that advisor type,
+        // not a bug. Added 2026-07-19 as part of the Phase-1 credit-collapse fix.
+        'consul_contract_income_per_rank' => [1 => 10, 2 => 25, 3 => 45],
     ],
 
     // Bar/Cantina NPC offer generation (GDD §12 Kanal 1).

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -251,8 +251,9 @@ Credits werden durch vier Quellen erworben:
 
 | Quelle | Beschreibung |
 |--------|-------------|
-| Relaisvergütung | Nexus zahlt pro Sol eine Vergütung für die Relais-/Sensor-Infrastruktur, die jedes Wohnhabitat für das Nexus-Netzwerk bereithält — abhängig vom Wohnhabitat-Level |
+| Relaisvergütung | Nexus zahlt pro Sol eine Vergütung für die Relais-/Sensor-Infrastruktur der Uplink-Station — abhängig vom Uplink-Station-Level |
 | Galaktischer Rat | Staatliche Subventionen für aktive Kolonien pro Sol (Arbeitstitel: Name noch offen) |
+| Handelsvertrag (Konsul) | Garantierte Bar-Einnahme, sobald ein Konsul zugewiesen ist und die Cantina Lv1+ steht — ≈10/25/45 Cr/Sol je Konsul-Rang (§12, §13) |
 | Handel | Einnahmen aus Handelsrouten beim Verkauf von Regolith / Organika / Werkstoffen |
 | Events | Einmalige Gutschriften durch zufällige Ereignisse |
 
@@ -1565,6 +1566,17 @@ Die Bar ist ab CC Lv2 verfügbar. Pro Sol erscheinen 0–2 Gäste — Händler, 
 
 Der Spieler entscheidet pro Angebot: annehmen oder ablehnen. **Annehmen kostet 1 Economy-AP** — dieser Sink macht den Konsul-AP-Pool spielerisch relevant.
 
+**Handelsvertrag (neue, garantierte Einnahmequelle, 2026-07-19):** Beide obigen Angebotstypen erzeugen kein Credits-Einkommen für den Spieler — sie kosten Credits (Kauf) oder sind ressourcenneutral (Tausch). Das war die Kernursache dafür, dass die Kolonie strukturell kein Credits-Einkommen aus Handel ziehen konnte (Playtest-Bot-Befund, PR #218; siehe §18 `task_credit_reserve`). Fix: kein Bar-Angebot im bisherigen Sinn (kein Karten-Slot, keine Annahme, kein AP-Kosten), sondern eine **passive Cr/Sol-Einnahme** — strukturell identisch zur Relaisvergütung (§3): sie fließt automatisch pro Tick, solange ein Konsul der Kolonie zugewiesen ist **und** die Cantina mind. Lv1 gebaut ist. Thematisch vermittelt der Konsul laufende Handelsverträge im Hintergrund; die Kolonie liefert dafür keine Ressourcen. Config-Key-Vorschlag: `game.credits.consul_contract_income_per_rank`, verarbeitet in `GameTick` im selben Schritt wie `nexus_subsidy`/`relay_bonus_per_uplink_level`. Werte nach Konsul-Rang:
+
+| Konsul-Rang | Handelsvertrag-Einkommen |
+|-------------|--------------------------|
+| Kein Konsul | 0 Cr/Sol |
+| 1 — Junior | 10 Cr/Sol |
+| 2 — Senior | 25 Cr/Sol |
+| 3 — Experte | 45 Cr/Sol |
+
+Ohne zugewiesenen Konsul entfällt diese Einnahme vollständig — **beabsichtigt**, keine versteckte Falle: die Konsul-Entscheidung bekommt dadurch einen echten wirtschaftlichen Gegenwert, den Analytiker und Raumfahrer nicht bieten. Ein Spieler ohne Konsul kompensiert über Uplink-Station-Ausbau oder trägt ein spürbares, aber wegen des hohen Credits-Fail-Schwellenwerts (> 12.000 Cr Schulden, §15) nicht sofort tödliches Defizit.
+
 **Bar-Level-Progression:**
 
 | Level | Angebots-Gültigkeit | Max. gleichzeitig aktive Angebote |
@@ -1856,10 +1868,12 @@ Jeder Berater hat einen von drei Rängen. Der Rang bestimmt den AP-Bonus pro Sol
 | Rang | Bezeichnung | AP-Bonus/Sol | Gesamt-AP/Sol | Upkeep (Cr/Sol) |
 |------|-------------|--------------|---------------|-----------------|
 | 1 | Junior | +4 | 10 | 10 |
-| 2 | Senior | +7 | 13 | 50 |
-| 3 | Experte | +12 | 18 | 160 |
+| 2 | Senior | +7 | 13 | 30 |
+| 3 | Experte | +12 | 18 | 80 |
 
 *(Gesamt-AP = 6 Grundwert + AP-Bonus)*
+
+> **Balance-Entscheidung (2026-07-19):** Upkeep-Kurve gegenüber der ursprünglichen Kalibrierung (10/50/160) abgeflacht — die alte Kurve ließ die Credits-Ökonomie strukturell kollabieren, sobald mehrere Berater gleichzeitig Rang 2 erreichten (Playtest-Bot-Befund, PR #218). Begleitend wurden die Beförderungs-Schwellen (`rank_thresholds`) von `[1=>10, 2=>20]` auf **`[1=>15, 2=>45]`** aktive Ticks gestreckt — mehr Zeit, um Uplink-Station und Cantina vor dem teureren Upkeep hochzuziehen. Volle Herleitung inkl. Break-even-Rechnung: siehe §18 Balancing-Richtlinien (`task_credit_reserve`).
 
 **Einstellungskosten (Rang 1) — typ-spezifisch:**
 
@@ -2095,7 +2109,7 @@ Die Wirkung folgt der Standard-Event-Logik (siehe "Einflussfaktoren: Ereignisse"
 
 **Nur eine Zulage pro Sol.** Die drei Stufen sind unterschiedliche Event-Keys (nicht Varianten desselben Keys) — das bestehende Dedup in `TrustService::eventContribution` fasst nur *gleiche* Keys zusammen und summiert *unterschiedliche* Keys auf. Ohne zusätzliche Sperre könnten "Klein" + "Groß" im selben Sol also zu +6 Vertrauen kombiniert werden. Das ist **nicht gewollt** und muss bei der Implementierung als eigene Regel ergänzt werden: pro Kolonie und Sol ist höchstens eine Zulagen-Stufe auslösbar (Fire-Time-Guard im Service, nicht im bestehenden Event-Dedup). Dieser Punkt ist ein expliziter Implementierungs-Hinweis, kein bereits vorhandenes Verhalten.
 
-**Kein Cooldown über mehrere Sole hinweg.** Die Staffelung ist bewusst **degressiv** (Credits pro Vertrauenspunkt steigen von 50 auf 150) — je größer die Ausschüttung, desto ineffizienter pro Credit. Das macht tägliches Wiederholen unattraktiv, ohne eine künstliche Sperre zu benötigen: Wer jeden Sol die kleine Stufe zieht, zahlt 100 Credits/Sol für einen wiederkehrenden +2-Bonus — spürbar gegenüber der Relaisvergütung (20–120 Cr/Sol, abhängig vom Wohnhabitat-Level) und dem Berater-Upkeep (50 Cr/Sol, Rang 2), aber nicht kostenlos. Zum Vergleich: der seltene Händler-Artikel "Vertrauensschub" (§12, `trust_boost`) liefert einmalig +15 Vertrauen für 600 Credits (40 Cr/Punkt) — die Kolonisten-Zulage ist bewusst *weniger* effizient pro Credit, da sie jederzeit verfügbar ist und die übrigen Vertrauensfaktoren (Gebäude, Kenntnisse, Verpflegung) nicht verdrängen soll.
+**Kein Cooldown über mehrere Sole hinweg.** Die Staffelung ist bewusst **degressiv** (Credits pro Vertrauenspunkt steigen von 50 auf 150) — je größer die Ausschüttung, desto ineffizienter pro Credit. Das macht tägliches Wiederholen unattraktiv, ohne eine künstliche Sperre zu benötigen: Wer jeden Sol die kleine Stufe zieht, zahlt 100 Credits/Sol für einen wiederkehrenden +2-Bonus — spürbar gegenüber der Relaisvergütung (20–60 Cr/Sol, abhängig vom Uplink-Station-Level) und dem Berater-Upkeep (50 Cr/Sol, Rang 2), aber nicht kostenlos. Zum Vergleich: der seltene Händler-Artikel "Vertrauensschub" (§12, `trust_boost`) liefert einmalig +15 Vertrauen für 600 Credits (40 Cr/Punkt) — die Kolonisten-Zulage ist bewusst *weniger* effizient pro Credit, da sie jederzeit verfügbar ist und die übrigen Vertrauensfaktoren (Gebäude, Kenntnisse, Verpflegung) nicht verdrängen soll.
 
 **Rationale:** Die Zulage gibt dem Spieler einen direkten, jederzeit verfügbaren Hebel auf Vertrauen — aber zu einem Preis, der die Entscheidung "Vertrauen jetzt sichern" gegen "Credits in Ausbau/Handel investieren" tatsächlich schwer macht. Die degressive Staffelung verhindert, dass die große Stufe zur Standardwahl wird; die Einmal-pro-Sol-Regel verhindert Kombination innerhalb eines Sols. Zusammen ersetzt das einen Cooldown, ohne die Reaktionsfreiheit des Spielers einzuschränken.
 
@@ -3397,7 +3411,18 @@ Bei Phase-1-Ende Sol 20 fällt Phase-2-Sol 80 exakt auf Gesamt-Sol 100 — das i
 
 > ⚠️ BALANCE CONCERN: `task_expedition_coverage: 19` (alle Colony-Zone-Tiles erkundet) ist der schwierigste Task-Target-Wert und braucht als erstes Playtest-Validierung. 19 Tiles bei ring-gestaffelten Kosten (1/2/3 Nav-AP/Ring) und einem Junior-Raumfahrer mit ~7 Nav-AP/Sol ergibt rechnerisch ~3–5 Sole reiner Erkundungsarbeit, was realistisch ist — aber stark von der Tile-Verteilung der Karte abhängt (impassable Tiles zählen nicht; auf vulkanischen Planeten könnten sehr viele Tiles aus der Zone fallen). Vor dem Finalisieren dieses Task-Targets den Colony-Zone-Expansion-Mechanismus (§4a) gegen typische Karten durchrechnen.
 
-> ⚠️ BALANCE CONCERN: `task_credit_reserve: 10` bedeutet 10 aufeinanderfolgende Sole mit Credits > 5.000. Mit Nexus-Subvention 30 Cr/Sol + Relaisvergütung (20 Cr/Sol je Housing-Level, §3) und einem Wohnhabitat Lv2 = 70 Cr/Sol Einnahmen — Upkeep für 3 Berater Rang 1 kostet 3 × 10 = 30 Cr/Sol → Nettoeinnahmen ~40 Cr/Sol. Ab Startkapital 3.000 Cr dauert es ~50 Sole ohne Ausgaben um 5.000 Cr zu erreichen. Realistische Ausgaben (Gebäude, Reparaturen) machen den Task signifikant schwieriger. Nach Playtest kalibrieren.
+> **Entschieden (2026-07-19):** `task_credit_reserve: 10` (10 aufeinanderfolgende Sole mit Credits > 5.000) war mit der alten Ökonomie strukturell unerreichbar — Playtest-Bot-Befund PR #218 bestätigt: Credits fielen auf 0 und blieben dort geklemmt, der dritte Berater wurde nie leistbar, Phase 1 nie abgeschlossen. Fix über drei Hebel (Details siehe §13 "Rang-System" und §12 "Kanal 1: Bar/Cantina"):
+>
+> 1. **Upkeep-Kurve abgeflacht:** `advisor.upkeep` von `[1=>10, 2=>50, 3=>160]` auf **`[1=>10, 2=>30, 3=>80]`**. Rang-2-Sprung war 5×, jetzt 3×; Rang-3-Sprung war 3,2×, jetzt 2,67×. Weiterhin eine echte Eskalation (teure Berater bleiben teuer), aber kein Klippensturz.
+> 2. **Beförderungs-Schwellen gestreckt:** `advisor.rank_thresholds` von `[1=>10, 2=>20]` auf **`[1=>15, 2=>45]`** aktive Ticks. Gibt dem Spieler bis Rang 2 mehr als doppelt so lange Zeit, Uplink-Station und Cantina hochzuziehen, bevor der teurere Upkeep greift.
+> 3. **Neue passive Einnahmequelle "Handelsvertrag":** Kein Bar-Angebot (kein Slot, keine Annahme, kein AP-Kosten), sondern eine passive Cr/Sol-Einnahme — strukturell identisch zur Relaisvergütung: sie fließt automatisch pro Tick, solange ein Konsul der Kolonie zugewiesen ist **und** die Cantina mind. Lv1 gebaut ist. Feste Werte nach Konsul-Rang: **Rang 1 = 10 Cr/Sol, Rang 2 = 25 Cr/Sol, Rang 3 = 45 Cr/Sol** (Config-Key-Vorschlag: `game.credits.consul_contract_income_per_rank`, verarbeitet in `GameTick` im selben Schritt wie `nexus_subsidy`/`relay_bonus_per_uplink_level`). Ohne Konsul: 0 — bewusst, siehe unten.
+>
+> **Break-even-Rechnung (Zielgröße, kein Autopilot-Sieg):** 3 Berater gleichzeitig auf Rang 2 kosten 3 × 30 = 90 Cr/Sol Upkeep.
+> - Mit Uplink-Station Lv2 (Relaisvergütung 40 Cr/Sol) + Nexus-Subvention (30 Cr/Sol, unverändert) + Handelsvertrag Rang 2 (25 Cr/Sol) = 95 Cr/Sol → **+5 Cr/Sol Überschuss**. Ein Spieler, der Uplink-Station ausbaut und einen Konsul hält, trägt drei Rang-2-Berater knapp, aber stabil.
+> - Ohne Uplink-Station (nur Subvention 30 + Handelsvertrag 25 = 55 Cr/Sol) → **-35 Cr/Sol Defizit.** Spürbarer Druck, Uplink-Station zu bauen — kein Soft-Lock, da der Credits-Fail-Schwellenwert erst bei > 12.000 Cr Schuldenstand liegt (§15): ein Defizit dieser Größe ist ein langsames Ausbluten über viele Sole, keine sofortige Niederlage.
+> - Ohne Konsul zugewiesen (z. B. Spieler wählt Analytiker + Raumfahrer als die zwei freien Slots) entfällt der Handelsvertrag komplett: Subvention 30 + Uplink Lv2 40 = 70 vs. 90 Upkeep → -20 Cr/Sol. Das ist **beabsichtigt**: die Konsul-Entscheidung hat einen echten wirtschaftlichen Preis, kein versteckter Kollaps — der Spieler kompensiert über Uplink-Ausbau, langsameres Rang-Aufsteigen (weniger aktive Nutzung) oder gelegentliche manuelle Bar-Trades.
+>
+> Bewusst **nicht** geändert: `nexus_subsidy` bleibt bei 30 Cr/Sol (kein zusätzlicher passiver Puffer — sonst nähert sich die Ökonomie einem Autopilot-Sieg an) und `promotion_costs` bleiben bei `[2=>150, 3=>400]` (das einmalige Beförderungs-Gate war nie das Problem, siehe ursprüngliche Diagnose).
 
 ---
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/mg/workspace/nouron/node_modules

--- a/resources/views/partials/debug-bar.blade.php
+++ b/resources/views/partials/debug-bar.blade.php
@@ -96,8 +96,8 @@
             <div style="color:#ff0;margin-bottom:4px;">Credits</div>
             <div><span style="color:#666;">nexus_subsidy:</span> <span
                     style="color:#ddd;">{{ $cfgCredit["nexus_subsidy"] }} Cr</span></div>
-            <div><span style="color:#666;">tax_per_housing:</span> <span
-                    style="color:#ddd;">{{ $cfgCredit["tax_per_housing"] }} Cr</span></div>
+            <div><span style="color:#666;">relay_bonus_per_uplink_level:</span> <span
+                    style="color:#ddd;">{{ $cfgCredit["relay_bonus_per_uplink_level"] }} Cr</span></div>
         </div>
 
         {{-- Trust Events --}}

--- a/tests/Feature/GameTick/AdvisorPromotionCostTest.php
+++ b/tests/Feature/GameTick/AdvisorPromotionCostTest.php
@@ -48,7 +48,7 @@ class AdvisorPromotionCostTest extends TestCase
     private const ADVISOR_PERSONELL_ID = 92;
 
     /**
-     * Threshold from config: advisor at rank 1 needs 10 active_ticks to become rank 2.
+     * Threshold from config: advisor at rank 1 needs 15 active_ticks to become rank 2.
      * Set active_ticks to threshold - 1 so that one tick push crosses the boundary.
      */
     private const RANK1_THRESHOLD = 15; // config('game.advisor.rank_thresholds')[1]

--- a/tests/Feature/GameTick/AdvisorPromotionCostTest.php
+++ b/tests/Feature/GameTick/AdvisorPromotionCostTest.php
@@ -9,7 +9,7 @@ namespace Tests\Feature\GameTick;
  * one-time Credits cost when an advisor crosses a rank threshold.
  *
  * Config:
- *   game.advisor.rank_thresholds  = [1 => 10, 2 => 20]  (active_ticks needed to promote)
+ *   game.advisor.rank_thresholds  = [1 => 15, 2 => 45]  (active_ticks needed to promote)
  *   game.advisor.promotion_costs  = [2 => 150, 3 => 400]  (Credits charged at target rank)
  *
  * Test fixture (from TestSeeder):
@@ -51,7 +51,7 @@ class AdvisorPromotionCostTest extends TestCase
      * Threshold from config: advisor at rank 1 needs 10 active_ticks to become rank 2.
      * Set active_ticks to threshold - 1 so that one tick push crosses the boundary.
      */
-    private const RANK1_THRESHOLD = 10; // config('game.advisor.rank_thresholds')[1]
+    private const RANK1_THRESHOLD = 15; // config('game.advisor.rank_thresholds')[1]
 
     private const RANK2_COST = 150; // config('game.advisor.promotion_costs')[2]
 
@@ -236,7 +236,7 @@ class AdvisorPromotionCostTest extends TestCase
         $afterFirstTick = $this->getCredits();
 
         // Second tick: advisor is now rank 2, already past rank-1 threshold.
-        // The rank-2 threshold (20 ticks) is far away — no second promotion should fire.
+        // The rank-2 threshold (45 ticks) is far away — no second promotion should fire.
         $this->runTick(9531);
         $afterSecondTick = $this->getCredits();
 

--- a/tests/Feature/GameTick/GameTickAdvisorTest.php
+++ b/tests/Feature/GameTick/GameTickAdvisorTest.php
@@ -15,8 +15,8 @@ use Tests\TestCase;
  * have their active_ticks incremented.
  *
  * When active_ticks reaches a rank threshold, the advisor is promoted:
- *   rank 1 → rank 2: requires 10 active_ticks, costs 150 Cr (one-time)
- *   rank 2 → rank 3: requires 20 active_ticks, costs 400 Cr (one-time)
+ *   rank 1 → rank 2: requires 15 active_ticks, costs 150 Cr (one-time)
+ *   rank 2 → rank 3: requires 45 active_ticks, costs 400 Cr (one-time)
  *
  * If the player cannot afford the promotion cost it is deferred until next tick.
  *
@@ -39,7 +39,7 @@ use Tests\TestCase;
  * Fixture summary (TestSeeder):
  *   Colony 1 (Springfield), user_id=3 (Bart)
  *   Seeded advisor: personell 35 (engineer), rank=1, active_ticks=0
- *   Config rank_thresholds: [1 => 10, 2 => 20]
+ *   Config rank_thresholds: [1 => 15, 2 => 45]
  *   Config promotion_costs:  [2 => 150, 3 => 400]
  *
  * Uses tick numbers 11500–11549.
@@ -53,9 +53,9 @@ class GameTickAdvisorTest extends TestCase
     private const COLONY_ID = 1;
 
     // From config/game.php
-    private const RANK1_THRESHOLD = 10;
+    private const RANK1_THRESHOLD = 15;
 
-    private const RANK2_THRESHOLD = 20;
+    private const RANK2_THRESHOLD = 45;
 
     private const RANK2_COST = 150;
 
@@ -206,13 +206,9 @@ class GameTickAdvisorTest extends TestCase
         // We need to compare two runs — simpler: just verify the exact credit delta
         // for the promotion cost after accounting for fixed income/upkeep.
 
-        // Housing=2 → income = 30 + 2×20 = 70; upkeep rank1 for two advisors = 2×10 = 20
-        // Net income (no promotion) = 70 - 20 = 50
-        // Net income (with promotion) = 70 - 20 - 150 = -100
-        // But we have TWO advisors now (rank 1). Let's simplify: remove housing to get known values.
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
+        // Housing produces no passive income (Relaisvergütung is Uplink-Station-based) —
+        // no zeroing needed there. We have TWO advisors now (rank 1); remove the second
+        // to keep the math simple.
         DB::table('advisors')->where('id', $noPromotionId)->delete();
 
         $before = $this->getCredits();
@@ -235,12 +231,8 @@ class GameTickAdvisorTest extends TestCase
     {
         $id = $this->insertAdvisor(rank: 1, activeTicks: self::RANK1_THRESHOLD - 1);
         // Ensure credits will always be below 150 even after income:
-        // income = 30 + 2×20 = 70; needed: credits + 70 < 150 → credits < 80
+        // income = 30 (nexus only, no Uplink Station); needed: credits + 30 < 150
         $this->setCredits(0);
-
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
 
         Artisan::call('game:tick', ['--tick' => 11512]);
 
@@ -263,11 +255,11 @@ class GameTickAdvisorTest extends TestCase
         $this->assertEquals(2, (int) $this->getAdvisor($id)->rank, 'Must promote on first crossing');
         $afterTick1 = $this->getCredits();
 
-        // Second tick: already rank 2, rank-2 threshold (20 ticks) is far away
+        // Second tick: already rank 2, rank-2 threshold (45 ticks) is far away
         Artisan::call('game:tick', ['--tick' => 11521]);
         $afterTick2 = $this->getCredits();
 
-        // Delta from tick2: income - upkeep (rank 2 = 50 Cr). No 150 Cr promotion.
+        // Delta from tick2: income - upkeep (rank 2 = 30 Cr). No 150 Cr promotion.
         $deltaSecond = $afterTick1 - $afterTick2;
         $this->assertLessThan(self::RANK2_COST, $deltaSecond,
             'Promotion cost must not be charged a second time after promotion is complete');

--- a/tests/Feature/GameTick/GameTickCreditsTest.php
+++ b/tests/Feature/GameTick/GameTickCreditsTest.php
@@ -12,12 +12,17 @@ use Tests\TestCase;
  * GameTick steps 8c + 8d — Passive Credits generation and Advisor upkeep.
  *
  * Step 8c — Passive Credits (generatePassiveCredits):
- *   Formula: nexus_subsidy (30) + housingComplex.level × tax_per_housing (20)
+ *   Formula: nexus_subsidy (30) + uplinkStation.level × relay_bonus_per_uplink_level (20)
+ *            + consul_contract_income_per_rank[konsulRank] (Konsul assigned + Cantina >= Lv1)
+ *   "Relaisvergütung" is anchored on Uplink Station, not Housing — colonists' living
+ *   quarters have no thematic connection to Nexus relay/sensor capacity.
+ *   "Handelsvertrag" requires a Konsul (trader advisor, personell_id 92) assigned to
+ *   the colony AND the Cantina (building_id 52) at level >= 1.
  *   Only colonies where CC level > 0 receive credits.
  *   NPC colonies (user_id = null) are skipped.
  *
  * Step 8d — Advisor upkeep (deductAdvisorUpkeep):
- *   Upkeep per rank: 1 → 10 Cr, 2 → 50 Cr, 3 → 160 Cr
+ *   Upkeep per rank: 1 → 10 Cr, 2 → 30 Cr, 3 → 80 Cr (flattened 2026-07-19, GDD §18)
  *   Deducted AFTER passive credits (so income is applied before costs).
  *   Credits clamped to ≥ 0 — never goes negative from upkeep alone.
  *   Advisors without a colony assignment incur no upkeep.
@@ -25,15 +30,19 @@ use Tests\TestCase;
  * Covered scenarios:
  *  Happy path:
  *  - Nexus subsidy (30 Cr) added each tick when CC > 0
- *  - Housing tax added per level
+ *  - Relay bonus added per Uplink Station level
+ *  - Handelsvertrag contract income added when Konsul + Cantina present
  *  - Advisor upkeep deducted (rank 1 = 10 Cr)
  *  - Net income = passive - upkeep for one rank-1 advisor
  *
  *  Edge cases:
  *  - No CC → no passive credits at all
+ *  - No Uplink Station built → nexus subsidy only
+ *  - Cantina built but no Konsul assigned → no contract income
+ *  - Konsul assigned but no Cantina built → no contract income
  *  - Advisor upkeep clamped to 0 (credits cannot go negative)
  *  - Multiple advisors: each deducts independently
- *  - Advisor rank 2 (50 Cr) and rank 3 (160 Cr) upkeep correct
+ *  - Advisor rank 2 (30 Cr) and rank 3 (80 Cr) upkeep correct
  *
  *  Adversarial:
  *  - Upkeep fires AFTER passive income (order of operations)
@@ -42,7 +51,8 @@ use Tests\TestCase;
  * Fixture summary (TestSeeder):
  *   Colony 1 (Springfield), user_id=3 (Bart)
  *     CC (building_id=25): level=3 → passive subsidy fires
- *     housing (building_id=28): level=2 → +40 Cr housing tax
+ *     No Uplink Station (building_id=54) row seeded — tests that need one insert it.
+ *     No Cantina (building_id=52) row seeded — tests that need one insert it.
  *   user_resources: user 3, credits=2700
  *   Advisor id seeded: personell 35 (engineer), colony 1, rank=1
  *
@@ -55,6 +65,8 @@ class GameTickCreditsTest extends TestCase
     private const USER_ID = 3;   // Bart
 
     private const COLONY_ID = 1;   // Springfield
+
+    private const UPLINK_BUILDING_ID = 54;
 
     protected function setUp(): void
     {
@@ -81,6 +93,38 @@ class GameTickCreditsTest extends TestCase
             ->update(['credits' => $amount]);
     }
 
+    private function setUplinkLevel(int $level): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::UPLINK_BUILDING_ID, 'instance_id' => 1],
+            ['level' => $level, 'status_points' => 20, 'tile_x' => 0, 'tile_y' => 3]
+        );
+    }
+
+    private const CANTINA_BUILDING_ID = 52;
+
+    private const KONSUL_PERSONELL_ID = 92;
+
+    private function setCantinaLevel(int $level): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::CANTINA_BUILDING_ID, 'instance_id' => 1],
+            ['level' => $level, 'status_points' => 20, 'tile_x' => 0, 'tile_y' => 4]
+        );
+    }
+
+    private function insertKonsul(int $rank): void
+    {
+        DB::table('advisors')->insert([
+            'user_id' => self::USER_ID,
+            'colony_id' => self::COLONY_ID,
+            'personell_id' => self::KONSUL_PERSONELL_ID,
+            'rank' => $rank,
+            'active_ticks' => 0,
+            'unavailable_until_tick' => null,
+        ]);
+    }
+
     /** Auto-increments personell_id to avoid UNIQUE(colony_id, personell_id) violations. */
     private int $nextPersonellId = 35;
 
@@ -101,36 +145,30 @@ class GameTickCreditsTest extends TestCase
     // ── Step 8c: Passive Credits ───────────────────────────────────────────────
 
     /**
-     * With CC > 0 and no advisor, user receives:
-     *   nexus_subsidy (30) + housing_level (2) × tax_per_housing (20) = 70 Cr per tick.
+     * With CC > 0 and an Uplink Station at level 2, user receives:
+     *   nexus_subsidy (30) + uplink_level (2) × relay_bonus_per_uplink_level (20) = 70 Cr per tick.
      */
     public function test_passive_credits_added_when_cc_is_active(): void
     {
+        $this->setUplinkLevel(2);
         $before = $this->getCredits();
 
         Artisan::call('game:tick', ['--tick' => 11400]);
 
         $after = $this->getCredits();
         $nexus = (int) config('game.credits.nexus_subsidy', 30);
-        $taxPerHousing = (int) config('game.credits.tax_per_housing', 20);
-        $housingLevel = (int) DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->value('level');
+        $relayBonusPerLevel = (int) config('game.credits.relay_bonus_per_uplink_level', 20);
 
-        $expected = $before + $nexus + ($housingLevel * $taxPerHousing);
+        $expected = $before + $nexus + (2 * $relayBonusPerLevel);
         $this->assertEquals($expected, $after,
-            'User must receive nexus_subsidy + (housing_level × tax_per_housing) per tick');
+            'User must receive nexus_subsidy + (uplink_level × relay_bonus_per_uplink_level) per tick');
     }
 
     /**
-     * Nexus subsidy alone (no housing) = 30 Cr.
+     * Nexus subsidy alone (no Uplink Station built) = 30 Cr — matches the fixture default.
      */
-    public function test_nexus_subsidy_only_when_no_housing(): void
+    public function test_nexus_subsidy_only_when_no_uplink_station(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         $before = $this->getCredits();
 
         Artisan::call('game:tick', ['--tick' => 11401]);
@@ -138,7 +176,7 @@ class GameTickCreditsTest extends TestCase
         $after = $this->getCredits();
         $expected = $before + (int) config('game.credits.nexus_subsidy', 30);
         $this->assertEquals($expected, $after,
-            'User must receive exactly nexus_subsidy (30 Cr) when there is no housing');
+            'User must receive exactly nexus_subsidy (30 Cr) when there is no Uplink Station');
     }
 
     /**
@@ -160,22 +198,19 @@ class GameTickCreditsTest extends TestCase
     }
 
     /**
-     * Higher housing level increases the housing tax contribution.
-     * Housing level 5 → 5 × 20 = 100 Cr housing tax + 30 Cr nexus = 130 Cr total.
+     * Higher Uplink Station level increases the relay bonus contribution.
+     * Uplink level 3 (max_level) → 3 × 20 = 60 Cr relay bonus + 30 Cr nexus = 90 Cr total.
      */
-    public function test_housing_tax_scales_with_housing_level(): void
+    public function test_relay_bonus_scales_with_uplink_level(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 5]);
-
+        $this->setUplinkLevel(3);
         $before = $this->getCredits();
 
         Artisan::call('game:tick', ['--tick' => 11403]);
 
         $after = $this->getCredits();
-        $expected = $before + 30 + (5 * 20); // nexus + housing
-        $this->assertEquals($expected, $after, 'Housing tax must scale with housing level');
+        $expected = $before + 30 + (3 * 20); // nexus + relay bonus
+        $this->assertEquals($expected, $after, 'Relay bonus must scale with Uplink Station level');
     }
 
     // ── Step 8d: Advisor upkeep ────────────────────────────────────────────────
@@ -183,15 +218,10 @@ class GameTickCreditsTest extends TestCase
     /**
      * A rank-1 advisor costs 10 Cr/tick (deducted after passive income).
      *
-     * Net: +30 (nexus, no housing) - 10 (upkeep) = +20 Cr.
-     * Housing is zeroed for simplicity.
+     * Net: +30 (nexus, no Uplink Station) - 10 (upkeep) = +20 Cr.
      */
     public function test_rank_1_advisor_upkeep_deducted(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         $this->insertAdvisor(1);
         $this->setCredits(1000);
 
@@ -205,61 +235,49 @@ class GameTickCreditsTest extends TestCase
     }
 
     /**
-     * A rank-2 advisor costs 50 Cr/tick.
-     * Net: +30 (nexus) - 50 (upkeep) = -20 → but credits started at 1000, so 980.
+     * A rank-2 advisor costs 30 Cr/tick.
+     * Net: +30 (nexus) - 30 (upkeep) = 0 → credits started at 1000, so 1000.
      */
     public function test_rank_2_advisor_upkeep_deducted(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         $this->insertAdvisor(2);
         $this->setCredits(1000);
 
         Artisan::call('game:tick', ['--tick' => 11411]);
 
         $after = $this->getCredits();
-        $expected = 1000 + 30 - 50; // 980
+        $expected = 1000 + 30 - 30; // 1000
         $this->assertEquals($expected, $after,
-            'Rank-2 advisor upkeep (50 Cr) must be deducted after passive income');
+            'Rank-2 advisor upkeep (30 Cr) must be deducted after passive income');
     }
 
     /**
-     * A rank-3 advisor costs 160 Cr/tick.
+     * A rank-3 advisor costs 80 Cr/tick.
      */
     public function test_rank_3_advisor_upkeep_deducted(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         $this->insertAdvisor(3);
         $this->setCredits(1000);
 
         Artisan::call('game:tick', ['--tick' => 11412]);
 
         $after = $this->getCredits();
-        $expected = 1000 + 30 - 160; // 870
+        $expected = 1000 + 30 - 80; // 950
         $this->assertEquals($expected, $after,
-            'Rank-3 advisor upkeep (160 Cr) must be deducted after passive income');
+            'Rank-3 advisor upkeep (80 Cr) must be deducted after passive income');
     }
 
     /**
      * Advisor upkeep clamps credits to 0 — never creates debt.
      *
-     * Start with 0 credits. Passive income = 30. Rank-3 upkeep = 160.
-     * 0 + 30 - 160 = -130 → clamped to 0.
+     * Start with 0 credits. Passive income = 30. Rank-3 upkeep = 80.
+     * 0 + 30 - 80 = -50 → clamped to 0.
      *
      * Actually: income is added first, then upkeep is MAX(0, credits - upkeep).
-     * After income: 0 + 30 = 30. After upkeep: MAX(0, 30 - 160) = 0.
+     * After income: 0 + 30 = 30. After upkeep: MAX(0, 30 - 80) = 0.
      */
     public function test_advisor_upkeep_clamps_credits_to_zero(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         $this->insertAdvisor(3);
         $this->setCredits(0);
 
@@ -271,15 +289,11 @@ class GameTickCreditsTest extends TestCase
 
     /**
      * Multiple advisors each deduct upkeep independently.
-     * Rank 1 (10 Cr) + Rank 2 (50 Cr) = 60 Cr total upkeep.
-     * Net: 1000 + 30 (nexus) - 60 = 970.
+     * Rank 1 (10 Cr) + Rank 2 (30 Cr) = 40 Cr total upkeep.
+     * Net: 1000 + 30 (nexus) - 40 = 990.
      */
     public function test_multiple_advisors_upkeep_deducted(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         $this->insertAdvisor(1);
         $this->insertAdvisor(2);
         $this->setCredits(1000);
@@ -287,9 +301,63 @@ class GameTickCreditsTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11414]);
 
         $after = $this->getCredits();
-        $expected = 1000 + 30 - 10 - 50; // 970
+        $expected = 1000 + 30 - 10 - 30; // 990
         $this->assertEquals($expected, $after,
             'Multiple advisor upkeep costs must all be deducted independently');
+    }
+
+    // ── Handelsvertrag (Konsul + Cantina) ──────────────────────────────────────
+
+    /**
+     * With Cantina built and a rank-2 Konsul assigned, contract income (25 Cr)
+     * is added on top of nexus subsidy, minus the Konsul's own rank-2 upkeep (30 Cr):
+     * 30 (nexus) + 25 (contract) - 30 (Konsul upkeep) = +25.
+     */
+    public function test_contract_income_added_when_konsul_and_cantina_present(): void
+    {
+        $this->setCantinaLevel(1);
+        $this->insertKonsul(2);
+        $before = $this->getCredits();
+
+        Artisan::call('game:tick', ['--tick' => 11416]);
+
+        $after = $this->getCredits();
+        $expected = $before + 30 + 25 - 30;
+        $this->assertEquals($expected, $after,
+            'Contract income must be added when a Konsul is assigned and the Cantina is built');
+    }
+
+    /**
+     * Cantina built but no Konsul assigned → no contract income, nexus subsidy only.
+     */
+    public function test_no_contract_income_without_konsul(): void
+    {
+        $this->setCantinaLevel(1);
+        $before = $this->getCredits();
+
+        Artisan::call('game:tick', ['--tick' => 11417]);
+
+        $after = $this->getCredits();
+        $expected = $before + 30;
+        $this->assertEquals($expected, $after,
+            'No contract income without a Konsul assigned, even with Cantina built');
+    }
+
+    /**
+     * Konsul assigned but no Cantina built → no contract income; nexus subsidy (30)
+     * minus the Konsul's own rank-2 upkeep (30) nets to 0.
+     */
+    public function test_no_contract_income_without_cantina(): void
+    {
+        $this->insertKonsul(2);
+        $before = $this->getCredits();
+
+        Artisan::call('game:tick', ['--tick' => 11418]);
+
+        $after = $this->getCredits();
+        $expected = $before + 30 - 30;
+        $this->assertEquals($expected, $after,
+            'No contract income without a Cantina built, even with a Konsul assigned');
     }
 
     /**
@@ -298,10 +366,6 @@ class GameTickCreditsTest extends TestCase
      */
     public function test_unassigned_advisor_has_no_upkeep(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         // One assigned (rank 1, 10 Cr)
         $this->insertAdvisor(1, self::COLONY_ID);
 
@@ -310,7 +374,7 @@ class GameTickCreditsTest extends TestCase
             'user_id' => self::USER_ID,
             'colony_id' => null,
             'personell_id' => 35,
-            'rank' => 3, // would cost 160 Cr if assigned
+            'rank' => 3, // would cost 80 Cr if assigned
             'active_ticks' => 0,
             'unavailable_until_tick' => null,
         ]);
@@ -340,10 +404,6 @@ class GameTickCreditsTest extends TestCase
      */
     public function test_passive_income_applied_before_advisor_upkeep(): void
     {
-        DB::table('colony_buildings')
-            ->where('colony_id', self::COLONY_ID)->where('building_id', 28)
-            ->update(['level' => 0]);
-
         $this->insertAdvisor(1); // upkeep = 10 Cr
         $this->setCredits(0);
 

--- a/tests/Feature/SolReportTest.php
+++ b/tests/Feature/SolReportTest.php
@@ -312,7 +312,7 @@ class SolReportTest extends TestCase
             'tick' => 7,
             'event' => 'colony.passive_credits',
             'area' => 'colony',
-            'parameters' => json_encode(['colony_id' => self::COLONY_ID, 'subsidy' => 30, 'housing_tax' => 40, 'total' => 70]),
+            'parameters' => json_encode(['colony_id' => self::COLONY_ID, 'subsidy' => 30, 'relay_bonus' => 40, 'total' => 70]),
             'created_at' => now(),
             'is_read' => 1,
         ]);

--- a/tests/Feature/Techtree/PersonellServiceTest.php
+++ b/tests/Feature/Techtree/PersonellServiceTest.php
@@ -393,35 +393,35 @@ class PersonellServiceTest extends TestCase
         $this->assertEquals(7, $unavailable->active_ticks); // unchanged
     }
 
-    public function test_rank_promotion_to_two_at_ten_ticks(): void
+    public function test_rank_promotion_to_two_at_fifteen_ticks(): void
     {
         $advisor = Advisor::create([
             'user_id' => $this->userId,
             'personell_id' => PersonellService::idFor('trader'),
             'colony_id' => $this->colonyId,
             'rank' => 1,
-            'active_ticks' => 9,
+            'active_ticks' => 14,
         ]);
 
         $this->artisan('game:tick')->assertSuccessful();
         $advisor->refresh();
-        $this->assertEquals(10, $advisor->active_ticks);
+        $this->assertEquals(15, $advisor->active_ticks);
         $this->assertEquals(2, $advisor->rank);
     }
 
-    public function test_rank_promotion_to_three_at_twenty_ticks(): void
+    public function test_rank_promotion_to_three_at_fortyfive_ticks(): void
     {
         $advisor = Advisor::create([
             'user_id' => $this->userId,
             'personell_id' => PersonellService::idFor('trader'),
             'colony_id' => $this->colonyId,
             'rank' => 2,
-            'active_ticks' => 19,
+            'active_ticks' => 44,
         ]);
 
         $this->artisan('game:tick')->assertSuccessful();
         $advisor->refresh();
-        $this->assertEquals(20, $advisor->active_ticks);
+        $this->assertEquals(45, $advisor->active_ticks);
         $this->assertEquals(3, $advisor->rank);
     }
 
@@ -442,7 +442,7 @@ class PersonellServiceTest extends TestCase
 
     public function test_rank_promotion_ap_points_reflect_new_rank_after_tick(): void
     {
-        // Start with 1 engineer at rank 1, 9 ticks — after one tick it hits 10 and promotes
+        // Start with 1 engineer at rank 1, 14 ticks — after one tick it hits 15 and promotes
         Advisor::where('colony_id', $this->colonyId)
             ->where('personell_id', PersonellService::idFor('engineer'))
             ->delete();
@@ -452,7 +452,7 @@ class PersonellServiceTest extends TestCase
             'personell_id' => PersonellService::idFor('engineer'),
             'colony_id' => $this->colonyId,
             'rank' => 1,
-            'active_ticks' => 9,
+            'active_ticks' => 14,
         ]);
 
         $this->artisan('game:tick')->assertSuccessful();


### PR DESCRIPTION
## Zusammenfassung

Balance-Ticket: Playtest-Bot (PR #218) erreichte Phase 2 nie — Credits-Ökonomie kollabierte strukturell. Root cause: Advisor-Upkeep (`10/50/160 Cr/Tick`) skaliert schneller als Einkommen; laufender Upkeep ist (anders als die Beförderungsgebühr) nicht Credits-gated, kollabiert also sobald 2+ Berater Rang 2 erreichen — unabhängig vom Spielverhalten.

- **Relaisvergütung umgehängt:** Housing → Uplink Station. Housing hat keinen thematischen Bezug zu Nexus-Relais/Sensor-Infrastruktur; Uplink Station (CC Lv2+) ist bereits Gate für Deep-Scan/Direct-Import/Händlerfrequenz.
- **Advisor-Upkeep abgeflacht:** `[1=>10, 2=>50, 3=>160]` → `[1=>10, 2=>30, 3=>80]`
- **Rang-Schwellen gestreckt:** `[1=>10, 2=>20]` → `[1=>15, 2=>45]` active_ticks
- **Neues Einkommen "Handelsvertrag":** `consul_contract_income_per_rank = [1=>10, 2=>25, 3=>45]` — Cr/Tick bei Konsul (Trader-Berater) + Cantina (Bar) gebaut. Schließt die Lücke, dass Bar bisher keinen reinen Credits-Einkommenstyp bot.
- Events als Einkommensquelle bewusst zurückgestellt (Owner-Entscheidung).
- **Review-Nachtrag:** Hartcodierte Config-Fallbacks für `advisor.upkeep`/`rank_thresholds` in `GameTick` und `AdvisorController` auf die neuen Werte angeglichen; veralteter Schwellen-Kommentar in `AdvisorPromotionCostTest` korrigiert. Kaputter self-referenzierender `node_modules`-Symlink aus Git entfernt.

Playtest-Bot vorher/nachher: `phase2_start_sol=-` (nie erreicht) → `phase2_start_sol=49`.

GDD §3/§12/§13/§18 aktualisiert (game-designer-Review inkl. Break-even-Rechnung).

## Test plan

- [x] `bin/phpunit` — 723 Tests, 0 Failures (erneut grün nach Review-Nachtrag)
- [x] `bin/phpunit --testsuite=playtest` — Bot erreicht jetzt Phase 2 (Sol 49)
- [x] Owner-Review der neuen Balance-Zahlen (Review 2026-07-19, Findings gefixt bzw. als Todos festgehalten)

https://claude.ai/code/session_01E1SgbXcCzyXAvFEBASAReN