### PR TITLE
chore: Larastan-Setup, Trust-Rename, TODO-Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Drei kleine offene Todos abgearbeitet:
 - **TickService DST-TODO geklärt:** Kein offener Punkt — Runtime läuft fest auf UTC (`AppServiceProvider::boot()`), UTC kennt keine Sommer-/Winterzeit. Kommentar entsprechend präzisiert, keine Implementierung nötig.
 - **Hangar Konsul-AP-Pool angebunden:** `verfuegbareVerhandlungsAP` liest jetzt echtes Economy-AP (`PersonellService::getEconomyPoints()`) statt hartcodiert `0` — Konsul-Rabatt-Regler im Nexus-Anfrage-Dialog ist damit erstmals nutzbar. `HangarService::requestShip()` validiert `consulApSpent` gegen verfügbares AP und sperrt es pro Tick (analog `BarService::acceptOffer()`), verhindert Mehrfachausgabe im selben Tick.
 
+Zwei weitere veraltete TODO-Kommentare bereinigt (Implementierung war bereits vorhanden, nur die Kommentare hinkten hinterher):
+
+- `config/advisors.php`: SecurityHub-Gate für den Stratege-Slot ist längst in `AdvisorController` + `PersonellService::hire()` umgesetzt.
+- `config/buildings.php`: SecurityHub `event_mitigation_pct` (25% Trust-Event-Abschwächung) ist längst in `TrustService::eventContribution()` umgesetzt.
+
 ## 2026-07-20
 
 Fortsetzung des Credit-Ökonomie-Balance-Tickets (siehe 2026-07-19): Playtest-Bot lief nach dem gestrigen Fix zwar bis Phase 2 (Sol 49), Ökonomie kollabierte danach aber weiterhin. Interaktives Brainstorming mit Owner + game-designer-Subagent ergab: Grundproduktion (Harvester/Agrardom) war zu knapp, um Puffer für Uplink-Station/Cantina/Konsul aufzubauen, bevor Berater-Upkeep zuschlägt — und Kenntnisse-Sekundäreffekte (Ressourcen-/AP-Boni) dürfen laut Owner-Vorgabe nicht die einzige Lösung sein, da Hangar/Cantina-Erstwähler sonst strukturell benachteiligt wären.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Zwei weitere veraltete TODO-Kommentare bereinigt (Implementierung war bereits vo
 - `config/advisors.php`: SecurityHub-Gate für den Stratege-Slot ist längst in `AdvisorController` + `PersonellService::hire()` umgesetzt.
 - `config/buildings.php`: SecurityHub `event_mitigation_pct` (25% Trust-Event-Abschwächung) ist längst in `TrustService::eventContribution()` umgesetzt.
 
+Code-Qualität: `larastan/larastan` (PHPStan) als Dev-Dependency + `phpstan.neon` (Level 5, `paths: app`) vorbereitet — Analyse-Lauf und Auswertung folgt, sobald `composer install` in einer Umgebung mit vollem GitHub-Zugriff nachgeholt ist (diese Sandbox-Session ist auf `nouron/nouron` beschränkt).
+
+Unittest-Review: Moral→Trust-Umbenennung (CLAUDE.md) war in Tests nur teilweise durchgezogen. `GameTickMoralTest.php` → `GameTickTrustTest.php` umbenannt (Klasse, Konstante, Helper, alle `test_moral_*`-Methoden), dazugehörige Reste in `GameTickResourceGenerationTest.php`, `OnboardingTriggersTest.php`, `PersonellServiceTest.php`, `KnowledgeServiceTest.php` sowie in `GameTick.php`/`GameTickDryRun.php` und zwei Config-Kommentaren bereinigt. Migrations bewusst unangetastet (historische Schema-Namen). Restliche Testsuite auf Auffälligkeiten geprüft (Skips, Debug-Leftover, Duplikate) — unauffällig, der eine bestehende Skip (`PlaytestBotTest`) ist bereits dokumentiert und bewusst. 672 Tests weiterhin grün.
+
 ## 2026-07-20
 
 Fortsetzung des Credit-Ökonomie-Balance-Tickets (siehe 2026-07-19): Playtest-Bot lief nach dem gestrigen Fix zwar bis Phase 2 (Sol 49), Ökonomie kollabierte danach aber weiterhin. Interaktives Brainstorming mit Owner + game-designer-Subagent ergab: Grundproduktion (Harvester/Agrardom) war zu knapp, um Puffer für Uplink-Station/Cantina/Konsul aufzubauen, bevor Berater-Upkeep zuschlägt — und Kenntnisse-Sekundäreffekte (Ressourcen-/AP-Boni) dürfen laut Owner-Vorgabe nicht die einzige Lösung sein, da Hangar/Cantina-Erstwähler sonst strukturell benachteiligt wären.

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -34,7 +34,7 @@ use Illuminate\Support\Facades\DB;
  *  4. Building decay      — decrement status_points (per-type decay_rate); level-down at ≤ 0
  *  6. Research decay      — decrement colony_researches.status_points; level-down at ≤ 0
  *  7. Supply cap          — SET user_resources.supply = CC_flat + housing_level × 8 (cap model)
- *  8. Resource generation — produce colony resources per industry building level (moral multiplier applied)
+ *  8. Resource generation — produce colony resources per industry building level (trust multiplier applied)
  *  8b. Trust calculation  — recalculate colony trust and store in colony_resources (resource_id=12)
  *  8c. Passive Credits    — Nexus subsidy (30 Cr) + colony tax per housing level (20 Cr/level) added to user Credits
  *  8d. Advisor upkeep     — deduct Credits per active advisor by rank (10/50/160 Cr); clamped to ≥ 0

--- a/app/Console/Commands/GameTickDryRun.php
+++ b/app/Console/Commands/GameTickDryRun.php
@@ -159,8 +159,8 @@ class GameTickDryRun extends Command
             ->pluck('amount', 'resource_id');
 
         $production = config('game.production_curve', []);
-        $moral = $this->trustService->getTrust($cid);
-        $multiplier = $this->trustService->getProductionMultiplier($moral);
+        $trust = $this->trustService->getTrust($cid);
+        $multiplier = $this->trustService->getProductionMultiplier($trust);
 
         $resNames = [3 => 'Regolith', 4 => 'Werkstoffe', 5 => 'Organika'];
         $this->line('  Resources:');
@@ -181,10 +181,10 @@ class GameTickDryRun extends Command
             $this->line(sprintf('    %-14s %6d → %6d  (%s)', $rname.':', $cur, $new, $yieldStr));
         }
 
-        $trustColor = $moral >= 0 ? 'green' : 'red';
+        $trustColor = $trust >= 0 ? 'green' : 'red';
         $this->line(sprintf(
             '    Trust:        <fg=%s>%d</> (production ×%.2f)',
-            $trustColor, $moral, $multiplier
+            $trustColor, $trust, $multiplier
         ));
 
         // ── Building decay ────────────────────────────────────────────────

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
+        "larastan/larastan": "^3.10",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.24",
         "laravel/sail": "^1.41",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c29afbd92692bdac951a5aef24978d2",
+    "content-hash": "f6d9c4ba9b811c951202d5278dd3ed9e",
     "packages": [
         {
             "name": "brick/math",
@@ -6197,6 +6197,137 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "iamcal/sql-parser",
+            "version": "v0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/610392f38de49a44dab08dc1659960a29874c4b8",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
+            },
+            "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
+            "name": "larastan/larastan",
+            "version": "v3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/2970f83398154178a739609c244577267c7ee8eb",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.7.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/database": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.2.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "laravel/framework": "^11.44.2 || ^12.7.2 || ^13",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
+                "phpmyadmin/sql-parser": "Install to enable Larastan's optional phpMyAdmin-based SQL parser automatically"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-28T08:00:58+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.6",
             "source": {
@@ -6763,6 +6894,70 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "reference": "909c1e5fef7989ac0d0c1c5c42e32a5c4f6198a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-05T06:31:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -8395,5 +8590,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/advisors.php
+++ b/config/advisors.php
@@ -19,8 +19,8 @@
  *     matching path building (sciencelab→scientist, hangar→pilot, bar→trader).
  *     See AdvisorController::PATH_BUILDINGS.
  *   Slot 5 (fix): strategist — gate: CC Lv3 + SecurityHub Lv1 (Pfad D).
- *     CC Lv3 check is already in AdvisorController ($ccGate=3 for 'strategist').
- *     SecurityHub check is a TODO (see AdvisorController comment "gate wired up later").
+ *     Both checks live in AdvisorController ($ccGate=3 + SecurityHub level lookup)
+ *     and are mirrored in PersonellService::hire() for the actual hire gate.
  *
  * Localization: lang/de/advisors.php
  */

--- a/config/buildings.php
+++ b/config/buildings.php
@@ -215,7 +215,7 @@ return [
     //   1. trust_per_lv = 1: passive trust bonus per level (see GDD §4).
     //   2. Event mitigation: negative trust events (building_level_down,
     //      encounter_lost, colony_threatened) reduced by 25% when Hub active
-    //      (TrustService — TODO: implement, key: securityHub_event_mitigation_pct).
+    //      (TrustService::eventContribution()).
     //   3. recycle_pct: on building level-down by decay, return 10% of build
     //      cost in tradeable resources (GameTick — partially implemented).
     //
@@ -231,7 +231,7 @@ return [
         'max_status_points' => 20,
         'max_level' => 3,
         'recycle_pct' => 0.10,                 // fraction of build cost returned on level-down
-        'event_mitigation_pct' => 0.25,        // 25% reduction on encounter/decay trust penalties (TODO: implement)
+        'event_mitigation_pct' => 0.25,        // 25% reduction on encounter/decay trust penalties (TrustService::eventContribution())
     ],
 
     // Uplink Station — CC Lv2 (Lv1), CC Lv3 (Lv2), CC Lv5 (Lv3). 1 instance (is_instanced=0).

--- a/config/game.php
+++ b/config/game.php
@@ -217,11 +217,11 @@ return [
     // Per-entity trust_per_lv / trust_per_unit values live in config/buildings.php,
     // config/techs.php and config/ships.php — TrustService reads from those files.
     'trust' => [
-        // resource_id in colony_resources where the trust value is stored (res_moral).
+        // resource_id in colony_resources where the trust value is stored (res_trust).
         'resource_id' => 12,
         // Hard cap for total ship trust contribution (before global clamp).
         'ships_cap' => 30,
-        // Production multipliers by trust band (see GDD §13 "Effekte der Moral").
+        // Production multipliers by trust band (see GDD §14 "Effekte des Vertrauens").
         'production_multiplier' => [
             ['min' => 61, 'max' => 100, 'factor' => 1.20],
             ['min' => 21, 'max' => 60, 'factor' => 1.10],

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -88,7 +88,7 @@ return [
 
     'defense' => [
         'id' => 96,
-        'trust_per_lv' => -1,      // see GDD §13 — vigilance dampens morale slightly
+        'trust_per_lv' => -1,      // see GDD §13 — vigilance dampens trust slightly
         'decay_rate' => 0,
         'max_status_points' => 20,
         'credits' => 100,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,8 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+    paths:
+        - app
+
+    level: 5

--- a/tests/Feature/GameTick/GameTickResourceGenerationTest.php
+++ b/tests/Feature/GameTick/GameTickResourceGenerationTest.php
@@ -18,14 +18,14 @@ use Tests\TestCase;
  *                                    cumulative: L1=8 L2=20 L3=32 L4=41 L5=48 L6=53 L7=56 L8=58
  *   Both capped at max_level=8 (config/buildings.php) — higher levels are not reachable.
  *
- * Production is modified by a moral multiplier. To isolate production from moral
- * drift, these tests fix the moral at 0 (multiplier = 1.0) by setting colony
- * moral resource to 0 and ensuring no moral events fire in the tick.
+ * Production is modified by a trust multiplier. To isolate production from trust
+ * drift, these tests fix trust at 0 (multiplier = 1.0) by setting colony
+ * trust resource to 0 and ensuring no trust events fire in the tick.
  *
  * Covered scenarios:
  *  Happy path:
- *  - harvester at level N generates N×10 Regolith per tick (neutral moral)
- *  - bioFacility at level N generates N×10 Organics per tick (neutral moral)
+ *  - harvester at level N generates N×10 Regolith per tick (neutral trust)
+ *  - bioFacility at level N generates N×10 Organics per tick (neutral trust)
  *  - Stacking: both buildings produce in the same tick
  *
  *  Edge cases:
@@ -58,19 +58,19 @@ class GameTickResourceGenerationTest extends TestCase
 
     private const RES_ORGANICS = 5;
 
-    private const MORAL_RES_ID = 12;
+    private const TRUST_RES_ID = 12;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->app->make(TestSeeder::class)->run();
 
-        // Fix moral at 0 for colony 1 → multiplier = 1.0 (neutral band: -20..+20)
+        // Fix trust at 0 for colony 1 → multiplier = 1.0 (neutral band: -20..+20)
         DB::table('colony_resources')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'resource_id' => self::MORAL_RES_ID],
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
             ['amount' => 0]
         );
-        // Ensure moral events table is clean (no pending events that would shift moral)
+        // Ensure trust events table is clean (no pending events that would shift trust)
         DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
 
         // Isolate production from the Organika provisioning sink (GameTick step 8a):
@@ -223,22 +223,22 @@ class GameTickResourceGenerationTest extends TestCase
         $this->assertEquals(70, $regolith, 'Harvester level 10 (beyond cap) must produce the level-8 cap yield of 70 Regolith');
     }
 
-    // ── Moral multiplier interaction ────────────────────────────────────────────
+    // ── Trust multiplier interaction ────────────────────────────────────────────
 
     /**
-     * High moral (>60) applies a 1.20× production multiplier.
+     * High trust (>60) applies a 1.20× production multiplier.
      * harvester level 5 × 10 × 1.20 = round(60) = 60.
      */
-    public function test_high_moral_applies_production_bonus(): void
+    public function test_high_trust_applies_production_bonus(): void
     {
         $this->setBuildingLevel(self::HARVESTER_ID, 5);
         DB::table('colony_buildings')
             ->where('colony_id', self::COLONY_ID)->where('building_id', self::BIO_FACILITY_ID)
             ->update(['level' => 0]);
 
-        // Set moral to 75 (Euphorisch band: +61..+100 → multiplier 1.20)
+        // Set trust to 75 (Euphorisch band: +61..+100 → multiplier 1.20)
         DB::table('colony_resources')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'resource_id' => self::MORAL_RES_ID],
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
             ['amount' => 75]
         );
         DB::table('colony_resources')->updateOrInsert(
@@ -251,23 +251,23 @@ class GameTickResourceGenerationTest extends TestCase
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
         // cumulative curve at level 5 = 52; yield = round(52 × 1.20) = 62
         $this->assertEquals(62, $regolith,
-            'Production at moral=75 must apply 1.20× multiplier → 62 Regolith');
+            'Production at trust=75 must apply 1.20× multiplier → 62 Regolith');
     }
 
     /**
-     * Low moral (<-60) applies a 0.70× production penalty.
+     * Low trust (<-60) applies a 0.70× production penalty.
      * harvester level 5 cumulative curve (52) × 0.70 = round(36.4) = 36.
      */
-    public function test_low_moral_applies_production_penalty(): void
+    public function test_low_trust_applies_production_penalty(): void
     {
         $this->setBuildingLevel(self::HARVESTER_ID, 5);
         DB::table('colony_buildings')
             ->where('colony_id', self::COLONY_ID)->where('building_id', self::BIO_FACILITY_ID)
             ->update(['level' => 0]);
 
-        // Set moral to -80 (Aufruhr band: -100..-61 → multiplier 0.70)
+        // Set trust to -80 (Aufruhr band: -100..-61 → multiplier 0.70)
         DB::table('colony_resources')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'resource_id' => self::MORAL_RES_ID],
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
             ['amount' => -80]
         );
         DB::table('colony_resources')->updateOrInsert(
@@ -280,6 +280,6 @@ class GameTickResourceGenerationTest extends TestCase
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
         // cumulative curve at level 5 = 52; yield = round(52 × 0.70) = 36
         $this->assertEquals(36, $regolith,
-            'Production at moral=-80 must apply 0.70× penalty → 36 Regolith');
+            'Production at trust=-80 must apply 0.70× penalty → 36 Regolith');
     }
 }

--- a/tests/Feature/GameTick/GameTickTrustTest.php
+++ b/tests/Feature/GameTick/GameTickTrustTest.php
@@ -42,13 +42,13 @@ use Tests\TestCase;
  *
  * Uses tick numbers 11300–11349.
  */
-class GameTickMoralTest extends TestCase
+class GameTickTrustTest extends TestCase
 {
     use RefreshDatabase;
 
     private const COLONY_ID = 1;
 
-    private const MORAL_RES_ID = 12;
+    private const TRUST_RES_ID = 12;
 
     protected function setUp(): void
     {
@@ -57,7 +57,7 @@ class GameTickMoralTest extends TestCase
 
         // Start with clean trust state
         DB::table('colony_resources')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'resource_id' => self::MORAL_RES_ID],
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
             ['amount' => 0]
         );
 
@@ -94,19 +94,19 @@ class GameTickMoralTest extends TestCase
     {
         return (int) DB::table('colony_resources')
             ->where('colony_id', self::COLONY_ID)
-            ->where('resource_id', self::MORAL_RES_ID)
+            ->where('resource_id', self::TRUST_RES_ID)
             ->value('amount');
     }
 
     private function setTrust(int $value): void
     {
         DB::table('colony_resources')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'resource_id' => self::MORAL_RES_ID],
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
             ['amount' => $value]
         );
     }
 
-    private function insertMoralEvent(string $eventType, int $tick): void
+    private function insertTrustEvent(string $eventType, int $tick): void
     {
         DB::table('trust_events')->insert([
             'colony_id' => self::COLONY_ID,
@@ -123,7 +123,7 @@ class GameTickMoralTest extends TestCase
      * With no trust_per_lv buildings, no colony ships with trust_per_unit, and no
      * events, expected trust = 0 (setUp has already zeroed these contributions).
      */
-    public function test_moral_is_stored_after_tick(): void
+    public function test_trust_is_stored_after_tick(): void
     {
         Artisan::call('game:tick', ['--tick' => 11300]);
 
@@ -138,11 +138,11 @@ class GameTickMoralTest extends TestCase
      * Pre-condition: trust at 0, no building/ship trust contribution (zeroed in setUp)
      * → result = event value = +1.
      */
-    public function test_positive_moral_event_increases_moral(): void
+    public function test_positive_trust_event_increases_trust(): void
     {
         $eventEffect = (int) config('game.trust.events.building_level_up', 1);
 
-        $this->insertMoralEvent('building_level_up', 11301);
+        $this->insertTrustEvent('building_level_up', 11301);
 
         Artisan::call('game:tick', ['--tick' => 11301]);
 
@@ -156,11 +156,11 @@ class GameTickMoralTest extends TestCase
      * A 'trade_blocked' trust event contributes a negative delta to trust.
      * setUp has already zeroed building and ship trust contributions.
      */
-    public function test_negative_moral_event_decreases_moral(): void
+    public function test_negative_trust_event_decreases_trust(): void
     {
         $eventEffect = (int) config('game.trust.events.trade_blocked', -3);
 
-        $this->insertMoralEvent('trade_blocked', 11302);
+        $this->insertTrustEvent('trade_blocked', 11302);
 
         Artisan::call('game:tick', ['--tick' => 11302]);
 
@@ -174,7 +174,7 @@ class GameTickMoralTest extends TestCase
      * Colony 1 infirmary level=1 → trust contribution = +3.
      * setUp has already zeroed all other trust-contributing buildings and ships.
      */
-    public function test_building_with_moral_per_lv_contributes_to_moral(): void
+    public function test_building_with_trust_per_lv_contributes_to_trust(): void
     {
         $infirmaryId = 46;
         $trustPerLv = (int) (config('buildings.infirmary.trust_per_lv', 3));
@@ -204,7 +204,7 @@ class GameTickMoralTest extends TestCase
      * Bar (building_id=52) has trust_per_lv=2. At level=60 → contribution=120 → clamped to 100.
      * setUp has already zeroed ships and other trust-contributing buildings.
      */
-    public function test_moral_clamped_at_positive_100(): void
+    public function test_trust_clamped_at_positive_100(): void
     {
         $barTrustPerLv = (int) config('buildings.bar.trust_per_lv', 2);
 
@@ -230,7 +230,7 @@ class GameTickMoralTest extends TestCase
      *
      * Use events from all negative-value event types and assert the result is always >= -100.
      */
-    public function test_moral_clamped_at_negative_100(): void
+    public function test_trust_clamped_at_negative_100(): void
     {
         // Strategy: use events from all negative-value event types
         // and assert the result is always >= -100.
@@ -239,7 +239,7 @@ class GameTickMoralTest extends TestCase
             ->keys();
 
         foreach ($negativeEvents as $eventType) {
-            $this->insertMoralEvent($eventType, 11311);
+            $this->insertTrustEvent($eventType, 11311);
         }
 
         Artisan::call('game:tick', ['--tick' => 11311]);
@@ -252,10 +252,10 @@ class GameTickMoralTest extends TestCase
      * Trust events are consumed in one tick and must not affect the next tick.
      * setUp has already zeroed building and ship trust contributions for isolation.
      */
-    public function test_moral_event_does_not_carry_to_next_tick(): void
+    public function test_trust_event_does_not_carry_to_next_tick(): void
     {
         // Insert event only for tick 11320 — not for tick 11321
-        $this->insertMoralEvent('building_level_up', 11320);
+        $this->insertTrustEvent('building_level_up', 11320);
 
         Artisan::call('game:tick', ['--tick' => 11320]);
         $trustAfterTick1 = $this->getTrust();
@@ -274,11 +274,11 @@ class GameTickMoralTest extends TestCase
      * 'trade_blocked' = -3; two of them → still -3 (not -6).
      * setUp has already zeroed building and ship trust contributions for isolation.
      */
-    public function test_duplicate_moral_events_same_type_do_not_stack(): void
+    public function test_duplicate_trust_events_same_type_do_not_stack(): void
     {
         // Insert the same event type twice for the same tick
-        $this->insertMoralEvent('trade_blocked', 11330);
-        $this->insertMoralEvent('trade_blocked', 11330);
+        $this->insertTrustEvent('trade_blocked', 11330);
+        $this->insertTrustEvent('trade_blocked', 11330);
 
         Artisan::call('game:tick', ['--tick' => 11330]);
 
@@ -297,7 +297,7 @@ class GameTickMoralTest extends TestCase
      * and must not affect trust.
      * setUp has already zeroed building and ship trust contributions for isolation.
      */
-    public function test_unknown_moral_event_type_is_ignored(): void
+    public function test_unknown_trust_event_type_is_ignored(): void
     {
         // TrustService::fireEvent() guards unknown types — it never inserts.
         // But what if someone directly inserts an unknown type?

--- a/tests/Feature/Onboarding/OnboardingTriggersTest.php
+++ b/tests/Feature/Onboarding/OnboardingTriggersTest.php
@@ -343,7 +343,7 @@ class OnboardingTriggersTest extends TestCase
      * When trust (resource_id=12) transitions from >= 0 (before tick) to < 0 (after
      * TrustService recalculates), the trigger must emit an onboarding_trust INNN event.
      *
-     * We drive trust negative by inserting a 'trade_blocked' moral event (value = -3)
+     * We drive trust negative by inserting a 'trade_blocked' trust event (value = -3)
      * into the trust_events table at the pinned tick (500) for this colony.
      * After the tick, TrustService will store trust = -5 in colony_resources, which
      * satisfies the onboarding_trust trigger condition (trustBefore=0 >= 0, trustAfter=-5 < 0).
@@ -353,7 +353,7 @@ class OnboardingTriggersTest extends TestCase
         // Trust starts at 0 (set in setUp); trigger not yet fired.
         $this->assertFalse($this->triggerService->hasFired($this->userId, 'onboarding_trust'));
 
-        // Insert a negative moral event at the pinned tick so TrustService produces -3.
+        // Insert a negative trust event at the pinned tick so TrustService produces -3.
         DB::table('trust_events')->insert([
             'colony_id' => $this->colonyId,
             'tick' => 500, // matches the tick pinned in setUp
@@ -362,12 +362,12 @@ class OnboardingTriggersTest extends TestCase
 
         Artisan::call('game:tick', ['--run' => $this->runId]);
 
-        $moralAfter = (int) DB::table('colony_resources')
+        $trustAfter = (int) DB::table('colony_resources')
             ->where('colony_id', $this->colonyId)
             ->where('resource_id', 12)
             ->value('amount');
 
-        $this->assertLessThan(0, $moralAfter, 'Trust must be negative after trade_blocked moral event');
+        $this->assertLessThan(0, $trustAfter, 'Trust must be negative after trade_blocked trust event');
 
         $event = ColonyLog::where('user', $this->userId)
             ->where('event', 'onboarding_trust')
@@ -395,7 +395,7 @@ class OnboardingTriggersTest extends TestCase
     {
         $this->triggerService->markFired($this->userId, 'onboarding_trust');
 
-        // Force moral to go negative via trade_blocked event.
+        // Force trust to go negative via trade_blocked event.
         DB::table('trust_events')->insert([
             'colony_id' => $this->colonyId,
             'tick' => 500,
@@ -427,7 +427,7 @@ class OnboardingTriggersTest extends TestCase
             ->where('resource_id', 12)
             ->update(['amount' => -5]);
 
-        // Also insert a moral event so the result stays negative after recalculation.
+        // Also insert a trust event so the result stays negative after recalculation.
         DB::table('trust_events')->insert([
             'colony_id' => $this->colonyId,
             'tick' => 500,
@@ -471,7 +471,7 @@ class OnboardingTriggersTest extends TestCase
             'amount' => 0,
         ]);
 
-        // Moral event for the NPC colony so trust would go negative.
+        // Trust event for the NPC colony so trust would go negative.
         DB::table('trust_events')->insert([
             'colony_id' => 9999,
             'tick' => 500,

--- a/tests/Feature/Techtree/KnowledgeServiceTest.php
+++ b/tests/Feature/Techtree/KnowledgeServiceTest.php
@@ -30,7 +30,7 @@ class KnowledgeServiceTest extends TestCase
 
     protected int $userId = 3;
 
-    // knowledge_health (94) — positive moral effect, representative for all Kenntnisse
+    // knowledge_health (94) — positive trust effect, representative for all Kenntnisse
     protected int $knowledgeId = 94;
 
     protected function setUp(): void

--- a/tests/Feature/Techtree/PersonellServiceTest.php
+++ b/tests/Feature/Techtree/PersonellServiceTest.php
@@ -317,7 +317,7 @@ class PersonellServiceTest extends TestCase
         $this->artisan('game:tick', ['--tick' => $currentTick + 1])->assertSuccessful();
 
         // After tick, available must equal total — no locked AP from the old tick applies.
-        // (Moral may change during the tick, so we compare against the new total, not tickBefore.)
+        // (Trust may change during the tick, so we compare against the new total, not tickBefore.)
         $this->assertEquals(
             $this->service->getTotalActionPoints('construction', $this->colonyId),
             $this->service->getAvailableActionPoints('construction', $this->colonyId)
@@ -459,7 +459,7 @@ class PersonellServiceTest extends TestCase
         $advisor->refresh();
 
         // After promotion to rank 2, AP must exceed rank-1 value (4).
-        // The exact value depends on the moral multiplier, so we just assert the promotion raised AP.
+        // The exact value depends on the trust multiplier, so we just assert the promotion raised AP.
         $this->assertEquals(2, $advisor->rank);
         $this->assertGreaterThan(4, $this->service->getTotalActionPoints('construction', $this->colonyId));
     }


### PR DESCRIPTION
## Summary
- Larastan (PHPStan) als Dev-Dependency eingerichtet
- moral→trust-Umbenennung in Tests und Kommentaren nachgezogen
- zwei veraltete TODO-Kommentare bereinigt

## Test plan
- [x] CHANGELOG-Eintrag vorhanden