### PR TITLE
test: Code-Coverage von 70,7 % auf 89,9 % gebracht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 2026-07-21
+## 2026-07-24
+
+PHPUnit-Code-Coverage von 70,7 % auf 89,9 % gebracht (Ziel war mittelfristig 80 %), durch gezielte Tests für die größten Lücken:
+
+- **`CommLogController`** (0%→88,5%), **`SyncConfig`** (0%→100%), **`ValidateColony`** (0%→100%), **`GameTickDryRun`** (0%→98%), **`GameSnapshot`** (0%→88,8%), **`ColonySeedDemo`** (0%→96,8%), **`ResetPlayer`** (0,6%→94,7% — größte Einzellücke), plus kleinere Dateien (`JsonController`, `ShipService`, `DbReset`, `RunResultController`, `UserController`, `LobbyController`).
+- **Echter Bug gefunden (nicht gefixt, dokumentiert):** `advisors_colony_personell_unique`-Index (`(colony_id, personell_id)`) existiert auf der aktuellen Schema nicht mehr — beim Fleet/Galaxie-Rebuild verlorengegangen. `insertOrIgnore()`-Aufrufe (z. B. `ColonySeedDemo::ensurePilotAdvisor()`) sind dadurch nicht mehr idempotent und erzeugen bei wiederholtem Aufruf Advisor-Duplikate. Test dokumentiert das aktuelle (fehlerhafte) Verhalten explizit als bekannten Bug, statt es stillschweigend als korrekt zu behaupten.
+- 848 Tests insgesamt (vorher 723 + PR #224s 725), alle grün. PHPStan weiterhin 0 Fehler.
 
 Larastan (Level 5) auf 0 Fehler gebracht (vorher 151):
 

--- a/tests/Feature/CommLog/CommLogControllerTest.php
+++ b/tests/Feature/CommLog/CommLogControllerTest.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace Tests\Feature\CommLog;
+
+use App\Models\ColonyLog;
+use App\Models\User;
+use App\Services\EventService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * CommLogController had 0% test coverage — this exercises log()/nexus() and,
+ * through them, the private decorate()/buildDescription() branches for every
+ * event type the comm log renders.
+ *
+ * Fixture: user_id=3 (Bart), colony 1 (Springfield), run 1 already active
+ * (data/sql/testdata.sqlite.sql) — no extra Run setup needed.
+ */
+class CommLogControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_ID = 3;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        // Test data pre-populates colony_log with ~14 rows for this user (playtest
+        // fixture) — clear them so each test starts from a known, empty log.
+        DB::table('colony_log')->where('user', self::USER_ID)->delete();
+    }
+
+    private function user(): User
+    {
+        return User::where('user_id', self::USER_ID)->firstOrFail();
+    }
+
+    // Mirrors EventService::createEvent()'s is_read logic (nexus events start
+    // unread, everything else starts read) so unread-count assertions match
+    // real behaviour instead of ColonyLog's own column default.
+    private function log(string $event, array $params = [], string $area = 'colony', int $tick = 10): int
+    {
+        return app(EventService::class)->createEvent([
+            'user' => self::USER_ID,
+            'tick' => $tick,
+            'event' => $event,
+            'area' => $area,
+            'parameters' => json_encode($params),
+        ]);
+    }
+
+    // ── log(): filtering ────────────────────────────────────────────────────
+
+    public function test_log_excludes_nexus_area_and_onboarding_events(): void
+    {
+        $this->log('colony.building_placed', ['building_id' => 25], area: 'colony');
+        $this->log('run.nexus_warning_sol30', [], area: 'nexus');
+        $this->log('run.run_completed', [], area: 'colony'); // nexus key, non-nexus area
+        $this->log('onboarding_decay', [], area: 'techtree');
+        $this->log('run.sol_advanced', [], area: 'colony');
+
+        $response = $this->actingAs($this->user())->get(route('comm.log'));
+
+        $response->assertOk();
+        $entries = $response->viewData('entries');
+        $this->assertCount(1, $entries);
+        $this->assertSame('colony.building_placed', $entries->first()['event']);
+    }
+
+    public function test_log_reports_unread_nexus_count(): void
+    {
+        $this->log('run.nexus_warning_sol30', [], area: 'nexus');
+        $this->log('run.nexus_warning_sol50', [], area: 'nexus');
+
+        $response = $this->actingAs($this->user())->get(route('comm.log'));
+
+        $response->assertOk();
+        $this->assertSame(2, $response->viewData('unreadCount'));
+    }
+
+    // ── nexus(): filtering + read-marking ───────────────────────────────────
+
+    public function test_nexus_includes_nexus_area_and_nexus_keys_regardless_of_area(): void
+    {
+        $this->log('run.nexus_sanction_sol65', [], area: 'colony'); // nexus key, non-nexus area
+        $this->log('run.run_failed_trust', [], area: 'nexus');
+        $this->log('colony.building_placed', ['building_id' => 25], area: 'colony');
+
+        $response = $this->actingAs($this->user())->get(route('comm.nexus'));
+
+        $response->assertOk();
+        $entries = $response->viewData('entries');
+        $this->assertCount(2, $entries);
+        $this->assertSame(0, $response->viewData('unreadCount'));
+    }
+
+    public function test_nexus_marks_entries_as_read(): void
+    {
+        $this->log('run.nexus_warning_sol30', [], area: 'nexus');
+        $this->assertSame(1, app(EventService::class)->countUnreadNexus(self::USER_ID));
+
+        $this->actingAs($this->user())->get(route('comm.nexus'))->assertOk();
+
+        $this->assertSame(0, app(EventService::class)->countUnreadNexus(self::USER_ID));
+    }
+
+    // ── decorate()/buildDescription(): one assertion per event branch ───────
+
+    public function test_building_placed_description(): void
+    {
+        $this->log('colony.building_placed', ['building_id' => 25, 'building_name' => 'building_commandCenter']);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertSame('building', $segments[0]['type']);
+        $this->assertSame(__('techtree.building_commandCenter'), $segments[0]['label']);
+        $this->assertStringContainsString('platziert', $segments[1]['value']);
+    }
+
+    public function test_building_invested_description_without_levelup(): void
+    {
+        $this->log('colony.building_invested', [
+            'building_id' => 25, 'building_name' => 'building_commandCenter',
+            'ap_spend' => 3, 'ap_for_levelup' => 10, 'level_up' => false,
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertStringContainsString('3 AP in', $segments[0]['value']);
+        $this->assertStringContainsString('7 / 10 AP', $segments[2]['value']);
+    }
+
+    public function test_building_invested_description_with_levelup(): void
+    {
+        $this->log('colony.building_invested', [
+            'building_id' => 25, 'building_name' => 'building_commandCenter',
+            'ap_spend' => 10, 'ap_for_levelup' => 10, 'level_up' => true, 'new_level' => 4,
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertSame(4, $segments[1]['tooltip']['level']);
+        $this->assertStringContainsString('Level 4 erreicht', $segments[2]['value']);
+    }
+
+    public function test_building_repaired_description(): void
+    {
+        $this->log('colony.building_repaired', [
+            'building_id' => 25, 'building_name' => 'building_commandCenter',
+            'status_points' => 15, 'max_status_points' => 20,
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertStringContainsString('15 / 20', $segments[1]['value']);
+    }
+
+    public function test_tile_deep_scanned_with_coords(): void
+    {
+        $this->log('colony.tile_deep_scanned', ['q' => 2, 'r' => -1]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $this->assertNotEmpty($entries->first()['segments']);
+    }
+
+    public function test_tile_deep_scanned_without_coords(): void
+    {
+        $this->log('colony.tile_deep_scanned', []);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $this->assertNotEmpty($entries->first()['segments']);
+    }
+
+    public function test_level_up_finished_for_knowledge(): void
+    {
+        $this->log('techtree.level_up_finished', [
+            'entity_name' => 'knowledge_cartography', 'new_level' => 2,
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertSame('knowledge', $segments[1]['type']);
+        $this->assertStringContainsString('Kenntnis', $segments[0]['value']);
+        $this->assertStringContainsString('Level 2 gestiegen', $segments[2]['value']);
+    }
+
+    public function test_level_up_finished_falls_back_to_tech_id_lookup(): void
+    {
+        // No entity_name/entity_type — resolved via tech_id against the building map.
+        $this->log('techtree.level_up_finished', ['tech_id' => 25, 'new_level' => 3]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertSame('building', $segments[1]['type']);
+        $this->assertSame(__('techtree.building_commandCenter'), $segments[1]['label']);
+    }
+
+    public function test_level_down_for_ship(): void
+    {
+        $this->log('techtree.level_down', ['entity_type' => 'ship', 'entity_name' => 'ship_scout']);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertSame('ship', $segments[1]['type']);
+        $this->assertStringContainsString('zerstört', $segments[2]['value']);
+    }
+
+    public function test_level_down_for_building(): void
+    {
+        $this->log('techtree.level_down', [
+            'entity_type' => 'building', 'entity_name' => 'building_commandCenter', 'new_level' => 2,
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertStringContainsString('auf 2 gesunken', $segments[2]['value']);
+    }
+
+    public function test_advisor_hired_with_cost(): void
+    {
+        $this->log('techtree.advisor_hired', ['advisor_type' => 'engineer', 'credits_cost' => 200]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertSame('advisor', $segments[0]['type']);
+        $this->assertStringContainsString('200 CR', $segments[1]['value']);
+    }
+
+    public function test_advisor_hired_without_cost(): void
+    {
+        $this->log('techtree.advisor_hired', ['advisor_type' => 'engineer', 'credits_cost' => 0]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertStringNotContainsString('CR', $segments[1]['value']);
+    }
+
+    public function test_bar_accepted_with_resources(): void
+    {
+        $this->log('trade.bar_accepted', [
+            'give_resource_id' => 3, 'give_amount' => 20,
+            'get_resource_id' => 4, 'get_amount' => 5,
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $segments = $entries->first()['segments'];
+
+        $this->assertSame('resource', $segments[1]['type']);
+        $this->assertSame('Regolith', $segments[1]['label']);
+    }
+
+    public function test_bar_accepted_fallback_text(): void
+    {
+        $this->log('trade.bar_accepted', []);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $this->assertNotEmpty($entries->first()['segments']);
+    }
+
+    public function test_unmapped_event_yields_empty_segments(): void
+    {
+        $this->log('some.unmapped_event', ['foo' => 'bar']);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $this->assertSame([], $entries->first()['segments']);
+    }
+
+    // ── collapseEntries(): consecutive same-key events within a Sol ─────────
+
+    public function test_consecutive_building_invested_entries_collapse(): void
+    {
+        $this->log('colony.building_invested', ['building_id' => 25, 'ap_spend' => 1], tick: 5);
+        $this->log('colony.building_invested', ['building_id' => 25, 'ap_spend' => 2], tick: 5);
+        $this->log('colony.building_invested', ['building_id' => 25, 'ap_spend' => 3], tick: 5);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+
+        // Collapsed to one representative entry (newest first) with a _collapsed count.
+        $this->assertCount(1, $entries);
+        $this->assertSame(3, $entries->first()['_collapsed']);
+    }
+
+    public function test_building_invested_entries_for_different_buildings_do_not_collapse(): void
+    {
+        $this->log('colony.building_invested', ['building_id' => 25, 'ap_spend' => 1], tick: 5);
+        $this->log('colony.building_invested', ['building_id' => 28, 'ap_spend' => 1], tick: 5);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+
+        $this->assertCount(2, $entries);
+    }
+
+    public function test_non_collapsible_events_never_merge(): void
+    {
+        $this->log('colony.renamed', [], tick: 5);
+        $this->log('colony.renamed', [], tick: 5);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+
+        $this->assertCount(2, $entries);
+    }
+
+    // ── parseParams(): legacy serialized payload fallback ────────────────────
+
+    public function test_legacy_php_serialized_parameters_are_parsed(): void
+    {
+        ColonyLog::create([
+            'user' => self::USER_ID,
+            'tick' => 5,
+            'event' => 'colony.building_placed',
+            'area' => 'colony',
+            'parameters' => serialize(['building_id' => 25, 'building_name' => 'building_commandCenter']),
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $this->assertSame(__('techtree.building_commandCenter'), $entries->first()['segments'][0]['label']);
+    }
+
+    public function test_missing_parameters_yield_empty_params(): void
+    {
+        ColonyLog::create([
+            'user' => self::USER_ID,
+            'tick' => 5,
+            'event' => 'colony.renamed',
+            'area' => 'colony',
+            'parameters' => '',
+        ]);
+
+        $entries = $this->actingAs($this->user())->get(route('comm.log'))->viewData('entries');
+        $this->assertSame([], $entries->first()['params']);
+    }
+}

--- a/tests/Feature/Console/ColonySeedDemoTest.php
+++ b/tests/Feature/Console/ColonySeedDemoTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ColonySeedDemoTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    public function test_unknown_colony_fails(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => 999999])
+            ->expectsOutputToContain('Colony 999999 not found.')
+            ->assertExitCode(1);
+    }
+
+    public function test_seeds_37_tiles_across_rings_0_to_3(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $this->assertSame(37, DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->count());
+        $this->assertEqualsCanonicalizing(
+            [0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->pluck('ring')->all()
+        );
+    }
+
+    public function test_command_center_tile_is_empty_terrain(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $cc = DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->where('q', 0)->where('r', 0)->first();
+        $this->assertSame('terrain_empty', $cc->tile_type);
+        $this->assertSame(0, $cc->resource_max);
+    }
+
+    public function test_harvester_tile_is_regolith_rich_with_resources(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $tile = DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)->first();
+        $this->assertSame('regolith_rich', $tile->tile_type);
+        $this->assertGreaterThan(0, $tile->resource_max);
+        $this->assertGreaterThan(0, $tile->resource_amount);
+        $this->assertLessThan($tile->resource_max, $tile->resource_amount);
+    }
+
+    public function test_forced_ring3_events_are_placed(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $events = DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('ring', 3)->whereNotNull('event_type')
+            ->pluck('event_type', DB::raw("q || ',' || r"));
+
+        $this->assertSame('event_ruin', DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 0)->where('r', 3)->value('event_type'));
+        $this->assertSame('event_crystal', DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', -3)->where('r', 2)->value('event_type'));
+        $this->assertSame('event_cache', DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 0)->where('r', -3)->value('event_type'));
+        $this->assertSame('event_wreck', DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 2)->where('r', -3)->value('event_type'));
+    }
+
+    public function test_all_tiles_are_explored_and_ring3_partially_deep_scanned(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('is_explored', false)->count());
+
+        $ring3DeepScanned = DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('ring', 3)->where('is_deep_scanned', true)->count();
+        // ~67% of 18 ring-3 tiles per the seed formula — just assert it's a mix, not all-or-nothing.
+        $this->assertGreaterThan(0, $ring3DeepScanned);
+        $this->assertLessThan(18, $ring3DeepScanned);
+    }
+
+    public function test_building_placements_and_levels_are_applied(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $cc = DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 25)->first();
+        $this->assertSame(0, $cc->tile_x);
+        $this->assertSame(0, $cc->tile_y);
+        $this->assertSame(5, $cc->level);
+
+        $harvester = DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 27)->first();
+        $this->assertSame(3, $harvester->tile_x);
+        $this->assertSame(1, $harvester->level);
+    }
+
+    public function test_unplaced_buildings_are_cleared_to_available(): void
+    {
+        // infirmary (46) is deliberately left unplaced.
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => 46],
+            ['tile_x' => 9, 'tile_y' => 9, 'level' => 3, 'status_points' => 20, 'ap_spend' => 0]
+        );
+
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $infirmary = DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 46)->first();
+        $this->assertNull($infirmary->tile_x);
+        $this->assertNull($infirmary->tile_y);
+        $this->assertSame(0, $infirmary->level);
+    }
+
+    public function test_ensures_pilot_advisor_exists(): void
+    {
+        DB::table('advisors')->where('colony_id', self::COLONY_ID)
+            ->where('personell_id', config('advisors.pilot.id'))->delete();
+
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $this->assertSame(1, DB::table('advisors')
+            ->where('colony_id', self::COLONY_ID)->where('personell_id', config('advisors.pilot.id'))->count());
+    }
+
+    /**
+     * KNOWN BUG (found 2026-07-24, not fixed here — out of scope for a coverage
+     * pass): the `advisors_colony_personell_unique` partial index
+     * (colony_id, personell_id) that insertOrIgnore() relies on for idempotency
+     * no longer exists on the current schema — lost during a later table rebuild
+     * (galaxy/fleet removal). ensurePilotAdvisor() is NOT actually idempotent;
+     * this test documents the current (buggy) behavior rather than asserting the
+     * intended one, so it doesn't silently regress further.
+     */
+    public function test_ensure_pilot_advisor_currently_duplicates_on_rerun_known_bug(): void
+    {
+        DB::table('advisors')->where('colony_id', self::COLONY_ID)
+            ->where('personell_id', config('advisors.pilot.id'))->delete();
+
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $this->assertSame(2, DB::table('advisors')
+            ->where('colony_id', self::COLONY_ID)->where('personell_id', config('advisors.pilot.id'))->count());
+    }
+
+    public function test_rerun_clears_previous_tiles_instead_of_duplicating(): void
+    {
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+        $this->artisan('colony:seed-demo', ['colony_id' => self::COLONY_ID])->assertExitCode(0);
+
+        $this->assertSame(37, DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->count());
+    }
+}

--- a/tests/Feature/Console/DbResetTest.php
+++ b/tests/Feature/Console/DbResetTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Tests\TestCase;
+
+/**
+ * DbReset had 0% test coverage. Safe to actually run here — the test environment
+ * always points at the in-memory sqlite connection (phpunit.xml), never the real
+ * dev database (data/db/nouron.db).
+ *
+ * Deliberately NOT using RefreshDatabase: migrate:fresh's underlying wipe (VACUUM)
+ * cannot run inside RefreshDatabase's wrapping transaction ("cannot VACUUM from
+ * within a transaction") — this command performs its own full reset per test.
+ */
+class DbResetTest extends TestCase
+{
+    public function test_aborts_without_confirmation(): void
+    {
+        $this->artisan('db:reset')
+            ->expectsConfirmation('Are you sure?', 'no')
+            ->expectsOutputToContain('Aborted.')
+            ->assertExitCode(0);
+    }
+
+    public function test_confirmed_resets_and_seeds_the_database(): void
+    {
+        $this->artisan('db:reset')
+            ->expectsConfirmation('Are you sure?', 'yes')
+            ->expectsOutputToContain('Resetting database...')
+            ->expectsOutputToContain('Done. Database has been reset and seeded.')
+            ->assertExitCode(0);
+    }
+
+    public function test_force_flag_skips_confirmation(): void
+    {
+        $this->artisan('db:reset', ['--force' => true])
+            ->doesntExpectOutputToContain('This will DELETE all data')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/Console/GameSnapshotTest.php
+++ b/tests/Feature/Console/GameSnapshotTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class GameSnapshotTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_ID = 3; // Bart
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        Storage::fake('local');
+    }
+
+    public function test_unknown_action_fails(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'nuke', 'user' => 'bart'])
+            ->expectsOutputToContain('Unknown action: nuke')
+            ->assertExitCode(1);
+    }
+
+    public function test_unknown_user_by_name_fails(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'list', 'user' => 'nobody'])
+            ->expectsOutputToContain('User not found: nobody')
+            ->assertExitCode(1);
+    }
+
+    public function test_resolves_user_by_numeric_id(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'list', 'user' => (string) self::USER_ID])
+            ->assertExitCode(0);
+    }
+
+    public function test_list_with_no_snapshots(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'list', 'user' => 'bart'])
+            ->expectsOutputToContain("Keine Snapshots für 'Bart'.")
+            ->assertExitCode(0);
+    }
+
+    public function test_save_then_list_shows_the_snapshot(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'save', 'user' => 'bart', 'label' => 'pre-blocker'])
+            ->expectsOutputToContain("Snapshot 'pre-blocker' gespeichert")
+            ->assertExitCode(0);
+
+        Storage::assertExists('snapshots/'.self::USER_ID.'/pre-blocker.json');
+
+        $this->artisan('game:snapshot', ['action' => 'list', 'user' => 'bart'])
+            ->assertExitCode(0);
+    }
+
+    public function test_save_overwrite_requires_confirmation_and_aborts_on_no(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'save', 'user' => 'bart', 'label' => 'x'])->assertExitCode(0);
+
+        $this->artisan('game:snapshot', ['action' => 'save', 'user' => 'bart', 'label' => 'x'])
+            ->expectsConfirmation("Snapshot 'x' existiert bereits — überschreiben?", 'no')
+            ->expectsOutputToContain('Aborted.')
+            ->assertExitCode(0);
+    }
+
+    public function test_save_overwrite_with_yes_flag_skips_confirmation(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'save', 'user' => 'bart', 'label' => 'x'])->assertExitCode(0);
+
+        $this->artisan('game:snapshot', ['action' => 'save', 'user' => 'bart', 'label' => 'x', '--yes' => true])
+            ->expectsOutputToContain("Snapshot 'x' gespeichert")
+            ->assertExitCode(0);
+    }
+
+    public function test_restore_missing_snapshot_fails(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'restore', 'user' => 'bart', 'label' => 'ghost'])
+            ->expectsOutputToContain('Snapshot not found: ghost')
+            ->assertExitCode(1);
+    }
+
+    public function test_restore_roundtrip_recreates_saved_state(): void
+    {
+        $originalRegolith = (int) DB::table('colony_resources')
+            ->where('colony_id', 1)->where('resource_id', 3)->value('amount');
+
+        $this->artisan('game:snapshot', ['action' => 'save', 'user' => 'bart', 'label' => 'checkpoint', '--yes' => true])
+            ->assertExitCode(0);
+
+        // Mutate live state after the snapshot was taken.
+        DB::table('colony_resources')->where('colony_id', 1)->where('resource_id', 3)->update(['amount' => 999999]);
+
+        $this->artisan('game:snapshot', ['action' => 'restore', 'user' => 'bart', 'label' => 'checkpoint', '--yes' => true])
+            ->expectsOutputToContain("Snapshot 'checkpoint' wiederhergestellt")
+            ->assertExitCode(0);
+
+        $restored = (int) DB::table('colony_resources')
+            ->where('colony_id', 1)->where('resource_id', 3)->value('amount');
+        $this->assertSame($originalRegolith, $restored);
+    }
+
+    public function test_restore_requires_confirmation_and_aborts_on_no(): void
+    {
+        $this->artisan('game:snapshot', ['action' => 'save', 'user' => 'bart', 'label' => 'checkpoint', '--yes' => true])
+            ->assertExitCode(0);
+
+        $this->artisan('game:snapshot', ['action' => 'restore', 'user' => 'bart', 'label' => 'checkpoint'])
+            ->expectsConfirmation(
+                "Aktuellen Spielstand von 'Bart' durch Snapshot 'checkpoint' (Sol 5) ersetzen?",
+                'no'
+            )
+            ->expectsOutputToContain('Aborted.')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/Console/GameTickDryRunTest.php
+++ b/tests/Feature/Console/GameTickDryRunTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * GameTickDryRun had 0% coverage — a read-only diagnostic display, safe to
+ * exercise fully (no DB writes, per its own docblock).
+ */
+class GameTickDryRunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const USER_ID = 3;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    public function test_no_colonies_found_warns_and_fails(): void
+    {
+        $this->artisan('game:tick-dry-run', ['--colony' => 999999])
+            ->expectsOutputToContain('No colonies found.')
+            ->assertExitCode(1);
+    }
+
+    public function test_all_colonies_mode_renders_header(): void
+    {
+        $this->artisan('game:tick-dry-run')
+            ->expectsOutputToContain('Tick Dry-Run')
+            ->assertExitCode(0);
+    }
+
+    public function test_single_colony_filter_shows_only_that_colony(): void
+    {
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('ID:'.self::COLONY_ID)
+            ->assertExitCode(0);
+    }
+
+    public function test_npc_colony_shows_npc_fallback_for_username(): void
+    {
+        DB::table('glx_colonies')->where('id', self::COLONY_ID)->update(['user_id' => null]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('User: NPC')
+            ->assertExitCode(0);
+    }
+
+    public function test_supply_cap_increase_is_shown(): void
+    {
+        DB::table('user_resources')->where('user_id', self::USER_ID)->update(['supply' => 1]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('Supply cap:')
+            ->assertExitCode(0);
+    }
+
+    public function test_supply_cap_decrease_when_command_center_missing(): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 25)
+            ->update(['level' => 0]);
+        DB::table('user_resources')->where('user_id', self::USER_ID)->update(['supply' => 50]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('Supply cap:')
+            ->assertExitCode(0);
+    }
+
+    public function test_cantina_contract_income_is_included_when_konsul_assigned(): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => 52],
+            ['level' => 1, 'status_points' => 20, 'ap_spend' => 0]
+        );
+        DB::table('advisors')->where('colony_id', self::COLONY_ID)->delete();
+        DB::table('advisors')->insert([
+            'user_id' => self::USER_ID,
+            'personell_id' => config('advisors.trader.id', 92),
+            'colony_id' => self::COLONY_ID,
+            'rank' => 2,
+            'active_ticks' => 0,
+        ]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('contract')
+            ->assertExitCode(0);
+    }
+
+    public function test_resource_production_yield_is_shown_for_built_harvester(): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => 27],
+            ['level' => 3, 'status_points' => 20, 'ap_spend' => 0]
+        );
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('Regolith:')
+            ->assertExitCode(0);
+    }
+
+    public function test_building_decay_level_down_flag_when_status_points_would_hit_zero(): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 27)
+            ->update(['level' => 1, 'status_points' => 0.1]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('LEVEL DOWN')
+            ->assertExitCode(0);
+    }
+
+    public function test_building_decay_critical_flag_below_20_percent(): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 27)
+            ->update(['level' => 1, 'status_points' => 3]);
+        DB::table('buildings')->where('id', 27)->update(['decay_rate' => 0, 'max_status_points' => 20]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('critical')
+            ->assertExitCode(0);
+    }
+
+    public function test_building_decay_attention_flag_between_20_and_40_percent(): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 27)
+            ->update(['level' => 1, 'status_points' => 6]);
+        DB::table('buildings')->where('id', 27)->update(['decay_rate' => 0, 'max_status_points' => 20]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('attention')
+            ->assertExitCode(0);
+    }
+
+    public function test_overcap_decay_factor_applied_when_supply_exceeds_cap(): void
+    {
+        DB::table('user_resources')->where('user_id', self::USER_ID)->update(['supply' => 0]);
+
+        $this->artisan('game:tick-dry-run', ['--colony' => self::COLONY_ID])
+            ->expectsOutputToContain('Over supply cap')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Feature/Console/ResetPlayerTest.php
+++ b/tests/Feature/Console/ResetPlayerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Models\Colony;
+use App\Models\Run;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * ResetPlayer had 0.6% test coverage — the biggest single gap in the codebase.
+ * Each scenario method is largely a straight-line sequence of DB writes with
+ * little branching, so one successful run per scenario (non-interactive via
+ * --yes --scenario=X) exercises the bulk of it; a handful of assertions per
+ * scenario confirm the documented resulting state (tick/trust/credits/etc.).
+ */
+class ResetPlayerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_ID = 3; // Bart
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function colony(): Colony
+    {
+        return Colony::where('user_id', self::USER_ID)->latest('id')->firstOrFail();
+    }
+
+    private function activeRun(): Run
+    {
+        return Run::where('user_id', self::USER_ID)->where('status', 'active')->latest('id')->firstOrFail();
+    }
+
+    // ── User/scenario resolution + confirmation ──────────────────────────────
+
+    public function test_unknown_user_by_name_fails(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'nobody', '--yes' => true, '--scenario' => 'fresh'])
+            ->expectsOutputToContain('User not found: nobody')
+            ->assertExitCode(1);
+    }
+
+    public function test_unknown_scenario_fails(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'bogus'])
+            ->expectsOutputToContain('Unknown scenario: bogus')
+            ->assertExitCode(1);
+    }
+
+    public function test_resolves_user_by_numeric_id(): void
+    {
+        $this->artisan('game:reset-player', [
+            'user' => (string) self::USER_ID, '--yes' => true, '--scenario' => 'fresh',
+        ])->assertExitCode(0);
+    }
+
+    public function test_aborts_without_confirmation(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--scenario' => 'fresh'])
+            ->expectsConfirmation('Alle Spielerdaten löschen und Szenario anwenden?', 'no')
+            ->expectsOutputToContain('Aborted.')
+            ->assertExitCode(0);
+    }
+
+    // ── fresh ─────────────────────────────────────────────────────────────────
+
+    public function test_fresh_scenario_resets_to_sol1(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'fresh'])
+            ->expectsOutputToContain('reset to Sol 1')
+            ->assertExitCode(0);
+
+        $run = $this->activeRun();
+        $this->assertSame(1, $run->phase);
+        $this->assertSame(0, $run->current_tick);
+    }
+
+    // ── pre-phase2 ────────────────────────────────────────────────────────────
+
+    public function test_pre_phase2_scenario_sets_documented_state(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'pre-phase2'])
+            ->expectsOutputToContain("Scenario 'pre-phase2' applied.")
+            ->assertExitCode(0);
+
+        $colony = $this->colony();
+        $run = $this->activeRun();
+
+        $this->assertSame(1, $run->phase); // still Phase 1 — one hire short
+        $this->assertSame(12, $run->current_tick);
+        $this->assertSame(2400, DB::table('user_resources')->where('user_id', self::USER_ID)->value('credits'));
+        $this->assertSame(3, DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)->where('building_id', 25)->value('level'));
+        $this->assertSame(2, DB::table('advisors')->where('colony_id', $colony->id)->count());
+    }
+
+    // ── phase2 ────────────────────────────────────────────────────────────────
+
+    public function test_phase2_scenario_transitions_to_phase2_with_objectives(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'phase2'])
+            ->assertExitCode(0);
+
+        $run = $this->activeRun();
+        $this->assertSame(2, $run->phase);
+        $this->assertSame(15, $run->current_tick);
+        $this->assertSame(12, $run->phase2_start_tick);
+        $this->assertSame(3, $run->objectives()->count());
+        $this->assertSame(3, DB::table('advisors')->where('colony_id', $run->colony_id)->count());
+    }
+
+    // ── near-fail-trust ───────────────────────────────────────────────────────
+
+    public function test_near_fail_trust_scenario_sets_low_trust(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'near-fail-trust'])
+            ->assertExitCode(0);
+
+        $colony = $this->colony();
+        $run = $this->activeRun();
+
+        $this->assertSame(30, $run->current_tick);
+        $this->assertSame(-15, DB::table('colony_resources')
+            ->where('colony_id', $colony->id)->where('resource_id', 12)->value('amount'));
+    }
+
+    // ── near-deadline ─────────────────────────────────────────────────────────
+
+    public function test_near_deadline_scenario_sets_tick_near_limit_and_completes_one_objective(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'near-deadline'])
+            ->assertExitCode(0);
+
+        $run = $this->activeRun();
+        $this->assertSame((int) config('game.run.tick_limit', 100) - 5, $run->current_tick);
+
+        $objectives = $run->objectives()->orderBy('id')->get();
+        $this->assertSame(3, $objectives->count());
+        $this->assertNotNull($objectives->first()->completed_at);
+        $this->assertGreaterThan(0, $objectives->get(1)->current_value);
+        $this->assertNull($objectives->get(1)->completed_at);
+
+        // 4th advisor (trader/Konsul) hired after Cantina built.
+        $this->assertSame(4, DB::table('advisors')->where('colony_id', $run->colony_id)->count());
+
+        // Harvester relocated off its Phase-1 tile by exploreTilesAndMoveHarvester().
+        $harvesterTile = DB::table('colony_buildings')
+            ->where('colony_id', $run->colony_id)->where('building_id', 27)->first(['tile_x', 'tile_y']);
+        $this->assertNotSame([1, 0], [$harvesterTile->tile_x, $harvesterTile->tile_y]);
+    }
+
+    // ── objectives-done ───────────────────────────────────────────────────────
+
+    public function test_objectives_done_scenario_completes_all_objectives(): void
+    {
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'objectives-done'])
+            ->assertExitCode(0);
+
+        $run = $this->activeRun();
+        $this->assertSame(60, $run->current_tick);
+
+        $objectives = $run->objectives()->get();
+        $this->assertSame(3, $objectives->count());
+        foreach ($objectives as $objective) {
+            $this->assertSame(40, $objective->completed_at);
+            $this->assertSame($objective->target_value, $objective->current_value);
+        }
+
+        // engineer + scientist upgraded to Senior (rank 2) for the "Expertenstab" objective.
+        $seniorCount = DB::table('advisors')
+            ->where('colony_id', $run->colony_id)
+            ->whereIn('personell_id', [(int) config('advisors.engineer.id'), (int) config('advisors.scientist.id')])
+            ->where('rank', 2)
+            ->count();
+        $this->assertSame(2, $seniorCount);
+
+        // 5 advisors total (engineer, scientist, pilot, trader, strategist).
+        $this->assertSame(5, DB::table('advisors')->where('colony_id', $run->colony_id)->count());
+    }
+
+    // ── wipe behavior ─────────────────────────────────────────────────────────
+
+    public function test_reset_wipes_previous_colony_state_before_reapplying(): void
+    {
+        // Leave some stale state from the seed data's default colony.
+        $oldColonyId = $this->colony()->id;
+
+        $this->artisan('game:reset-player', ['user' => 'bart', '--yes' => true, '--scenario' => 'fresh'])
+            ->assertExitCode(0);
+
+        // Exactly one active run and one colony remain for this user.
+        $this->assertSame(1, Run::where('user_id', self::USER_ID)->where('status', 'active')->count());
+        $this->assertSame(1, DB::table('glx_colonies')->where('user_id', self::USER_ID)->count());
+    }
+}

--- a/tests/Feature/Console/SyncConfigTest.php
+++ b/tests/Feature/Console/SyncConfigTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SyncConfigTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    public function test_reports_no_changes_on_a_second_run(): void
+    {
+        // Fresh seed data isn't guaranteed to already match config (that's the whole
+        // point of this command) — sync once, then the second run must be a no-op.
+        $this->artisan('game:sync-config')->assertExitCode(0);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain('Everything is already in sync')
+            ->assertExitCode(0);
+    }
+
+    public function test_updates_a_drifted_ship_column(): void
+    {
+        DB::table('ships')->where('id', 37)->update(['moving_speed' => 999]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain('[ship]')
+            ->assertExitCode(0);
+
+        $this->assertSame(4, (int) DB::table('ships')->where('id', 37)->value('moving_speed'));
+    }
+
+    public function test_updates_a_drifted_building_column(): void
+    {
+        DB::table('buildings')->where('id', 25)->update(['max_status_points' => 1]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain('[building]')
+            ->assertExitCode(0);
+
+        $this->assertNotSame(1, (int) DB::table('buildings')->where('id', 25)->value('max_status_points'));
+    }
+
+    public function test_dry_run_previews_without_writing(): void
+    {
+        DB::table('ships')->where('id', 37)->update(['moving_speed' => 999]);
+
+        $this->artisan('game:sync-config', ['--dry-run' => true])
+            ->expectsOutputToContain('DRY RUN')
+            ->expectsOutputToContain('[ship]')
+            ->assertExitCode(0);
+
+        $this->assertSame(999, (int) DB::table('ships')->where('id', 37)->value('moving_speed'));
+    }
+
+    public function test_ship_config_entry_missing_id_is_skipped_with_warning(): void
+    {
+        config(['ships.broken' => ['moving_speed' => 1]]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain("ships/broken: missing 'id' — skipped.")
+            ->assertExitCode(0);
+    }
+
+    public function test_ship_config_entry_with_unknown_id_is_skipped_with_warning(): void
+    {
+        config(['ships.ghost' => ['id' => 999999]]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain('ships/ghost: id=999999 not found in DB — skipped.')
+            ->assertExitCode(0);
+    }
+
+    public function test_building_config_entry_missing_id_is_skipped_with_warning(): void
+    {
+        config(['buildings.broken' => ['decay_rate' => 1]]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain("buildings/broken: missing 'id' — skipped.")
+            ->assertExitCode(0);
+    }
+
+    public function test_building_config_entry_with_unknown_id_is_skipped_with_warning(): void
+    {
+        config(['buildings.ghost' => ['id' => 999999]]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain('buildings/ghost: id=999999 not found in DB — skipped.')
+            ->assertExitCode(0);
+    }
+
+    public function test_building_max_level_syncs_to_configured_value(): void
+    {
+        // commandCenter (id=25) has an explicit max_level (5) in config.
+        DB::table('buildings')->where('id', 25)->update(['max_level' => 7]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain('[building]')
+            ->assertExitCode(0);
+
+        $this->assertSame(5, (int) DB::table('buildings')->where('id', 25)->value('max_level'));
+    }
+
+    /**
+     * When config omits 'max_level' entirely, isset($cfg['max_level']) is false and
+     * the sync intentionally falls back to whatever's already in the DB (never
+     * writes null) — housingComplex's config always defines it, so simulate the
+     * omission via a config override to exercise that fallback branch.
+     */
+    public function test_building_max_level_untouched_when_absent_from_config(): void
+    {
+        $key = collect(config('buildings'))->search(fn ($cfg) => ($cfg['id'] ?? null) === 28);
+        $withoutMaxLevel = collect(config("buildings.{$key}"))->except('max_level')->all();
+        config(["buildings.{$key}" => $withoutMaxLevel]);
+        DB::table('buildings')->where('id', 28)->update(['max_level' => 9]);
+
+        $this->artisan('game:sync-config')->assertExitCode(0);
+
+        $this->assertSame(9, (int) DB::table('buildings')->where('id', 28)->value('max_level'));
+    }
+
+    public function test_syncs_building_costs_from_config(): void
+    {
+        DB::table('building_costs')->where('building_id', 25)->whereIn('resource_id', [3, 4])->delete();
+        DB::table('building_costs')->insert(['building_id' => 25, 'resource_id' => 3, 'amount' => 1]);
+
+        $this->artisan('game:sync-config')
+            ->expectsOutputToContain('[build_cost]')
+            ->assertExitCode(0);
+    }
+
+    public function test_reports_total_row_count_across_ships_and_buildings(): void
+    {
+        DB::table('ships')->where('id', 37)->update(['moving_speed' => 999]);
+        DB::table('buildings')->where('id', 25)->update(['max_status_points' => 1]);
+
+        // The summary line can word-wrap in the test runner's assumed terminal
+        // width, splitting a naive substring search across two writes — assert
+        // on the actual DB effect instead of matching output text.
+        $this->artisan('game:sync-config')->assertExitCode(0);
+
+        $this->assertSame(4, (int) DB::table('ships')->where('id', 37)->value('moving_speed'));
+        $this->assertSame(20, (int) DB::table('buildings')->where('id', 25)->value('max_status_points'));
+    }
+}

--- a/tests/Feature/Console/ValidateColonyTest.php
+++ b/tests/Feature/Console/ValidateColonyTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Enums\BuildingId;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ValidateColonyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    public function test_unknown_colony_id_reports_not_found_and_fails(): void
+    {
+        $this->artisan('game:validate-colony', ['colony_id' => 999999])
+            ->expectsOutputToContain('Colony 999999 not found.')
+            ->assertExitCode(1);
+    }
+
+    public function test_healthy_colony_exits_zero_with_no_errors(): void
+    {
+        // Bring supply usage within cap and CC to a healthy level for a clean run.
+        DB::table('user_resources')->where('user_id', 3)->update(['supply' => 999]);
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => 12],
+            ['amount' => 25]
+        );
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->assertExitCode(0);
+    }
+
+    public function test_missing_active_run_warns(): void
+    {
+        DB::table('runs')->where('colony_id', self::COLONY_ID)->delete();
+        DB::table('user_resources')->where('user_id', 3)->update(['supply' => 999]);
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->expectsOutputToContain('No active run for colony')
+            ->assertExitCode(0);
+    }
+
+    public function test_supply_overrun_is_an_error(): void
+    {
+        DB::table('user_resources')->where('user_id', 3)->update(['supply' => 0]);
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->expectsOutputToContain('Supply overrun')
+            ->assertExitCode(1);
+    }
+
+    public function test_missing_command_center_is_an_error(): void
+    {
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('building_id', BuildingId::CommandCenter->value)
+            ->update(['level' => 0]);
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->expectsOutputToContain('CommandCenter missing or level 0')
+            ->assertExitCode(1);
+    }
+
+    public function test_missing_trust_resource_row_warns(): void
+    {
+        DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)->where('resource_id', 12)->delete();
+        DB::table('user_resources')->where('user_id', 3)->update(['supply' => 999]);
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->expectsOutputToContain('Trust resource row missing')
+            ->assertExitCode(0);
+    }
+
+    public function test_critically_low_trust_warns(): void
+    {
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => 12],
+            ['amount' => -60]
+        );
+        DB::table('user_resources')->where('user_id', 3)->update(['supply' => 999]);
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->expectsOutputToContain('Trust critically low: -60')
+            ->assertExitCode(0);
+    }
+
+    public function test_current_tick_exceeding_limit_is_an_error(): void
+    {
+        DB::table('runs')->where('colony_id', self::COLONY_ID)->where('status', 'active')
+            ->update(['current_tick' => 500, 'settings' => json_encode(['tick_limit' => 100])]);
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->expectsOutputToContain('exceeds tick_limit=100')
+            ->assertExitCode(1);
+    }
+
+    public function test_current_tick_within_limit_is_ok(): void
+    {
+        DB::table('runs')->where('colony_id', self::COLONY_ID)->where('status', 'active')
+            ->update(['current_tick' => 5, 'settings' => json_encode(['tick_limit' => 100])]);
+        DB::table('user_resources')->where('user_id', 3)->update(['supply' => 999]);
+
+        $this->artisan('game:validate-colony', ['colony_id' => self::COLONY_ID])
+            ->expectsOutputToContain('current_tick=5 / 100')
+            ->assertExitCode(0);
+    }
+
+    public function test_without_colony_id_checks_all_colonies(): void
+    {
+        $this->artisan('game:validate-colony')
+            ->assertExitCode(1); // Shelbyville (colony 2) has no CC etc. — expected to surface issues
+    }
+}

--- a/tests/Feature/LobbyControllerTest.php
+++ b/tests/Feature/LobbyControllerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Run;
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * LobbyController::newRun() is already heavily covered by LobbyNewRunTest — this
+ * file covers the rest: index() (listing + the auto-redirect-to-result branch),
+ * abandon(), start(), and newRun()'s "no colony" fallback.
+ */
+class LobbyControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_ID = 3;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        // Seed data ships an active run (id 1) for this user — clear it so each
+        // test starts from a known run-less state.
+        Run::where('user_id', self::USER_ID)->delete();
+    }
+
+    private function user(): User
+    {
+        return User::where('user_id', self::USER_ID)->firstOrFail();
+    }
+
+    private function makeRun(string $status, ?string $startedAt = '2026-01-01 00:00:00'): Run
+    {
+        return Run::create([
+            'user_id' => self::USER_ID,
+            'colony_id' => self::COLONY_ID,
+            'current_tick' => 5,
+            'status' => $status,
+            'started_at' => $startedAt,
+            'phase' => 1,
+        ]);
+    }
+
+    // ── index() ───────────────────────────────────────────────────────────
+
+    public function test_index_lists_pending_active_and_finished_runs(): void
+    {
+        $this->makeRun('active', startedAt: null); // pending
+        $this->makeRun('completed');
+
+        $response = $this->actingAs($this->user())->get(route('lobby'));
+
+        $response->assertOk();
+        $response->assertViewHas('pending', fn ($c) => $c->count() === 1);
+        $response->assertViewHas('finished', fn ($c) => $c->count() === 1);
+    }
+
+    public function test_index_shows_active_run_without_redirect(): void
+    {
+        $this->makeRun('active');
+
+        $response = $this->actingAs($this->user())->get(route('lobby'));
+
+        $response->assertOk();
+        $response->assertViewHas('active', fn ($c) => $c->count() === 1);
+    }
+
+    public function test_index_redirects_to_result_when_latest_run_just_ended(): void
+    {
+        $run = $this->makeRun('completed');
+
+        $response = $this->actingAs($this->user())->get(route('lobby'));
+
+        $response->assertRedirect(route('run.result', $run->id));
+    }
+
+    public function test_index_does_not_redirect_when_an_active_run_still_exists(): void
+    {
+        // A finished run exists, but so does an active one — must not redirect.
+        $this->makeRun('completed');
+        $this->makeRun('active');
+
+        $response = $this->actingAs($this->user())->get(route('lobby'));
+
+        $response->assertOk();
+    }
+
+    public function test_index_includes_finished_run_highscore_data(): void
+    {
+        $run = $this->makeRun('completed');
+        $run->update(['score' => 4200, 'ended_at' => now()]);
+        $this->makeRun('active'); // avoid the auto-redirect-to-result branch
+
+        $response = $this->actingAs($this->user())->get(route('lobby'));
+
+        $finishedRuns = $response->viewData('finishedRuns');
+        $this->assertSame(4200, $finishedRuns->first()['score']);
+    }
+
+    // ── abandon() ─────────────────────────────────────────────────────────
+
+    public function test_abandon_marks_active_run_as_failed(): void
+    {
+        $run = $this->makeRun('active');
+
+        $response = $this->actingAs($this->user())->post(route('lobby.abandon', $run->id));
+
+        $response->assertRedirect(route('lobby'));
+        $this->assertSame('failed', $run->fresh()->status);
+        $this->assertNotNull($run->fresh()->ended_at);
+    }
+
+    public function test_abandon_rejects_non_active_run(): void
+    {
+        $run = $this->makeRun('completed');
+
+        $response = $this->actingAs($this->user())->post(route('lobby.abandon', $run->id));
+
+        $response->assertRedirect(route('lobby'));
+        $response->assertSessionHas('error');
+        $this->assertSame('completed', $run->fresh()->status);
+    }
+
+    public function test_abandon_forbids_other_users_run(): void
+    {
+        $run = Run::create([
+            'user_id' => 1, // Homer
+            'colony_id' => 2,
+            'current_tick' => 1,
+            'status' => 'active',
+            'phase' => 1,
+        ]);
+
+        $response = $this->actingAs($this->user())->post(route('lobby.abandon', $run->id));
+
+        $response->assertForbidden();
+    }
+
+    // ── start() ───────────────────────────────────────────────────────────
+
+    public function test_start_marks_pending_run_as_started(): void
+    {
+        $run = $this->makeRun('active', startedAt: null);
+
+        $response = $this->actingAs($this->user())->post(route('lobby.start'));
+
+        $response->assertRedirect(route('colony.view'));
+        $this->assertNotNull($run->fresh()->started_at);
+    }
+
+    public function test_start_without_pending_run_returns_404(): void
+    {
+        $response = $this->actingAs($this->user())->post(route('lobby.start'));
+
+        $response->assertNotFound();
+    }
+
+    // ── newRun(): "no colony" fallback ───────────────────────────────────────
+
+    public function test_new_run_without_colony_shows_error(): void
+    {
+        DB::table('glx_colonies')->where('user_id', self::USER_ID)->update(['user_id' => null]);
+
+        $response = $this->actingAs($this->user())->post(route('run.new'));
+
+        $response->assertRedirect(route('lobby'));
+        $response->assertSessionHas('error');
+    }
+}

--- a/tests/Feature/Resources/JsonControllerTest.php
+++ b/tests/Feature/Resources/JsonControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature\Resources;
+
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * JsonController had 0% test coverage — this is also a regression guard for the
+ * larastan fix (2026-07-21) where the constructor called parent::__construct()
+ * without the required TickService, which would have thrown on every request.
+ */
+class JsonControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_ID = 3;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function user(): User
+    {
+        return User::where('user_id', self::USER_ID)->firstOrFail();
+    }
+
+    public function test_get_resources_returns_all_resource_types_keyed_by_id(): void
+    {
+        $response = $this->actingAs($this->user())->getJson(route('resources.index'));
+
+        $response->assertOk();
+        $response->assertJsonPath('3.name', 'res_regolith');
+    }
+
+    public function test_get_colony_resources_returns_amounts_keyed_by_resource_id(): void
+    {
+        $response = $this->actingAs($this->user())
+            ->getJson(route('resources.colony', ['id' => self::COLONY_ID]));
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertArrayHasKey(3, $json);
+        $this->assertSame(3, $json[3]['resource_id']);
+        $this->assertArrayHasKey('amount', $json[3]);
+    }
+
+    public function test_reload_resourcebar_renders_partial_with_merged_metadata(): void
+    {
+        $response = $this->actingAs($this->user())->get(route('resources.resourcebar'));
+
+        $response->assertOk();
+        $response->assertHeader('X-IC-Refresh', 'false');
+        $response->assertSee('Rg', false); // regolith icon label from resources.name
+    }
+}

--- a/tests/Feature/RunResultControllerTest.php
+++ b/tests/Feature/RunResultControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Run;
+use App\Models\RunObjective;
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RunResultControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_ID = 3;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function user(): User
+    {
+        return User::where('user_id', self::USER_ID)->firstOrFail();
+    }
+
+    private function makeRun(string $status): Run
+    {
+        $run = Run::create([
+            'user_id' => self::USER_ID,
+            'colony_id' => self::COLONY_ID,
+            'current_tick' => 20,
+            'status' => $status,
+            'phase' => 2,
+        ]);
+
+        RunObjective::create([
+            'run_id' => $run->id,
+            'task_key' => 'task_senior_advisors',
+            'target_value' => 5,
+            'current_value' => 5,
+        ]);
+
+        return $run;
+    }
+
+    public function test_completed_run_shows_result_screen(): void
+    {
+        $run = $this->makeRun('completed');
+
+        $response = $this->actingAs($this->user())->get(route('run.result', ['id' => $run->id]));
+
+        $response->assertOk();
+        $response->assertViewHas('score');
+        $response->assertViewHas('objectives');
+    }
+
+    public function test_active_run_redirects_to_colony_view(): void
+    {
+        $run = $this->makeRun('active');
+
+        $response = $this->actingAs($this->user())->get(route('run.result', ['id' => $run->id]));
+
+        $response->assertRedirect(route('colony.view'));
+    }
+
+    public function test_other_users_run_is_forbidden(): void
+    {
+        $otherUserId = 1; // Homer
+        $run = Run::create([
+            'user_id' => $otherUserId,
+            'colony_id' => 2,
+            'current_tick' => 20,
+            'status' => 'completed',
+            'phase' => 2,
+        ]);
+
+        $response = $this->actingAs($this->user())->get(route('run.result', ['id' => $run->id]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_unknown_run_returns_404(): void
+    {
+        $response = $this->actingAs($this->user())->get(route('run.result', ['id' => 999999]));
+
+        $response->assertNotFound();
+    }
+
+    public function test_admin_dev_preview_shows_result_for_active_run(): void
+    {
+        $run = $this->makeRun('active');
+        $admin = $this->user();
+        $admin->role = 'admin';
+        $admin->save();
+
+        $response = $this->actingAs($admin)
+            ->get(route('run.result', ['id' => $run->id]).'?preview=1&outcome=failed');
+
+        $response->assertOk();
+        $response->assertViewHas('run', fn (Run $r) => $r->status === 'failed');
+    }
+}

--- a/tests/Feature/Techtree/ShipServiceTest.php
+++ b/tests/Feature/Techtree/ShipServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\Techtree;
+
+use App\Services\Techtree\ShipService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * ShipService had 0% test coverage. checkRequiredResearchesByEntityId() is the
+ * one method it overrides beyond the shared AbstractTechnologyService contract —
+ * ships may additionally require a research at a minimum level before leveling up.
+ */
+class ShipServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const SHIP_ID = 37; // ship_corvette — no research requirement in seed data
+
+    private const RESEARCH_ID = 90; // construction
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function service(): ShipService
+    {
+        return app(ShipService::class);
+    }
+
+    public function test_ship_without_required_research_always_passes(): void
+    {
+        $this->assertTrue(
+            $this->service()->checkRequiredResearchesByEntityId(self::COLONY_ID, self::SHIP_ID)
+        );
+    }
+
+    public function test_ship_with_required_research_but_colony_has_none_fails(): void
+    {
+        DB::table('ships')->where('id', self::SHIP_ID)
+            ->update(['required_research_id' => self::RESEARCH_ID, 'required_research_level' => 2]);
+
+        $this->assertFalse(
+            $this->service()->checkRequiredResearchesByEntityId(self::COLONY_ID, self::SHIP_ID)
+        );
+    }
+
+    public function test_ship_with_research_below_required_level_fails(): void
+    {
+        DB::table('ships')->where('id', self::SHIP_ID)
+            ->update(['required_research_id' => self::RESEARCH_ID, 'required_research_level' => 2]);
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => self::RESEARCH_ID],
+            ['level' => 1, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $this->assertFalse(
+            $this->service()->checkRequiredResearchesByEntityId(self::COLONY_ID, self::SHIP_ID)
+        );
+    }
+
+    public function test_ship_with_research_at_required_level_passes(): void
+    {
+        DB::table('ships')->where('id', self::SHIP_ID)
+            ->update(['required_research_id' => self::RESEARCH_ID, 'required_research_level' => 2]);
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => self::RESEARCH_ID],
+            ['level' => 2, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $this->assertTrue(
+            $this->service()->checkRequiredResearchesByEntityId(self::COLONY_ID, self::SHIP_ID)
+        );
+    }
+
+    public function test_invest_advances_ap_spend(): void
+    {
+        config(['game.bypass.ap_checks' => true]);
+
+        DB::table('colony_ships')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'ship_id' => self::SHIP_ID],
+            ['level' => 0, 'ap_spend' => 0, 'status_points' => 0]
+        );
+
+        $this->assertTrue($this->service()->invest(self::COLONY_ID, self::SHIP_ID, 'add', 1));
+
+        $this->assertSame(1, DB::table('colony_ships')
+            ->where('colony_id', self::COLONY_ID)->where('ship_id', self::SHIP_ID)->value('ap_spend'));
+    }
+}

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_ID = 3; // Bart, password 'test123' (see feedback_dev_db_workflow memory)
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function user(): User
+    {
+        return User::where('user_id', self::USER_ID)->firstOrFail();
+    }
+
+    public function test_show_renders_profile(): void
+    {
+        $response = $this->actingAs($this->user())->get(route('user.show'));
+
+        $response->assertOk();
+    }
+
+    public function test_settings_defaults_onboarding_hints_to_true_without_prefs_row(): void
+    {
+        DB::table('user_preferences')->where('user_id', self::USER_ID)->delete();
+
+        $response = $this->actingAs($this->user())->get(route('user.settings'));
+
+        $response->assertOk();
+        $response->assertViewHas('onboarding_hints', true);
+    }
+
+    public function test_settings_reads_onboarding_hints_from_prefs_row(): void
+    {
+        DB::table('user_preferences')->updateOrInsert(
+            ['user_id' => self::USER_ID],
+            ['onboarding_hints' => false]
+        );
+
+        $response = $this->actingAs($this->user())->get(route('user.settings'));
+
+        $response->assertViewHas('onboarding_hints', false);
+    }
+
+    public function test_update_display_name(): void
+    {
+        $response = $this->actingAs($this->user())
+            ->patch(route('user.update.displayname'), ['display_name' => 'Bartholomew']);
+
+        $response->assertRedirect(route('user.settings'));
+        $this->assertSame('Bartholomew', $this->user()->display_name);
+    }
+
+    public function test_update_display_name_requires_value(): void
+    {
+        $response = $this->actingAs($this->user())
+            ->patch(route('user.update.displayname'), ['display_name' => '']);
+
+        $response->assertSessionHasErrors('display_name');
+    }
+
+    public function test_update_onboarding_hints(): void
+    {
+        $response = $this->actingAs($this->user())
+            ->patch(route('user.update.onboarding'), ['onboarding_hints' => false]);
+
+        $response->assertRedirect(route('user.settings'));
+        $this->assertSame(0, (int) DB::table('user_preferences')
+            ->where('user_id', self::USER_ID)->value('onboarding_hints'));
+    }
+
+    public function test_update_password_with_wrong_current_password_fails(): void
+    {
+        $response = $this->actingAs($this->user())
+            ->patch(route('user.update.password'), [
+                'current_password' => 'wrong-password',
+                'password' => 'newpassword123',
+                'password_confirmation' => 'newpassword123',
+            ]);
+
+        $response->assertSessionHasErrors('current_password');
+    }
+
+    public function test_update_password_with_correct_current_password_succeeds(): void
+    {
+        $response = $this->actingAs($this->user())
+            ->patch(route('user.update.password'), [
+                'current_password' => 'test123',
+                'password' => 'newpassword123',
+                'password_confirmation' => 'newpassword123',
+            ]);
+
+        $response->assertRedirect(route('user.settings'));
+        $response->assertSessionHas('success');
+        $this->assertTrue(Hash::check('newpassword123', $this->user()->password));
+    }
+}


### PR DESCRIPTION
## Summary

Ziel war mittelfristig 80 % Code-Coverage — jetzt bei **89,9 %** (vorher 70,7 %).

Vorgehen: PHPUnit-Lauf mit Xdebug + Clover-XML-Report, Dateien nach absoluter Anzahl fehlender Elemente sortiert, größte Lücken zuerst geschlossen:

| Datei | Vorher | Nachher |
|---|---|---|
| `ResetPlayer.php` (größte Einzellücke) | 0,6 % | 94,7 % |
| `CommLogController.php` | 0 % | 88,5 % |
| `SyncConfig.php` | 0 % | 100 % |
| `ValidateColony.php` | 0 % | 100 % |
| `GameTickDryRun.php` | 0 % | 98 % |
| `GameSnapshot.php` | 0 % | 88,8 % |
| `ColonySeedDemo.php` | 0 % | 96,8 % |
| `JsonController`, `ShipService`, `DbReset`, `RunResultController`, `UserController`, `LobbyController` | 0–24 % | jeweils vollständig/nahezu vollständig |

## Nebenfund (dokumentiert, nicht gefixt)

Beim Testen von `ColonySeedDemo::ensurePilotAdvisor()` (nutzt `insertOrIgnore()`) fiel auf: der partielle Unique-Index `advisors_colony_personell_unique` auf `(colony_id, personell_id)` existiert auf der aktuellen Schema **nicht mehr** — offenbar beim Fleet/Galaxie-Rebuild verloren gegangen (verifiziert per `SELECT ... FROM sqlite_master WHERE type='index' AND tbl_name='advisors'` → leer). Dadurch ist `insertOrIgnore()` nicht mehr idempotent; wiederholte Aufrufe erzeugen Advisor-Duplikate. Nicht Teil dieses PRs (Schema-Änderung mit eigenem Review-Bedarf), aber der Test macht das aktuelle (fehlerhafte) Verhalten explizit sichtbar (`test_ensure_pilot_advisor_currently_duplicates_on_rerun_known_bug`) statt es stillschweigend als korrekt zu behaupten. CHANGELOG-Eintrag verweist darauf.

## Test plan

- [x] `bin/phpunit` → 848/848 grün (1 Skip, unabhängig, vorbestehend)
- [x] `bin/phpstan analyse` → 0 Fehler
- [x] `bin/pint --test` → sauber
- [x] Gesamt-Coverage via Clover-Report verifiziert: 89,9 % (Elemente), 91,2 % (Statements)

https://claude.ai/code/session_01GV5YtRXpPTV58J8d12fouW