### PR TITLE
docs: TDD als verbindlichen Workflow für alle Code-Agenten festlegen

### DIFF
--- a/.claude/agents/backend-coder.md
+++ b/.claude/agents/backend-coder.md
@@ -61,6 +61,9 @@ Schema-Änderungen und Migrations gehören zu **db-migration-agent** — wenn Co
 - Blade-Views oder Frontend-JS/CSS NICHT bauen — gehört zu ui-specialist.
 - Lang-Datei-Stringwerte (Deutsch) NICHT ohne explizite Anfrage schreiben — PHP-Key mit leerem Platzhalter anlegen und für content-writer markieren.
 
+## Test-Driven Development — verbindlich
+Vor jedem neuen Controller-Endpoint oder jeder Service-Methode mit Verhalten: erst einen Feature-/Unit-Test schreiben (`tests/Feature/...`), rot laufen lassen, dann implementieren bis grün. Kein Endpoint ohne vorher existierenden Test. Ausnahme nur bei reinem Routing/Wiring ohne eigene Logik oder explizitem Owner-Spike. Details: CLAUDE.md → „Test-Driven Development (TDD) — verbindlich".
+
 ## Coding-Standards
 - PSR-12 strikt einhalten
 - Dependency Injection — keine statischen Calls oder globaler State außer idiomatischen Facades
@@ -70,7 +73,7 @@ Schema-Änderungen und Migrations gehören zu **db-migration-agent** — wenn Co
 - CSRF-Schutz auf jedem zustandsändernden Endpoint (Laravel handled via `web`-Middleware)
 
 ## Output-Format
-Vollständige, lauffähige Code-Dateien liefern. Kommentare nur wenn WHY nicht offensichtlich (versteckte Einschränkung, Workaround, subtile Invariante) — nie erklären was Code tut.
+Test-Datei (zuerst geschrieben, rot dann grün) + vollständige, lauffähige Code-Dateien liefern. Kommentare nur wenn WHY nicht offensichtlich (versteckte Einschränkung, Workaround, subtile Invariante) — nie erklären was Code tut.
 ## Code-Style (Linter — Pflicht)
 
 Vor jedem Commit formatiert der Hook PHP via **Laravel Pint** (`laravel`-Preset). Code so schreiben, dass Pint nichts mehr ändert:

--- a/.claude/agents/db-migration-agent.md
+++ b/.claude/agents/db-migration-agent.md
@@ -42,11 +42,15 @@ Beim Aufruf zuerst prüfen:
 - `app/Models/` — Eloquent-Models (Beziehungen, fillable Fields)
 - `config/game.php` — Game-Config (oft mit Schema-Änderungen verknüpft)
 
+## Test-Driven Development — verbindlich
+Migrations mit Logik (Backfill, Datenumformung, Constraint mit Verhalten wie Unique-Index) brauchen VORHER einen fehlschlagenden Test, der das Nachher-Verhalten prüft (z.B. Idempotenz einer `insertOrIgnore()`, die sich auf einen Unique-Index verlässt). Reines Spalte-Hinzufügen ohne Logik ist ausgenommen. Bei Table-Rebuilds (SQLite: CREATE TABLE + Daten kopieren) explizit prüfen, dass zusätzliche Indizes der Altdefinition mitgenommen werden — das wird beim Rebuild NICHT automatisch übernommen (siehe project_advisors_unique_index_missing-Memory: genau das ging beim Fleet/Galaxie-Rebuild verloren, unbemerkt weil kein Test die Idempotenz prüfte). Details: CLAUDE.md → „Test-Driven Development (TDD) — verbindlich".
+
 ## Schema-Regeln
 - **snake_case** für alle Tabellen-/Spaltennamen (alte Spalten camelCase — alle neuen snake_case)
 - Explizite Foreign Keys auf jeder Relation
 - Jede Schema-Änderung an geseedeter Tabelle muss `data/sql/testdata.sqlite.sql` aktualisieren
 - Kein Raw-SQL in Migrations außer bei SQLite-Quirks
+- Bei Table-Rebuild: alle Indizes (auch partielle/Unique) der Originaltabelle explizit in der neuen CREATE TABLE-Migration mitführen — nicht nur Spalten
 
 ## SQLite-Eigenheiten
 **RENAME COLUMN mit Views**: SQLite validiert alle Views bei `RENAME COLUMN`. Falls View die umbenannte Spalte referenziert, erst droppen:

--- a/.claude/agents/game-developer.md
+++ b/.claude/agents/game-developer.md
@@ -52,6 +52,9 @@ Beim Aufruf zuerst prüfen:
 - `app/Models/` — Eloquent-Models
 - `database/migrations/` — aktuelles Schema
 
+## Test-Driven Development — verbindlich
+Vor JEDER neuen Methode/Mechanik mit Verhalten: erst den PHPUnit-Test schreiben, laufen lassen und rot sehen (`bin/phpunit --filter test_name`), erst dann implementieren, bis er grün ist. Kein Service-Code ohne vorher existierenden, fehlschlagenden Test — auch nicht "schnell mal". Ausnahme nur bei reiner Config-Änderung ohne Codepfad oder explizit vom Owner markiertem Wegwerf-Spike. Siehe CLAUDE.md → „Test-Driven Development (TDD) — verbindlich" für die volle Regel.
+
 ## Implementierungsregeln
 - Game-Logik immer serverseitig — Client-Input nie vertrauen
 - Alle Spielzustands-Änderungen atomar (DB-Transaktionen)
@@ -69,7 +72,7 @@ Domain-Exceptions innerhalb Closure werfen — `DB::transaction()` rollt bei jed
 
 ## Output-Format
 Beim Implementieren einer Mechanik liefern:
-1. Service-Klasse oder -Methode (mit Typsignaturen)
+1. PHPUnit-Test (zuerst geschrieben, rot dann grün) + Service-Klasse/-Methode (mit Typsignaturen)
 2. Hinweis wenn DB-Migration benötigt (übergeben an db-migration-agent)
 3. Hinweise zur Einbindung in Controller/Route (für backend-coder)
 ## Code-Style (Linter — Pflicht)

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -1,12 +1,21 @@
 ---
 name: qa-tester
-description: Proaktiv einsetzen für Tests schreiben, Bugs finden, Eingabevalidierung prüfen, Security-Testing, Cheat-Vektoren erkennen und Regressionstests. Aufrufen nach Implementierung jeder Spielmechanik oder API-Endpoints, oder vor jedem Migrations-Schritt.
+description: Proaktiv einsetzen für Tests schreiben, Bugs finden, Eingabevalidierung prüfen, Security-Testing, Cheat-Vektoren erkennen und Regressionstests. TDD-Pflicht — aufrufen VOR der Implementierung jeder neuen Spielmechanik oder API-Endpoints (Test zuerst, rot, dann Übergabe an game-developer/backend-coder), zusätzlich danach für Security-/Adversarial-/Regressionstests.
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 
 # QA & Test Engineer
 
 Tests schreiben, Regressionen erkennen, adversarial denken — wie Spieler der das Spiel bricht oder Wirtschaft ausnutzt.
+
+## Test-Driven Development — Kernrolle, nicht Nachgedanke
+Standardfall: es gibt noch KEINEN Produktionscode. Aufgabe kommt als Spec/Verhalten-Beschreibung (von game-designer/Owner). Vorgehen:
+1. Test(s) schreiben, die das gewünschte Verhalten beschreiben (Happy Path + Edge Cases + Adversarial).
+2. Test laufen lassen — muss fehlschlagen (rot). Fehlschlägt er nicht, ist der Test wertlos (prüft evtl. nichts oder Feature existiert schon).
+3. An game-developer/backend-coder übergeben zur Implementierung, bis grün.
+4. Nach Fertigstellung: zusätzliche Security-/Regressionstests, die über den Kern-TDD-Test hinausgehen.
+
+Falls doch nachträglich für bestehenden, ungetesteten Code eingesetzt (Altbestand, Coverage-Lücke): Implementierung lesen, dann Tests schreiben, die das TATSÄCHLICHE Verhalten dokumentieren — inklusive gefundener Bugs (siehe unten), nicht das wie es "eigentlich" sein sollte.
 
 ## Sprachregeln
 - Test-Code, Methodennamen, Klassennamen, Kommentare: **Englisch**.
@@ -17,6 +26,7 @@ Tests schreiben, Regressionen erkennen, adversarial denken — wie Spieler der d
 - Nur Test-Dateien schreiben (`tests/Feature/`, `tests/Unit/`).
 - Kein Produktionscode, Lang-Dateien, Migrations oder Docs-Änderungen.
 - Bug beim Testen gefunden → klar im Output beschreiben. Produktionscode NICHT selbst fixen.
+- Bei Altbestand mit echtem Bug (z.B. Race Condition, fehlender Constraint): Test schreiben, der das aktuelle (fehlerhafte) Verhalten explizit als bekannten Bug dokumentiert (Testname + Kommentar sagen klar "known bug, not fixed here"), statt das gewünschte Verhalten stillschweigend zu behaupten oder den Test einfach wegzulassen.
 
 ## Tech Stack
 - PHPUnit 11.5
@@ -48,7 +58,7 @@ Beim Aufruf zuerst prüfen:
 - `tests/Feature/` — bestehende Test-Struktur und Benennungskonventionen
 - `phpunit.xml` — Test-Suite und Filter-Konfiguration
 - `data/sql/testdata.sqlite.sql` — Test-Fixture-Daten
-- Feature/Service unter Test — Implementierung lesen vor Test-Schreiben
+- Falls Implementierung schon existiert (Altbestand-Coverage-Fall): lesen vor Test-Schreiben. Im TDD-Standardfall existiert sie noch nicht — dann Spec/Verhalten-Beschreibung als Grundlage nehmen.
 
 ## Test-Anforderungen
 Jede neue Spielmechanik braucht mindestens:

--- a/.claude/agents/ui-specialist.md
+++ b/.claude/agents/ui-specialist.md
@@ -20,6 +20,9 @@ Responsives Spiel-UI für Nouron bauen. Neue Screens: Alpine.js + PicoCSS. Legac
 - `lang/de/*.php` Deutsche Werte NICHT ändern — content-writer zuständig. Keys mit leerem String oder `TODO`-Platzhalter anlegen und flaggen.
 - `docs/GDD.md`, `ROADMAP.md`, `CHANGELOG.md` NICHT anfassen.
 
+## TDD-Hinweis
+Kein JS-Testrunner im Projekt — TDD gilt hier nicht für Blade/Alpine/CSS direkt. Wird für eine neue UI-Interaktion ein neuer AJAX-Endpoint/Response-Contract gebraucht: Contract zuerst mit backend-coder/game-developer klären, die schreiben dort den Test zuerst (TDD-Pflicht gilt für den Backend-Teil). Neue JS-Logik so einfach halten, dass sie ohne Testrunner beim manuellen Durchklicken verifizierbar bleibt.
+
 ## Tech Stack — Neue Screens (Phase 3b+)
 - **Alpine.js 3** für Reaktivität (`x-data`, `x-show`, `x-bind`, `x-effect`, `x-ref`, `$refs`)
 - **PicoCSS 2** für Basis-Styles — semantisches HTML, `<dialog>`, `<article>`, `<details>`, `<progress>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,23 @@ Vollständige Entscheidung: `docs/adr/0001-graphics-asset-format.md`
 - `backend-coder` — Controller, Routes, API-Endpoints, Middleware
 - `ui-specialist` — Blade, Alpine.js + PicoCSS (neu), Bootstrap 5 (Legacy, kein jQuery mehr)
 - `db-migration-agent` — Schema, Migrations, SQLite, testdata.sqlite.sql
-- `qa-tester` — Tests schreiben (nach jeder Implementierung automatisch)
+- `qa-tester` — Tests schreiben: VOR der Implementierung (TDD-Pflicht, siehe unten) + danach für Security-/Adversarial-/Regressionstests
 - `content-writer` — lang/de/*.php Texte, Lore, Tooltips (bei neuen Entitäten automatisch)
 - `project-manager` — ROADMAP, CHANGELOG, ADRs, Feature-Breakdown
+
+## Test-Driven Development (TDD) — verbindlich
+
+Für jeden neuen Code mit Verhalten (Services, Controller-Logik, Game-Mechaniken, Migrations mit Datenlogik/Backfills) gilt Red-Green-Refactor, keine Ausnahme auf Zuruf:
+
+1. **Red** — Erst einen fehlschlagenden Test schreiben, der das gewünschte Verhalten beschreibt. Test laufen lassen, Fehlschlag bestätigen (sonst weiß niemand, ob der Test überhaupt etwas prüft).
+2. **Green** — Minimale Implementierung, bis der Test grün ist. Kein Code, der nicht durch einen Test motiviert ist.
+3. **Refactor** — Aufräumen, Tests bleiben grün.
+
+**Reihenfolge ist verbindlich:** kein Produktionscode schreiben, bevor der zugehörige Test existiert und rot war. `game-developer`, `backend-coder` und `db-migration-agent` schreiben den Test selbst zuerst, wenn sie allein an einer Aufgabe sitzen — nicht auf `qa-tester` warten. `qa-tester` wird zusätzlich eingesetzt für Security-/Adversarial-Fälle und Regressionsabdeckung, die über den TDD-Test der Kernlogik hinausgehen.
+
+**Ausnahmen** (keine Umgehung, sondern echte Nicht-Anwendbarkeit): reine Config-/Doku-/Lang-Änderungen ohne Codepfad, Migrations ohne Logik (Spalte hinzufügen, kein Backfill/keine Berechnung), vom Owner explizit als Wegwerf-Spike/Prototyp markierter Code. Im Zweifel: Test schreiben.
+
+Bei reaktivierten/bestehenden Dateien mit Coverage-Lücke (siehe `bin/phpunit --coverage-html`) gilt dieselbe Reihenfolge für jede Änderung daran: nicht "code first, Test irgendwann nachziehen".
 
 ## Workflow-Hinweise
 


### PR DESCRIPTION
## Summary

Owner-Wunsch: künftig Test-Driven Development als verbindlichen Workflow — jeder neue Code (mit Verhalten) bekommt zuerst einen fehlschlagenden Test, dann die Implementierung.

- **CLAUDE.md**: neue Sektion „Test-Driven Development (TDD) — verbindlich" mit Red-Green-Refactor-Ablauf, klaren Ausnahmen (reine Config/Doku, Migrations ohne Logik, explizite Owner-Spikes) und der Regel, dass die Reihenfolge (Test vor Code) nicht verhandelbar ist.
- **`qa-tester`**: Rolle gedreht — von "Tests nach Implementierung" zu "Tests VOR Implementierung" als Kernrolle (Security-/Adversarial-/Regressionstests bleiben zusätzlich danach).
- **`game-developer`/`backend-coder`**: TDD-Absatz ergänzt — schreiben den Test selbst zuerst, wenn sie ohne qa-tester an einer Aufgabe sitzen.
- **`db-migration-agent`**: TDD-Absatz + konkreter Verweis auf den in PR #225 gefundenen Bug (fehlender `advisors_colony_personell_unique`-Index, beim Fleet/Galaxie-Table-Rebuild verlorengegangen) als Beispiel, warum Migrations mit Verhalten einen Test brauchen.
- **`ui-specialist`**: Klarstellung, dass TDD hier nur indirekt greift (kein JS-Testrunner im Projekt) — bei neuen AJAX-Contracts zuerst mit backend-coder/game-developer abstimmen, die TDD auf der Backend-Seite durchziehen.

Reine Dokumentations-/Agent-Definitions-Änderung, kein Produktionscode betroffen.

## Test plan

- [x] Kein Code geändert — nichts auszuführen. Änderungen sind Markdown (`CLAUDE.md`, `.claude/agents/*.md`).

https://claude.ai/code/session_01GV5YtRXpPTV58J8d12fouW