### PR TITLE
refactor(colony): Tile-Panel-Titel-Zeile aufräumen (Code + Optik)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-25
+
+Tile-Panel-Titel (Kolonie-Ansicht) aufgeräumt: der 13-fache `@foreach`/`x-if`/`<x-entity-chip>`-Block zur Gebäudenamen-Anzeige (pro Gebäudetyp ein verstecktes Template) ist einem einzigen Alpine-Lookup (`buildingLabel()`) gewichen. Optisch kein Icon/Pill mehr in der Titel-Zeile — schlichter, fetter Text neben dem Level-Badge. Scope bewusst auf die Titel-Zeile begrenzt (Design-Spec: `docs/superpowers/specs/2026-07-24-tile-panel-title-cleanup-design.md`).
+
 ## 2026-07-21
 
 Larastan (Level 5) auf 0 Fehler gebracht (vorher 151):

--- a/docs/superpowers/plans/2026-07-24-tile-panel-title-cleanup.md
+++ b/docs/superpowers/plans/2026-07-24-tile-panel-title-cleanup.md
@@ -1,0 +1,136 @@
+# Tile-Panel-Titel Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ersetzt den 13-fachen `@foreach`/`x-if`/`<x-entity-chip>`-Block in der Tile-Panel-Titelzeile durch einen einzigen Alpine-Lookup, entfernt dabei den Chip-Look zugunsten von schlichtem Fett-Text.
+
+**Architecture:** `$buildingChipData` (bereits serverseitig berechnet) wird zusätzlich als JSON (`buildingCatalog`) in `window.__colonyViewData` mitgegeben. Eine neue Alpine-Methode `buildingLabel(key)` macht daraus einen Lookup. Der Blade-Block wird auf eine Zeile reduziert.
+
+**Tech Stack:** Laravel Blade, Alpine.js 3.
+
+## Global Constraints
+- Kein Deutsch in JS/Blade-Code-Kommentaren (Projektregel) — nur `lang/de/*.php`-Werte sind Deutsch.
+- Prettier muss `public/js/colony-hexgrid.js` unverändert lassen (`npx prettier --check`).
+- Scope: nur `resources/views/colony/hexview.blade.php` Zeilen 166–190. Die 3 Build-Mode-`@foreach`-Ketten (322, 346, 383) NICHT anfassen.
+
+---
+
+### Task 1: buildingCatalog ins Colony-View-Datenobjekt aufnehmen
+
+**Files:**
+- Modify: `resources/views/colony/hexview.blade.php:9-35` (Alpine-Datenobjekt `window.__colonyViewData`)
+- Modify: `public/js/colony-hexgrid.js` (neue Methode `buildingLabel`)
+
+**Interfaces:**
+- Produces: `buildingCatalog: Record<string, {label: string}>` auf `window.__colonyViewData`; `buildingLabel(key: string): string` als Alpine-Methode.
+
+- [ ] **Step 1: `buildingCatalog` ins JSON-Objekt aufnehmen**
+
+In `resources/views/colony/hexview.blade.php`, im `<script>`-Block, der `window.__colonyViewData` befüllt (ab Zeile 27), eine neue Zeile ergänzen:
+
+```php
+buildingCatalog: @json($buildingChipData->map(fn ($chip) => ["label" => $chip["label"]])),
+```
+
+Platzierung: direkt nach der `buildings: @json($buildings),`-Zeile.
+
+- [ ] **Step 2: `buildingLabel()` in colony-hexgrid.js ergänzen**
+
+In `public/js/colony-hexgrid.js`, im zurückgegebenen Alpine-Objekt (dieselbe Methodengruppe wie `buildingForTile`), folgende Methode ergänzen:
+
+```js
+buildingLabel(key) {
+    return this.buildingCatalog?.[key]?.label ?? key;
+},
+```
+
+Direkt neben `buildingForTile(tile)` einfügen (gleicher Verantwortungsbereich: Gebäude-Metadaten-Lookup). `buildingCatalog` selbst muss als State-Property im `return { ... }`-Objekt existieren — als `buildingCatalog: config.buildingCatalog ?? {},` neben den anderen `config.*`-Übernahmen (analog zu `ccBuildingId: config.ccBuildingId ?? 25,`) ergänzen.
+
+- [ ] **Step 3: Prettier-Check**
+
+Run: `npx prettier --check public/js/colony-hexgrid.js resources/views/colony/hexview.blade.php`
+Expected: beide Dateien "All matched files use Prettier code style!" — falls nicht, `npx prettier --write` beide Dateien, Blade-Datei danach ein zweites Mal (`--write` Blade braucht 2 Durchläufe, siehe `docs/code-style.md`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/views/colony/hexview.blade.php public/js/colony-hexgrid.js
+git commit -m "refactor(colony): buildingCatalog-Lookup für Titel-Zeile vorbereiten"
+```
+
+---
+
+### Task 2: Titel-Zeile auf den Lookup umstellen, Chip-Look entfernen
+
+**Files:**
+- Modify: `resources/views/colony/hexview.blade.php:166-190`
+
+**Interfaces:**
+- Consumes: `buildingLabel(key)` aus Task 1.
+
+- [ ] **Step 1: Block ersetzen**
+
+Aktueller Block (Zeilen 166–190):
+
+```blade
+<div class="tile-panel-title" x-show="!harvesterMoveMode && !buildMode && selectedTile" x-cloak>
+    <template x-if="selectedBuilding">
+        <div class="tile-panel-title__row">
+            <span class="tile-panel-title__name">
+                @foreach ($buildingChipData as $key => $chip)
+                    @php
+                        $chipLabel = $chip["label"];
+                        $chipTooltip = $chip["tooltip"];
+                    @endphp
+                    <template x-if="selectedBuilding.building_key === '{{ $key }}'">
+                        <x-entity-chip type="building" entity-key="{{ $key }}"
+                            label="{{ $chipLabel }}" :tooltip="$chipTooltip" />
+                    </template>
+                @endforeach
+            </span>
+            <span class="sidebar-level-badge" x-show="selectedBuilding.level > 0"
+                x-text="selectedBuilding.max_level
+                    ? `Lv. ${selectedBuilding.level} / ${selectedBuilding.max_level}`
+                    : `Lv. ${selectedBuilding.level}`"></span>
+        </div>
+    </template>
+    <template x-if="!selectedBuilding">
+        <span class="tile-panel-title__name" x-text="tileHeading(selectedTile)"></span>
+    </template>
+</div>
+```
+
+Ersetzen durch:
+
+```blade
+<div class="tile-panel-title" x-show="!harvesterMoveMode && !buildMode && selectedTile" x-cloak>
+    <template x-if="selectedBuilding">
+        <div class="tile-panel-title__row">
+            <span class="tile-panel-title__name" x-text="buildingLabel(selectedBuilding.building_key)"></span>
+            <span class="sidebar-level-badge" x-show="selectedBuilding.level > 0"
+                x-text="selectedBuilding.max_level
+                    ? `Lv. ${selectedBuilding.level} / ${selectedBuilding.max_level}`
+                    : `Lv. ${selectedBuilding.level}`"></span>
+        </div>
+    </template>
+    <template x-if="!selectedBuilding">
+        <span class="tile-panel-title__name" x-text="tileHeading(selectedTile)"></span>
+    </template>
+</div>
+```
+
+- [ ] **Step 2: Prettier-Check (Blade, 2 Durchläufe falls nötig)**
+
+Run: `npx prettier --check resources/views/colony/hexview.blade.php`
+Falls nicht konform: `npx prettier --write resources/views/colony/hexview.blade.php` zweimal ausführen.
+
+- [ ] **Step 3: Manueller Smoke-Test**
+
+`php artisan serve` (oder bestehenden Dev-Server nutzen), `/colony/view` öffnen, ein platziertes Gebäude anklicken (z.B. Analytik-Labor). Erwartet: Titel-Zeile zeigt Name (fett, Anthrazit, kein Icon/Pill mehr) + Level-Badge in einer Zeile. Leeres Tile anklicken: weiterhin Terrain-Name wie zuvor (unverändert, `tileHeading`-Zweig nicht angefasst).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/views/colony/hexview.blade.php
+git commit -m "refactor(colony): Tile-Panel-Titel auf schlichten Text ohne Chip umstellen"
+```

--- a/docs/superpowers/specs/2026-07-24-tile-panel-title-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-24-tile-panel-title-cleanup-design.md
@@ -1,0 +1,16 @@
+# Tile-Panel-Titel: Code- und Optik-Cleanup
+
+## Kontext
+`resources/views/colony/hexview.blade.php`, Zeilen 166–190 (`.tile-panel-title`): Gebäudename wird über einen `@foreach ($buildingChipData as $key => $chip)` mit 13 verschachtelten `<template x-if="selectedBuilding.building_key === '{{ $key }}'">`-Blöcken gerendert, die je einen `<x-entity-chip>` (Icon + Pill + Hover-Tooltip) erzeugen — nur um exakt einen davon anzuzeigen. Owner empfindet das als unnötig kompliziert und will optisch schlicht Name + Level in einer Zeile, ohne Chip-Look.
+
+## Entscheidung
+- `$buildingChipData` (Label pro `building_key`, in `hexview.blade.php:13` bereits serverseitig berechnet) zusätzlich als JSON in `window.__colonyViewData` mitgeben (`buildingCatalog`).
+- Neue Methode `buildingLabel(key)` in `colony-hexgrid.js`: `this.buildingCatalog[key]?.label ?? key`.
+- Der 13-fache `@foreach`/`x-if`/`<x-entity-chip>`-Block in der Titel-Zeile wird durch eine Zeile ersetzt: `<span class="tile-panel-title__name" x-text="buildingLabel(selectedBuilding.building_key)"></span>`.
+- Optik: kein Icon/Pill mehr, reiner Text — `.tile-panel-title__name` liefert das bereits (700 Weight, Anthrazit, keine neue CSS nötig). Level-Badge bleibt unverändert daneben (`.tile-panel-title__row` ist schon flex, also automatisch eine Zeile).
+
+## Scope
+Nur die Titel-Zeile (Zeilen 166–190). Die 3 weiteren `@foreach`-Ketten im Build-Mode (Zeilen 322, 346, 383 — Build-Katalog-Liste, In-Progress-Liste, Pending-Building-Preview) bleiben unangetastet — anderer UI-Kontext (Katalogliste mit Chip+Tooltip sinnvoll), nicht Teil dieses Fixes.
+
+## Test
+Kein PHPUnit-Test nötig (reine Blade/JS-Änderung, kein Backend-Verhalten). Manueller Smoke-Test im Browser: Gebäude auf der Kolonie-Ansicht auswählen, Titel-Zeile zeigt Name + Level ohne Chip-Pill/Icon.

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -94,6 +94,7 @@ function colonyHexView(config) {
         ccLevel: config.ccLevel,
         ccBuildingId: config.ccBuildingId ?? 25,
         buildings: config.buildings ?? [],
+        buildingCatalog: config.buildingCatalog ?? {},
         routes: config.routes ?? {},
         i18n: config.i18n ?? {},
         apNav: config.apNav ?? 0,
@@ -658,6 +659,10 @@ function colonyHexView(config) {
                 return this.buildings.find((b) => b.building_id === this.ccBuildingId) ?? null;
             }
             return this.buildings.find((b) => b.tile_x === tile.q && b.tile_y === tile.r) ?? null;
+        },
+
+        buildingLabel(key) {
+            return this.buildingCatalog?.[key]?.label ?? key;
         },
 
         // The building on the currently selected tile, or null. Single source

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -30,6 +30,7 @@
             ccLevel: {{ (int) $ccLevel }},
             ccBuildingId: {{ \App\Enums\BuildingId::CommandCenter->value }},
             buildings: @json($buildings),
+            buildingCatalog: @json($buildingChipData->map(fn($chip) => ["label" => $chip["label"]])),
             apNav: {{ (int) $navAp }},
             apConstruction: {{ (int) $constructionAp }},
             regolith: {{ (int) $regolith }},
@@ -166,18 +167,8 @@
                 <div class="tile-panel-title" x-show="!harvesterMoveMode && !buildMode && selectedTile" x-cloak>
                     <template x-if="selectedBuilding">
                         <div class="tile-panel-title__row">
-                            <span class="tile-panel-title__name">
-                                @foreach ($buildingChipData as $key => $chip)
-                                    @php
-                                        $chipLabel = $chip["label"];
-                                        $chipTooltip = $chip["tooltip"];
-                                    @endphp
-                                    <template x-if="selectedBuilding.building_key === '{{ $key }}'">
-                                        <x-entity-chip type="building" entity-key="{{ $key }}"
-                                            label="{{ $chipLabel }}" :tooltip="$chipTooltip" />
-                                    </template>
-                                @endforeach
-                            </span>
+                            <span class="tile-panel-title__name"
+                                x-text="buildingLabel(selectedBuilding.building_key)"></span>
                             <span class="sidebar-level-badge" x-show="selectedBuilding.level > 0"
                                 x-text="selectedBuilding.max_level
                                     ? `Lv. ${selectedBuilding.level} / ${selectedBuilding.max_level}`
@@ -293,8 +284,7 @@
 
                 {{-- Only labels build/harvester modes. In normal tile mode the tabs
                  (building) or the terrain <h3> name the content themselves. --}}
-                <div class="tile-panel-header tile-panel-header--hideable" x-show="harvesterMoveMode || buildMode"
-                    x-cloak>
+                <div class="tile-panel-header tile-panel-header--hideable" x-show="harvesterMoveMode || buildMode" x-cloak>
                     <h3
                         x-text="harvesterMoveMode ? '{{ __("colony.harvester_move") }}' : '{{ __("colony.build_mode_title") }}'">
                     </h3>


### PR DESCRIPTION
## Summary

Owner-Wunsch aus Screenshot-Review: der Gebäudename in der Tile-Panel-Titelzeile (Kolonie-Ansicht) wurde bisher über einen 13-fachen `@foreach ($buildingChipData as $key => $chip)` mit je einem `<template x-if="selectedBuilding.building_key === '{{ $key }}'">` gerendert — pro Gebäudetyp ein verstecktes Template, nur um exakt eines davon anzuzeigen. Owner: "ist das wirklich notwendig oder geht das eleganter" + optisch soll Name+Level schlicht in einer Zeile stehen, kein Chip/Icon.

**Fix:**
- `$buildingChipData` (Label pro `building_key`, bereits serverseitig berechnet) zusätzlich als JSON (`buildingCatalog`) in `window.__colonyViewData` mitgegeben.
- Neue Alpine-Methode `buildingLabel(key)` in `colony-hexgrid.js` — einfacher Lookup statt Template-Kette.
- Titel-Zeile (`hexview.blade.php:167-190`) auf eine Zeile reduziert: `x-text="buildingLabel(selectedBuilding.building_key)"`.
- Optik: kein `<x-entity-chip>` (Icon+Pill+Tooltip) mehr — reiner fetter Text (bestehende `.tile-panel-title__name`-Klasse liefert das bereits, kein neues CSS nötig).

**Scope bewusst begrenzt** (siehe Design-Spec `docs/superpowers/specs/2026-07-24-tile-panel-title-cleanup-design.md`): nur die Titel-Zeile. Die 3 weiteren `@foreach`-Ketten im Build-Mode (Katalog-Liste, In-Progress-Liste, Pending-Building-Preview) bleiben unangetastet — anderer UI-Kontext, wo Icon+Tooltip beim Scannen einer Liste sinnvoll bleiben.

## Test plan

- [x] `npx prettier --check` auf beiden geänderten Dateien → sauber
- [x] End-to-End-Smoke-Test per Playwright (lokal installiert, kein Projekt-Dependency): eingeloggt als Bart, Kommandozentrale-Tile angeklickt, HTML-Output der `.tile-panel-title` geprüft → `x-text="buildingLabel(...)"` rendert korrekt "Command Center" / "Lv. 3 / 5", kein Chip-Markup mehr. Screenshot bestätigt: schlichter Text statt Pille.
- [ ] Kein PHPUnit-Test (reine Blade/JS-Änderung ohne Backend-Verhalten, wie im Design-Spec begründet)

https://claude.ai/code/session_01GV5YtRXpPTV58J8d12fouW