### PR TITLE
refactor(colony): Tile-Panel-Titel kompakt in einer Zeile, Level als Hover-Popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-07-29
+
+Tile-Panel-Titel (Kolonie-Ansicht) weiter verfeinert (Folge-Feedback zu PR #227): Name + Level jetzt kompakt in einer Zeile (`Kommandozentrale | 3`) statt Name-Zeile + separatem Level-Chip darunter. Die volle Level-Angabe (`Level x / max`) zieht in ein dezentes Hover-Popup (`.res-popup`, wiederverwendet aus `resources.css`) — nur bei echtem Hover sichtbar (`@media (hover: hover)`), auf Touch-Geräten ausgeblendet.
+
 ## 2026-07-25
 
 Tile-Panel-Titel (Kolonie-Ansicht) aufgeräumt: der 13-fache `@foreach`/`x-if`/`<x-entity-chip>`-Block zur Gebäudenamen-Anzeige (pro Gebäudetyp ein verstecktes Template) ist einem einzigen Alpine-Lookup (`buildingLabel()`) gewichen. Optisch kein Icon/Pill mehr in der Titel-Zeile — schlichter, fetter Text neben dem Level-Badge. Scope bewusst auf die Titel-Zeile begrenzt (Design-Spec: `docs/superpowers/specs/2026-07-24-tile-panel-title-cleanup-design.md`).

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -619,6 +619,31 @@ button.btn-sol:hover,
     letter-spacing: 0.06em;
 }
 
+/* Hover popup for the level detail — desktop only (touch devices have no
+   hover to trigger it, same (hover: hover) gate as the repair-button ghost
+   segment). Position anchor for the reused .res-popup (resources.css). */
+.tile-panel-title__name--hoverable {
+    position: relative;
+}
+
+.tile-panel-title__name--hoverable .res-popup {
+    text-transform: none;
+    letter-spacing: normal;
+    font-weight: 400;
+}
+
+@media (hover: hover) {
+    .tile-panel-title__name--hoverable {
+        cursor: default;
+    }
+}
+
+@media not all and (hover: hover) {
+    .tile-panel-title__name--hoverable .res-popup {
+        display: none !important;
+    }
+}
+
 /* Terrain detail demoted to a closed disclosure on a built tile. PicoCSS styles
    <details>/<summary> natively; this only tunes spacing + the summary label. */
 .tile-terrain-disclosure {

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -162,17 +162,25 @@
 
                 {{-- Context title: building name + level (or terrain name) at the very
                  top, above the action strip — identity before action, and the one
-                 line that stays visible on mobile. Max level is shown inline on the
-                 badge only when the building is actually capped. --}}
+                 line that stays visible on mobile. Compact "Name | Level" inline;
+                 the full "Level x / max" detail lives in a hover popup (desktop
+                 only, .res-popup reused from resources.css) so the header never
+                 wraps to a second line. --}}
                 <div class="tile-panel-title" x-show="!harvesterMoveMode && !buildMode && selectedTile" x-cloak>
                     <template x-if="selectedBuilding">
-                        <div class="tile-panel-title__row">
-                            <span class="tile-panel-title__name"
-                                x-text="buildingLabel(selectedBuilding.building_key)"></span>
-                            <span class="sidebar-level-badge" x-show="selectedBuilding.level > 0"
-                                x-text="selectedBuilding.max_level
-                                    ? `Lv. ${selectedBuilding.level} / ${selectedBuilding.max_level}`
-                                    : `Lv. ${selectedBuilding.level}`"></span>
+                        <div class="tile-panel-title__row" x-data="{ hoverLevel: false }">
+                            <span class="tile-panel-title__name tile-panel-title__name--hoverable"
+                                @mouseenter="hoverLevel = true" @mouseleave="hoverLevel = false">
+                                <span x-text="buildingLabel(selectedBuilding.building_key)"></span>
+                                <template x-if="selectedBuilding.level > 0">
+                                    <span x-text="' | ' + selectedBuilding.level"></span>
+                                </template>
+                                <div class="res-popup" x-show="hoverLevel && selectedBuilding.level > 0" x-cloak
+                                    x-text="selectedBuilding.max_level
+                                        ? `Level ${selectedBuilding.level} / ${selectedBuilding.max_level}`
+                                        : `Level ${selectedBuilding.level}`">
+                                </div>
+                            </span>
                         </div>
                     </template>
                     <template x-if="!selectedBuilding">
@@ -284,7 +292,8 @@
 
                 {{-- Only labels build/harvester modes. In normal tile mode the tabs
                  (building) or the terrain <h3> name the content themselves. --}}
-                <div class="tile-panel-header tile-panel-header--hideable" x-show="harvesterMoveMode || buildMode" x-cloak>
+                <div class="tile-panel-header tile-panel-header--hideable" x-show="harvesterMoveMode || buildMode"
+                    x-cloak>
                     <h3
                         x-text="harvesterMoveMode ? '{{ __("colony.harvester_move") }}' : '{{ __("colony.build_mode_title") }}'">
                     </h3>


### PR DESCRIPTION
## Summary

Folge-Feedback zu PR #227 (Tile-Panel-Titel-Cleanup): der Level war zwar kein `<x-entity-chip>` mehr, stand aber immer noch als eigene grüne "Pille" (`.sidebar-level-badge`) unter dem Namen — nicht das gewünschte "kompakt, aber elegant".

**Fix:**
- Titel jetzt eine Zeile: `Kommandozentrale | 3` (Name + aktuelles Level, per `|` getrennt).
- Die volle Angabe (`Level x / max`) zieht in ein dezentes Hover-Popup — `.res-popup` aus `resources.css` wiederverwendet (gleicher Look wie die AP-Chip-Popups in der Resource-Bar), kein neuer Popup-Mechanismus erfunden.
- Popup nur auf Geräten mit echtem Hover sichtbar (`@media (hover: hover)`), auf Touch ausgeblendet — gleiches Gate wie der Reparatur-Button-Ghost-Segment (bestehende Konvention).

## Test plan

- [x] `bin/phpstan analyse` → 0 Fehler
- [x] `npx prettier --check` auf beiden geänderten Dateien → sauber
- [x] Playwright-Smoke-Test gegen die echte Dev-DB (Bart/Run #67): Titel-Zeile zeigt "KOMMANDOZENTRALE | 3", Hover löst Popup "Level 3 / 5" aus (Screenshots geprüft, normale Groß-/Kleinschreibung im Popup — nicht vom Titel geerbtes `uppercase`).
- [ ] Bekannte Einschränkung: bei sehr langen Gebäudenamen (z. B. "Kommandozentrale") wrapt die Titel-Zeile bei schmaler Panel-Breite weiterhin auf zwei Zeilen — das ist die Panel-Breite selbst, kein neuer Fehler (bestand auch vorher), nicht Teil dieses Fixes.

https://claude.ai/code/session_01GV5YtRXpPTV58J8d12fouW