### PR TITLE
Stufe 1: AP-Ratenmodell-Zahlensatz (§13.7) + Harvester-Erschöpfung (§4c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-08-03 (Fortsetzung 7)
+
+**§4c-Harvester-Mechanik implementiert** (Erschöpfung, Verlegekosten, Zweitinstanz-Gate, Geologie-Bonus). Bisher war die Erschöpfungsmechanik komplett unverdrahtet — `colony_tiles.resource_max`/`resource_amount` wurden nur bei Tile-Erstellung gesetzt, nie gelesen oder abgebaut; Harvester-Produktion lief ausschließlich über die jetzt inerte `production_curve[27]`-Glockenkurve.
+
+- **Erschöpfung:** `GameTick::harvesterYield()` (pure Funktion) + `generateHarvesterYield()` ersetzen die Level-Kurve für den Harvester durch `Ertrag = Frischwert × (0,5 + 0,5 × Restvorkommen / resource_max)`, gespeist aus der Tile-Instanz, auf der der Harvester steht. `resource_max` sinkt in `ColonyTileService` auf 500/300/160 (Frischwerte 24/18/12 in `config/game.php → harvester.*`). Alte Tiles mit höherem `resource_max` werden beim nächsten Produktionslauf geclampt, keine rückwirkende Migration.
+- **Verlegekosten:** 1 → 2 AP je Hex (`config('game.harvester.relocate_ap_per_hex')`), verdrahtet in `ColonyController::placeBuilding`.
+- **Zweitinstanz-Gate:** Instanz 1 bleibt Regolith-frei (Bootstrap-Ausnahme); Instanz 2 braucht CC Lv3 und kostet pauschal 100 Regolith. `placeBuilding` akzeptiert jetzt optional `instance_id` (1 oder 2), analog zu Reparieren/Ausbauen.
+- **Geologie-Kenntnis:** erster hartverdrahtete Kenntniseffekt (ROADMAP-Vorgabe: max. zwei vor dem generischen Framework) — +3/+3/+2/+2/+2 je Level, kumuliert max 12, einmal pro Kolonie (nicht je Instanz) additiv auf den Harvester-Ertrag.
+- Aufgedeckter, vorbestehender maskierter Bug: `GameTickDecayTest::test_security_hub_recycles_resources_on_building_level_down` testete Recycling am Harvester, dessen einzige `building_costs`-Zeile (Supply) nicht handelbar ist — das Recycling griff dort nie, nur die zufällige Harvester-Produktion im selben Tick maskierte das. Test auf Agrardom (echter Regolith-Baukosten-Eintrag) umgestellt.
+- `randomizeOuterRingRows()` (Ring-2/3-Seeding) setzt jetzt `resource_amount`/`resource_max` konsistent — vorher liefen echte neue Runs mit NULL-Werten auf den zufälligen Regolith-Tiles.
+- **Sol-1-Pacing-Änderung, Owner/Game-Designer-Bestätigung ausstehend:** Der Start-Harvester steht auf (1,0), einem Koloniezonen-Tile — Koloniezone ist laut `computeColonyZoneCoords()` grundsätzlich regolithfrei. Unter §4c produziert der Harvester dort **0 Regolith bis zur ersten Verlegung**, die Onboarding mit `hint_2` ohnehin schon lehrt. Vorher (Level-Kurve) produzierte er unabhängig vom Tile-Typ sofort. Das macht `hint_2` von einem weichen Hinweis zu einem harten Wirtschafts-Gate — passt zur Mechanik, war aber niemandes explizite Entscheidung. Siehe `HarvesterSol1BootstrapTest`.
+- `public/js/colony-hexgrid.js` / `hexview.blade.php`: Verlege-AP-Vorschau folgt jetzt `config('game.harvester.relocate_ap_per_hex')` statt fest 1 AP/Hex (analog zu `repairDisplayThreshold`).
+
+**§13.7-Zahlensatz umgesetzt** (Stufe 1, ein PR wie im Handoff gefordert). `config/buildings.php`: `decay_rate` in vier Klassen sortiert (0,40/0,60/0,80/1,20), Errichtungskosten der Sol-1-4-Rampe (Agrardom 70, Sciencelab/Cantina 95, Hangar 120), `cc_upgrade_regolith_per_level` 20→30, Hangar `max_level=3` (Schiffsklasse) + Temple/Monument `max_level=1` (§4c "1 Instanz, Lv1"). `config/game.php`: `repair.regolith_per_click` 2→1, `bar.base_prices`/`compound_import_price` nach Knappheitsordnung (Rg 25/Wk 110/165). `config/knowledge.php`: `levelup_costs` 20/28/36/44/52, `credits` 100→0. `ColonyController::levelupRegolithFor()`: Level-Up-Kosten jetzt flach 25 statt 25 % von `build_cost` (CC/Harvester-Sonderfälle unverändert). Elf Tests mit hardcodierten Alt-Werten auf den neuen Zahlensatz nachgezogen (kein Regressionsbruch, erwartete Fallout laut Handoff §2 Platzhalter-Regel). Agrardom Level→Instanz-Umstellung bewusst zurückgestellt auf Stufe 1d (Deckel + Produktionskurve dort noch offen).
+
 ## 2026-08-03
 
 **Beide ausstehenden Freigaben erteilt** — die AP-Struktur (§13.6) und der Regolith-Zahlensatz (§13.7) sind beschlossen, jeweils mit Korrekturen aus einer Konsistenzprüfung gegen §4c.

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -754,6 +754,36 @@ class GameTick extends Command
         return $total;
     }
 
+    /**
+     * Harvester yield for a single tile (GDD §4c "Erschöpfungskurve und Umzugstakt",
+     * freigegeben 2026-08-03) — pure, no DB access.
+     *
+     *   Ertrag = Frischwert × (0,5 + 0,5 × Restvorkommen / resource_max)
+     *
+     * Never drops below half of fresh_yield while resources remain; 0 once exhausted
+     * ($remaining <= 0). $geologyLevel adds the geology Kenntnis bonus (GDD §13.7,
+     * config('game.geology_harvester_bonus_per_level')) on top — callers that apply
+     * the bonus only once per colony (not per harvester instance) must pass 0 here
+     * for every instance but the one carrying the bonus (see generateHarvesterYield()).
+     */
+    public static function harvesterYield(string $tileType, int $remaining, int $resourceMax, int $geologyLevel): int
+    {
+        if ($resourceMax <= 0 || $remaining <= 0) {
+            return 0;
+        }
+
+        $fresh = (int) (config('game.harvester.fresh_yield', [])[$tileType] ?? 0);
+        if ($fresh <= 0) {
+            return 0;
+        }
+
+        $ratio = min(1.0, $remaining / $resourceMax);
+        $base = $fresh * (0.5 + 0.5 * $ratio);
+        $geologyBonus = self::cumulativeCurveYield(config('game.geology_harvester_bonus_per_level', []), $geologyLevel);
+
+        return (int) round($base) + $geologyBonus;
+    }
+
     private function generateResources(int $tick): int
     {
         $productionConfig = config('game.production_curve', []);
@@ -777,7 +807,20 @@ class GameTick extends Command
             $trust = $this->trustService->getTrust($colony->id);
             $multiplier = $this->trustService->getProductionMultiplier($trust);
 
+            $harvesterYield = $this->generateHarvesterYield($tick, $colony, $multiplier);
+            if ($harvesterYield > 0) {
+                ColonyResource::where('colony_id', $colony->id)
+                    ->where('resource_id', 3) // Regolith
+                    ->update(['amount' => DB::raw("amount + {$harvesterYield}")]);
+            }
+
             foreach ($productionConfig as $buildingId => $outputs) {
+                // Harvester (27) is handled above via the depletion mechanic (GDD §4c) —
+                // production_curve[27] stays inert historical data (GDD §13.7).
+                if ((int) $buildingId === BuildingId::Harvester->value) {
+                    continue;
+                }
+
                 $building = DB::table('colony_buildings')
                     ->where('colony_id', $colony->id)
                     ->where('building_id', $buildingId)
@@ -803,6 +846,99 @@ class GameTick extends Command
         }
 
         return $colonies->count();
+    }
+
+    /**
+     * Sums Regolith yield across every Harvester instance of a colony (GDD §4c),
+     * deducting the credited (trust-adjusted) amount from each tile's resource_amount
+     * and clamping stale resource_max values down to the current config (legacy tiles
+     * seeded before the 2026-08-03 500/300/160 reduction — no retroactive migration).
+     *
+     * The geology Kenntnis bonus (§13.7) is applied ONCE per colony — not per Harvester
+     * instance — on whichever active instance is evaluated first, matching "kumuliert
+     * max 12" as a cap on the total effect rather than a per-rig multiplier. The bonus
+     * is deducted from that instance's tile like any other credited yield.
+     */
+    private function generateHarvesterYield(int $tick, Colony $colony, float $multiplier): int
+    {
+        $resourceMaxCfg = config('game.harvester.resource_max', []);
+        $geologyId = (int) config('knowledge.geology.id', 92);
+
+        $instances = DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', BuildingId::Harvester->value)
+            ->where('level', '>', 0)
+            ->get();
+
+        if ($instances->isEmpty()) {
+            return 0;
+        }
+
+        $geologyLevel = (int) DB::table('colony_researches')
+            ->where('colony_id', $colony->id)
+            ->where('research_id', $geologyId)
+            ->value('level');
+        $geologyApplied = false;
+
+        $totalCredited = 0;
+
+        foreach ($instances as $instance) {
+            if ($instance->tile_x === null || $instance->tile_y === null) {
+                continue; // not placed yet
+            }
+
+            if ($instance->pending_until_tick !== null && (int) $instance->pending_until_tick >= $tick) {
+                continue; // in transit — no production this Sol
+            }
+
+            $tile = DB::table('colony_tiles')
+                ->where('colony_id', $colony->id)
+                ->where('q', $instance->tile_x)
+                ->where('r', $instance->tile_y)
+                ->first();
+
+            if (! $tile) {
+                continue;
+            }
+
+            $configMax = (int) ($resourceMaxCfg[$tile->tile_type] ?? 0);
+            if ($configMax <= 0) {
+                continue; // not a regolith tile — nothing to deplete/produce
+            }
+
+            $remaining = min((int) ($tile->resource_amount ?? $configMax), $configMax);
+
+            $geologyForThisTile = $geologyApplied ? 0 : $geologyLevel;
+            $base = self::harvesterYield($tile->tile_type, $remaining, $configMax, $geologyForThisTile);
+
+            if ($base <= 0) {
+                // Still clamp the stale resource_max down for consistency, even
+                // when exhausted or misconfigured.
+                DB::table('colony_tiles')
+                    ->where('colony_id', $colony->id)
+                    ->where('q', $instance->tile_x)
+                    ->where('r', $instance->tile_y)
+                    ->update(['resource_max' => $configMax, 'resource_amount' => $remaining]);
+
+                continue;
+            }
+
+            if (! $geologyApplied) {
+                $geologyApplied = true;
+            }
+
+            $credited = (int) round($base * $multiplier);
+            $totalCredited += $credited;
+
+            $newRemaining = max(0, $remaining - $credited);
+            DB::table('colony_tiles')
+                ->where('colony_id', $colony->id)
+                ->where('q', $instance->tile_x)
+                ->where('r', $instance->tile_y)
+                ->update(['resource_max' => $configMax, 'resource_amount' => $newRemaining]);
+        }
+
+        return $totalCredited;
     }
 
     // ── 8a. Food consumption (Organika provisioning) ──────────────────────────

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -63,10 +63,13 @@ class ColonyController extends BaseController
         return array_map('intval', $cfg['build_cost'] ?? []);
     }
 
+    /** Flat Regolith cost for a level-up on any non-CC, non-Harvester building (GDD §13.7). */
+    private const LEVELUP_REGOLITH_FLAT = 25;
+
     /**
-     * Regolith consumed when a building completes a level-up (flat, no escalation).
+     * Regolith consumed when a building completes a level-up.
      * Rules: CommandCenter scales as target_level × cc_upgrade_regolith_per_level;
-     * Harvester is free (bootstrap); all others = 25 % of build_cost Regolith (min 10).
+     * Harvester is free (bootstrap); all others pay a flat rate, independent of build_cost.
      */
     private function levelupRegolithFor(int $buildingId, int $targetLevel): int
     {
@@ -80,12 +83,7 @@ class ColonyController extends BaseController
             return $targetLevel * $perLevel;
         }
 
-        $erectRegolith = $this->buildCostFor($buildingId)[self::RES_REGOLITH] ?? 0;
-        if ($erectRegolith <= 0) {
-            return 0;
-        }
-
-        return max(10, (int) round($erectRegolith * 0.25));
+        return self::LEVELUP_REGOLITH_FLAT;
     }
 
     public function hexview(): View
@@ -289,6 +287,8 @@ class ColonyController extends BaseController
             'building_id' => 'required|integer',
             'q' => 'required|integer',
             'r' => 'required|integer',
+            // Harvester only: 1 (default, bootstrap-exempt) or 2 (paid expansion, GDD §4c).
+            'instance_id' => 'sometimes|integer|in:1,2',
         ]);
 
         $colony = $this->colonyService->getPrimeColony(Auth::id());
@@ -338,13 +338,16 @@ class ColonyController extends BaseController
             return $this->fail('building_not_found');
         }
 
-        // Path-gate: sciencelab/hangar/bar may only be placed when CC level allows.
-        // Harvester is marked is_instanced=1 in schema but has exactly one instance per colony
-        // and must always be moved (UPDATE), never duplicated (INSERT).
+        // Harvester instance targeted by this request — 1 (default, bootstrap-exempt,
+        // always moved/UPDATEd, never duplicated) or 2 (paid expansion, GDD §4c). Every
+        // other building keeps the existing single-row-per-instanced-slot lookup.
+        $requestedInstanceId = $isHarvester ? (int) ($data['instance_id'] ?? 1) : 1;
+
         $existingBuilding = ($isHarvester || ! $building->is_instanced)
             ? DB::table('colony_buildings')
                 ->where('colony_id', $colony->id)
                 ->where('building_id', $data['building_id'])
+                ->where('instance_id', $requestedInstanceId)
                 ->first()
             : null;
 
@@ -356,6 +359,32 @@ class ColonyController extends BaseController
                 && $existingBuilding->pending_until_tick !== null
                 && (int) $existingBuilding->pending_until_tick >= $this->getTick()) {
             return $this->fail('harvester_in_transit');
+        }
+
+        // Second Harvester instance gate (GDD §4c "Die zweite Instanz braucht ein
+        // Gate"): instance 1 keeps the Regolith-free bootstrap exemption; instance 2
+        // is a paid expansion, gated on CommandCenter level. Only applies to the
+        // FRESH placement (not a subsequent relocation of an already-placed instance 2).
+        $isSecondInstanceFreshPlacement = $isHarvester && $requestedInstanceId === 2 && ! $isHarvesterMove;
+
+        if ($isSecondInstanceFreshPlacement) {
+            $requiredCcLevel = (int) config('game.harvester.second_instance_cc_level', 3);
+            $ccLevel = (int) DB::table('colony_buildings')
+                ->where('colony_id', $colony->id)
+                ->where('building_id', BuildingId::CommandCenter->value)
+                ->value('level');
+
+            if ($ccLevel < $requiredCcLevel) {
+                return $this->fail('harvester_second_instance_cc_gate');
+            }
+
+            $secondInstanceCost = (int) config('game.harvester.second_instance_regolith_cost', 100);
+            if (! config('game.bypass.resource_costs')
+                && ! $this->resourcesService->check([['resource_id' => self::RES_REGOLITH, 'amount' => $secondInstanceCost]], $colony->id)) {
+                return $this->fail('resource_limit', __('colony.error_insufficient_resources'), [
+                    'cost' => [self::RES_REGOLITH => $secondInstanceCost],
+                ]);
+            }
         }
 
         // Agrardom gate: path buildings require Agrardom (41) to be placed first.
@@ -372,8 +401,11 @@ class ColonyController extends BaseController
             }
         }
 
+        // Verlegekosten 1 → 2 AP je Hex (GDD §4c, freigegeben 2026-08-03) — the
+        // relocation-frequency lever, not the depletion curve (config('game.harvester.relocate_ap_per_hex')).
         $apCost = $isHarvesterMove
-            ? max(1, $this->hexDistance((int) $existingBuilding->tile_x, (int) $existingBuilding->tile_y, (int) $data['q'], (int) $data['r']))
+            ? max(1, $this->hexDistance((int) $existingBuilding->tile_x, (int) $existingBuilding->tile_y, (int) $data['q'], (int) $data['r'])
+                * (int) config('game.harvester.relocate_ap_per_hex', 2))
             : 1;
 
         if (! config('game.bypass.ap_checks') && $this->personellService->getConstructionPoints($colony->id) < $apCost) {
@@ -383,12 +415,20 @@ class ColonyController extends BaseController
             ]);
         }
 
-        // Resource + supply gate for regular buildings (the harvester relocates for free,
-        // and CC/Harvester carry no build_cost — bootstrap exemption). Checked before any
-        // DB write so a failed gate leaves the colony untouched.
-        $buildCost = $isHarvester ? [] : $this->buildCostFor((int) $data['building_id']);
+        // Resource + supply gate. Harvester relocation (and its first, bootstrap
+        // instance) is free — CC/Harvester carry no build_cost. The Harvester's
+        // SECOND instance is the one exception: a paid expansion (GDD §4c), charged
+        // its own flat Regolith cost instead of the generic buildCostFor() lookup
+        // (Harvester has no build_cost entry at all). Checked before any DB write so
+        // a failed gate leaves the colony untouched.
+        $buildCost = match (true) {
+            $isSecondInstanceFreshPlacement => [self::RES_REGOLITH => (int) config('game.harvester.second_instance_regolith_cost', 100)],
+            $isHarvester => [],
+            default => $this->buildCostFor((int) $data['building_id']),
+        };
+        $chargesBuildCost = ! $isHarvester || $isSecondInstanceFreshPlacement;
 
-        if (! $isHarvester) {
+        if ($chargesBuildCost) {
             if (! config('game.bypass.resource_costs') && $buildCost !== []) {
                 $costs = [];
                 foreach ($buildCost as $resourceId => $amount) {
@@ -463,7 +503,7 @@ class ColonyController extends BaseController
                 DB::table('colony_buildings')->insert([
                     'colony_id' => $colony->id,
                     'building_id' => $data['building_id'],
-                    'instance_id' => 1,
+                    'instance_id' => $requestedInstanceId,
                     'level' => 0,
                     'status_points' => $building->max_status_points ?? 20,
                     'ap_spend' => 1,
@@ -471,6 +511,7 @@ class ColonyController extends BaseController
                     'tile_y' => $data['r'],
                     'placed_at_tick' => $this->getTick(),
                 ]);
+                $nextInstanceId = $requestedInstanceId;
             }
         }
 
@@ -478,8 +519,9 @@ class ColonyController extends BaseController
             $this->personellService->lockActionPoints('construction', $colony->id, $apCost);
         }
 
-        // Deduct erect cost (Regolith + any Werkstoffe). Harvester relocation is free.
-        if (! $isHarvester && ! config('game.bypass.resource_costs') && $buildCost !== []) {
+        // Deduct erect cost (Regolith + any Werkstoffe). Harvester relocation (and its
+        // bootstrap instance) is free — the second instance's flat Regolith cost is not.
+        if ($chargesBuildCost && ! config('game.bypass.resource_costs') && $buildCost !== []) {
             $costs = [];
             foreach ($buildCost as $resourceId => $amount) {
                 $costs[] = ['resource_id' => $resourceId, 'amount' => $amount];

--- a/app/Services/ColonyTileService.php
+++ b/app/Services/ColonyTileService.php
@@ -211,16 +211,8 @@ class ColonyTileService
                 $isExplored = $isCC || $ring <= 1;
                 $tileType = $isCC ? 'terrain_empty' : $this->pickTileType($q, $r, $colonyId, $ring);
 
-                $resourceAmount = null;
-                $resourceMax = null;
-                if (str_starts_with($tileType, 'regolith_')) {
-                    $resourceMax = match ($tileType) {
-                        'regolith_rich' => 800,
-                        'regolith_normal' => 500,
-                        default => 250,
-                    };
-                    $resourceAmount = $resourceMax;
-                }
+                $resourceMax = $this->resourceMaxFor($tileType);
+                $resourceAmount = $resourceMax;
 
                 $rows[] = [
                     'colony_id' => $colonyId,
@@ -242,6 +234,20 @@ class ColonyTileService
 
         DB::table('colony_tiles')->insertOrIgnore($rows);
         $this->assignColonyZone($colonyId, $ccLevel);
+    }
+
+    /**
+     * Fresh resource_max for a regolith tile_type, sourced from config/game.php
+     * (single source of truth shared with GameTick's harvester yield formula).
+     * Returns null for non-regolith tile types.
+     */
+    private function resourceMaxFor(string $tileType): ?int
+    {
+        if (! str_starts_with($tileType, 'regolith_')) {
+            return null;
+        }
+
+        return (int) (config('game.harvester.resource_max')[$tileType] ?? config('game.harvester.resource_max.regolith_poor', 160));
     }
 
     private function transformTile(ColonyTile $tile): array
@@ -332,17 +338,20 @@ class ColonyTileService
      * (not just their content) — otherwise the "frontier" shape would look
      * identical across every run/reset even though tile_type varies.
      *
-     * @return list<array{q:int,r:int,ring:int,tile_type:string,is_colony_zone:int,is_explored:int}>
+     * @return list<array{q:int,r:int,ring:int,tile_type:string,is_colony_zone:int,is_explored:int,resource_amount:?int,resource_max:?int}>
      */
     public function randomizeOuterRingRows(): array
     {
         $rows = [];
 
         foreach ($this->ringCoords(2) as [$q, $r]) {
+            $tileType = $this->randomTileType(2);
+            $resourceMax = $this->resourceMaxFor($tileType);
             $rows[] = [
                 'q' => $q, 'r' => $r, 'ring' => 2,
-                'tile_type' => $this->randomTileType(2),
+                'tile_type' => $tileType,
                 'is_colony_zone' => 0, 'is_explored' => 0,
+                'resource_amount' => $resourceMax, 'resource_max' => $resourceMax,
             ];
         }
 
@@ -363,6 +372,9 @@ class ColonyTileService
         foreach ($ring3Rows as $i => $row) {
             $row['is_colony_zone'] = 0;
             $row['is_explored'] = ($i === $targetIndex) ? 1 : 0;
+            $resourceMax = $this->resourceMaxFor($row['tile_type']);
+            $row['resource_amount'] = $resourceMax;
+            $row['resource_max'] = $resourceMax;
             $rows[] = $row;
         }
 

--- a/app/Services/OnboardingService.php
+++ b/app/Services/OnboardingService.php
@@ -145,16 +145,27 @@ class OnboardingService
         // Ring 2+3: randomized every call (roguelike) — see
         // ColonyTileService::randomizeOuterRingRows(). Exactly one ring-3 tile is
         // guaranteed pre-explored regolith (Nexus-Scout Harvester relocation target).
+        //
+        // (1,0) — the bootstrap Harvester's starting tile — stays terrain_empty, NOT
+        // regolith: colony-zone tiles are never regolith by design (computeColonyZoneCoords
+        // explicitly skips regolith_* — a zone tile hosts buildings, not extraction), and
+        // onboarding's hint_2 ("Harvester in colony zone → move it out", checkHint2())
+        // already exists specifically to teach the player to relocate it. Under the §4c
+        // depletion mechanic (2026-08-03) this means the Sol-1 Harvester produces 0
+        // Regolith until that relocation happens — a real pacing change from the old
+        // level-curve mechanic (which produced regardless of tile), not a bug: it makes
+        // hint_2 a hard economic step instead of a soft nudge. Flagged for game-designer/
+        // owner confirmation — see HarvesterSol1BootstrapTest and the session report.
         $tiles = [
             // ── Ring 0 ────────────────────────────────────────────────────────
-            ['q' => 0, 'r' => 0, 'ring' => 0, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1],
+            ['q' => 0, 'r' => 0, 'ring' => 0, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1, 'resource_amount' => null, 'resource_max' => null],
             // ── Ring 1 ────────────────────────────────────────────────────────
-            ['q' => 1, 'r' => 0, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1],
-            ['q' => 0, 'r' => 1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1],
-            ['q' => -1, 'r' => 1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1],
-            ['q' => -1, 'r' => 0, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1],
-            ['q' => 0, 'r' => -1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1],
-            ['q' => 1, 'r' => -1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1],
+            ['q' => 1, 'r' => 0, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1, 'resource_amount' => null, 'resource_max' => null],
+            ['q' => 0, 'r' => 1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1, 'resource_amount' => null, 'resource_max' => null],
+            ['q' => -1, 'r' => 1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1, 'resource_amount' => null, 'resource_max' => null],
+            ['q' => -1, 'r' => 0, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1, 'resource_amount' => null, 'resource_max' => null],
+            ['q' => 0, 'r' => -1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1, 'resource_amount' => null, 'resource_max' => null],
+            ['q' => 1, 'r' => -1, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_colony_zone' => 0, 'is_explored' => 1, 'resource_amount' => null, 'resource_max' => null],
         ];
 
         $tiles = array_merge($tiles, $this->tileService->randomizeOuterRingRows());

--- a/config/buildings.php
+++ b/config/buildings.php
@@ -11,8 +11,9 @@
  *                      (3 = Regolith, 4 = Werkstoffe/compounds). Absent = no resource cost
  *                      (CommandCenter + Harvester only — bootstrap exemption). Werkstoffe
  *                      appear only on late/high-tech buildings (accent, 10–25). Level-up
- *                      Regolith is derived as 25 % of build_cost[3] (min 10); CC scales
- *                      separately via cc_upgrade_regolith_per_level. Reparatur: 2 Rg/click.
+ *                      Regolith is a flat 25 for all non-CC/non-Harvester buildings,
+ *                      independent of build_cost (GDD §13.7, 2026-08-03); CC scales
+ *                      separately via cc_upgrade_regolith_per_level. Reparatur: 1 Rg/click.
  *                      Canonical source — synced into building_costs by game:sync-config.
  *   trust_per_lv     — trust change per building level (used by TrustService)
  *   decay_rate       — status_points lost per tick (also stored in DB, used by GameTick decay)
@@ -44,11 +45,15 @@ return [
         // 30 → 20 (playtest review 2026-07-14): with the new Sol-1-4 onboarding ramp
         // (Agrardom → path building → CC Lv2) the CC-Lv2 levelup was the single
         // biggest regolith drain, leaving ~7 Rg buffer on the hangar path by Sol 4.
-        'cc_upgrade_regolith_per_level' => 20,
+        // 20 → 30 (GDD §13.7, 2026-08-03): "zentraler Progressionshebel" — der Zahlensatz
+        // trägt CC-Ausbau jetzt als teuersten Einzelposten des Runs (Bilanz: 75% Sockel-
+        // Deckung der Zielkolonie), s. Handoff docs/handoff-ap-ratenmodell.md §7.
+        'cc_upgrade_regolith_per_level' => 30,
         'supply_cap' => 10,      // cap per level (CC Lv1 = 10, Lv5 = 50 — hard cap Lv5)
         'supply_cost' => 0,
         'trust_per_lv' => 0,
-        'decay_rate' => 0.33,    // 60 days
+        // Klasse "Robust" (GDD §13.7 decay_rate-Klassentabelle, 2026-08-03): 50 Sole bis Level-Down.
+        'decay_rate' => 0.40,
         'max_status_points' => 20,
         'max_level' => 5,
     ],
@@ -59,7 +64,8 @@ return [
         'supply_cap' => 8,       // per unit (instance), max 6 units → +48 cap
         'supply_cost' => 0,
         'trust_per_lv' => 0,
-        'decay_rate' => 0.44,    // 45 days
+        // Klasse "Robust" (GDD §13.7, 2026-08-03): 50 Sole bis Level-Down.
+        'decay_rate' => 0.40,
         'max_status_points' => 20,
         // max_level is a real per-instance level cap (not vestigial): each
         // housingComplex instance levels independently and ResourcesService::
@@ -83,7 +89,8 @@ return [
         // No build_cost: Harvester is the only Regolith source (bootstrap exemption).
         'supply_cost' => 2,
         'trust_per_lv' => 0,
-        'decay_rate' => 0.95,    // 21 days
+        // Klasse "Beansprucht" (GDD §13.7, 2026-08-03): 25 Sole bis Level-Down.
+        'decay_rate' => 0.80,
         'max_status_points' => 20,
         // Harvester ohne Level-Up (Owner-Entscheidung, GDD §13.5/§4c, 2026-08-03):
         // max_level bleibt 1, Wachstum läuft über max_instances (Deckel 2), nicht
@@ -102,10 +109,13 @@ return [
     // levelup endpoint (ColonyService — NOT in this config), not here.
     'bioFacility' => [                  // ex silicatemine (ID 41) — now produces Organika
         'id' => 41,
-        'build_cost' => [3 => 40],   // Regolith only (early)
+        // 40 → 70 (GDD §13.7 Sol-1-4-Rampe, 2026-08-03): Agrardom ist der erste Kauf des
+        // Runs, die Rampenprobe rechnet ihn explizit mit 70 gegen Startbestand 200.
+        'build_cost' => [3 => 70],
         'supply_cost' => 2,
         'trust_per_lv' => 0,
-        'decay_rate' => 0.95,
+        // Klasse "Standard" (GDD §13.7, 2026-08-03): 33 Sole bis Level-Down.
+        'decay_rate' => 0.60,
         'max_status_points' => 20,
         // Hard cap (2026-07-20, GDD §3/§18 balance ticket) — see harvester comment above.
         'max_level' => 8,
@@ -124,10 +134,13 @@ return [
         // Werkstoffe aren't reachable this early (Uplink-Station Lv1 +
         // Cantina/merchant, both later). The previous [Rg+Wk] cost made the
         // Analytiker structurally useless for several Sols right after hiring.
-        'build_cost' => [3 => 80],
+        // 80 → 95 (GDD §13.7, 2026-08-03): Pfad-Parität mit Cantina — die Rampenprobe
+        // rechnet beide Nicht-Hangar-Pfadgebäude mit 95, nur der Hangar-Pfad kostet mehr (120).
+        'build_cost' => [3 => 95],
         'supply_cost' => 8,
         'trust_per_lv' => 0,
-        'decay_rate' => 0.95,    // 21 days
+        // Klasse "Beansprucht" (GDD §13.7, 2026-08-03): 25 Sole bis Level-Down.
+        'decay_rate' => 0.80,
         'max_status_points' => 20,
         'max_level' => null,
     ],
@@ -151,21 +164,25 @@ return [
     //     design decision); the hangar shell itself is the cheapest-to-run path
     //     building, making it the "supply-friendly, Rg-heavy" option.
     //   Trade-off character: supply-light long-term, expensive to build (Rg 90).
-    //   Level-up Rg cost derives as 25% of build_cost[3] → ~22 Rg/level.
+    //   Level-up Rg cost is the flat rate (25), same as every other non-CC building.
     // Building it grants the matching generic advisor slot (Raumfahrer) — see
     // AdvisorController::PATH_BUILDINGS.
     'hangar' => [                       // replaces civilianSpaceyard + militarySpaceyard
         'id' => 44,      // ex civilianSpaceyard — 1 hangar = 1 ship slot
-        'build_cost' => [3 => 80],    // Rg only (90 → 80, playtest review 2026-07-14: path parity — Cantina 70/Lab 80/Hangar 80)
+        // 80 → 120 (GDD §13.7 Sol-1-4-Rampe, 2026-08-03): the priciest of the three path
+        // buildings on purpose — "die teuerste Pfadwahl wird damit zur echten Entscheidung
+        // statt zur kosmetischen." Path parity via trade-off character, not equal cost.
+        'build_cost' => [3 => 120],
         'supply_cost' => 4,       // low: hangar is a shell; ships add no supply cost (2026-06-08)
         'trust_per_lv' => 0,
-        'decay_rate' => 0.67,    // 30 days
+        // Klasse "Standard" (GDD §13.7, 2026-08-03): 33 Sole bis Level-Down.
+        'decay_rate' => 0.60,
         'max_status_points' => 20,
-        'max_level' => null,    // repeatable, supply-limited (per-instance ship-class level, uncapped)
-        // No prior max_level value to carry over (was already NULL) and nothing
-        // currently enforces an instance-count cap for the hangar — left NULL
-        // (uncapped) on purpose (2026-08-03, GDD §4c). Revisit once ship-slot
-        // balancing needs an explicit cap.
+        // max_level = 3 (GDD §4c "Hangar: der einzige Fall mit beiden Achsen", 2026-08-03):
+        // Level ist die Schiffsklasse (Lv1 Drohne, Lv2 Frachter, Lv3 Korvette) — der Techtree
+        // gatet Schiffe bereits so, das Feld holt nur nach. Instanzen bleiben die primäre
+        // Wachstumsachse (Schiffsplätze), unverändert unbegrenzt/supply-limitiert.
+        'max_level' => 3,
         'max_instances' => null,
     ],
 
@@ -176,7 +193,8 @@ return [
         'build_cost' => [3 => 60, 4 => 25],   // late: Regolith + Werkstoffe (accent)
         'supply_cost' => 10,
         'trust_per_lv' => 3,
-        'decay_rate' => 0.67,    // 30 days — core infrastructure, same tier as hangar
+        // Klasse "Beansprucht" (GDD §13.7, 2026-08-03): 25 Sole bis Level-Down.
+        'decay_rate' => 0.80,
         'max_status_points' => 20,
         'max_level' => null,
     ],
@@ -196,13 +214,16 @@ return [
     //     the unambiguous cheapest option.
     //   Trade-off character: balanced cost with Trust bonus — the "always-valid"
     //   option for players who need Trust stability.
-    //   Level-up Rg cost derives as 25% of build_cost[3] → ~17 Rg/level.
+    //   Level-up Rg cost is the flat rate (25), same as every other non-CC building.
     'bar' => [
         'id' => 52,
-        'build_cost' => [3 => 70],   // Regolith only (raised from 50 — see rebalancing note above)
+        // 70 → 95 (GDD §13.7 Sol-1-4-Rampe, 2026-08-03): Pfad-Parität mit Sciencelab —
+        // s. Kommentar dort.
+        'build_cost' => [3 => 95],
         'supply_cost' => 6,          // raised from 4 — balanced by trust_per_lv bonus
         'trust_per_lv' => 2,       // social hub — leisure in an otherwise bleak colony life
-        'decay_rate' => 1.0,     // 20 days — sturdy enough, but needs occasional maintenance
+        // Klasse "Beansprucht" (GDD §13.7, 2026-08-03): 25 Sole bis Level-Down.
+        'decay_rate' => 0.80,
         'max_status_points' => 20,
         'max_level' => null,
     ],
@@ -212,9 +233,13 @@ return [
         'build_cost' => [3 => 60, 4 => 25],   // late: Regolith + Werkstoffe (accent)
         'supply_cost' => 2,
         'trust_per_lv' => 2,
-        'decay_rate' => 0.33,    // 60 days — monuments are built to last
+        // Klasse "Robust" (GDD §13.7, 2026-08-03): 50 Sole bis Level-Down.
+        'decay_rate' => 0.40,
         'max_status_points' => 20,
-        'max_level' => null,
+        // 1 Instanz, Lv1 (GDD §4c Zuordnungstabelle, 2026-08-03): "Ein Denkmal, fertig
+        // oder nicht" — weder Instanz- noch Level-Wachstum. is_instanced bleibt false
+        // (eine Kopie), max_level=1 kappt das bisher unbegrenzte Hochleveln.
+        'max_level' => 1,
     ],
 
     'temple' => [
@@ -222,9 +247,12 @@ return [
         'build_cost' => [3 => 50, 4 => 15],   // late: Regolith + Werkstoffe (accent)
         'supply_cost' => 4,
         'trust_per_lv' => 2,
-        'decay_rate' => 2.0,     // 10 days — needs regular upkeep
+        // Klasse "Fragil" (GDD §13.7, 2026-08-03): 17 Sole bis Level-Down — bewusst der
+        // teuerste Unterhalt im Spiel, sie zahlt in Vertrauen statt Funktion.
+        'decay_rate' => 1.20,
         'max_status_points' => 20,
-        'max_level' => null,
+        // 1 Instanz, Lv1 (GDD §4c, 2026-08-03) — "ein Bekenntnis, kein Ausbauprojekt".
+        'max_level' => 1,
     ],
 
     // ── Phase 3g — implementiert (Mai 2026) ──────────────────────────────────
@@ -250,7 +278,8 @@ return [
         'build_cost' => [3 => 80, 4 => 25],   // Regolith + Werkstoffe (Compounds gate accepted — see GDD §4)
         'supply_cost' => 8,
         'trust_per_lv' => 1,                   // +1 trust per level (Lv3 max = +3)
-        'decay_rate' => 0.67,    // 30 days — provisional
+        // Klasse "Standard" (GDD §13.7, 2026-08-03): 33 Sole bis Level-Down.
+        'decay_rate' => 0.60,
         'max_status_points' => 20,
         'max_level' => 3,
         'recycle_pct' => 0.10,                 // fraction of build cost returned on level-down
@@ -270,7 +299,8 @@ return [
         'build_cost' => [3 => 80],
         'supply_cost' => 6,
         'trust_per_lv' => 0,
-        'decay_rate' => 0.67,    // 30 days — provisional
+        // Klasse "Standard" (GDD §13.7, 2026-08-03): 33 Sole bis Level-Down.
+        'decay_rate' => 0.60,
         'max_status_points' => 20,
         'max_level' => 3,
     ],
@@ -284,7 +314,8 @@ return [
         'build_cost' => [3 => 100, 4 => 25],   // late: Regolith + Werkstoffe (accent)
         'supply_cost' => 6,
         'trust_per_lv' => 0,
-        'decay_rate' => 0.67,    // 30 days — provisional
+        // Klasse "Standard" (GDD §13.7, 2026-08-03): 33 Sole bis Level-Down.
+        'decay_rate' => 0.60,
         'max_status_points' => 20,
         'max_level' => 3,
         'merchant_price_bonus' => 0.12,    // +12% trade value when Reisender Händler present

--- a/config/game.php
+++ b/config/game.php
@@ -65,18 +65,57 @@ return [
     // CC upgrades, path buildings, repairs); bioFacility peaks early (Organika/food
     // security must stand up fast, before the hunger→trust spiral bites).
     'production_curve' => [
-        27 => [3 => [1 => 8, 2 => 10, 3 => 12, 4 => 12, 5 => 10, 6 => 8, 7 => 6, 8 => 4]],   // harvester → Regolith
+        27 => [3 => [1 => 8, 2 => 10, 3 => 12, 4 => 12, 5 => 10, 6 => 8, 7 => 6, 8 => 4]],   // harvester → Regolith (inert since §4c depletion wiring — see game.harvester below)
         41 => [5 => [1 => 8, 2 => 12, 3 => 12, 4 => 9, 5 => 7, 6 => 5, 7 => 3, 8 => 2]],     // bioFacility → Organika
     ],
+
+    // Harvester depletion mechanic (GDD §4c "Erschöpfungskurve und Umzugstakt",
+    // freigegeben 2026-08-03). Replaces production_curve[27] as the actual Regolith
+    // source — the curve above stays as inert historical data (GDD §13.7).
+    //
+    //   Ertrag = Frischwert × (0,5 + 0,5 × Restvorkommen / resource_max)
+    //
+    // Never drops below half of fresh_yield; at resource_amount <= 0, yield is 0
+    // (relocation is player-triggered, not automatic). ColonyTileService reads the
+    // same resource_max map so tile seeding and production can't drift apart.
+    'harvester' => [
+        'fresh_yield' => [
+            'regolith_rich' => 24,
+            'regolith_normal' => 18,
+            'regolith_poor' => 12,
+        ],
+        'resource_max' => [
+            'regolith_rich' => 500,
+            'regolith_normal' => 300,
+            'regolith_poor' => 160,
+        ],
+        // Verlegekosten 1 → 2 AP je Hex (GDD §4c, 2026-08-03) — the relocation-frequency
+        // lever, not the depletion curve itself (see GDD §4c "Der eigentliche Regler...").
+        'relocate_ap_per_hex' => 2,
+        // Second harvester instance gate (GDD §4c "Die zweite Instanz braucht ein Gate"):
+        // instance 1 keeps the Regolith-free bootstrap exemption; instance 2 is a paid
+        // expansion, gated on CommandCenter level.
+        'second_instance_cc_level' => 3,
+        'second_instance_regolith_cost' => 100,
+    ],
+
+    // Geology (config/knowledge.php id 92) production bonus — first of at most two
+    // hardcoded Kenntnis-Effekte before the generic effect framework is mandatory
+    // (ROADMAP Stufe 1, GDD §13.7). Additive Regolith bonus per Harvester-Sol,
+    // cumulative across levels, capped at level 5 (+3+3+2+2+2 = 12 max).
+    'geology_harvester_bonus_per_level' => [1 => 3, 2 => 3, 3 => 2, 4 => 2, 5 => 2],
 
     // Economy — resource pricing for player-facing buy/sell mechanics.
     'economy' => [
         // Werkstoffe (compounds, resource 4) are not locally producible (GDD §3).
         // The Nexus direct import (gated behind Uplink-Station Lv1) is the guaranteed
         // safety-net source: a fixed Credits price per unit, always available. Set
-        // deliberately above the Cantina spot price (~60) so the Cantina/merchant stay
+        // deliberately above the Cantina spot price so the Cantina/merchant stay
         // the cheaper, opportunistic source and the Nexus stays the expensive fallback.
-        'compound_import_price' => 90,
+        // 90 → 165 (GDD §13.7, 2026-08-03): holds the ~1.5:1 ratio to the new Werkstoffe
+        // spot price (110) required by the Knappheitsordnung (§3) after the bar.base_prices
+        // correction below — Werkstoffe stay the scarcest good, Regolith < Organika < Werkstoffe.
+        'compound_import_price' => 165,
     ],
 
     // Kolonisten-Zulage (GDD §14) — player-triggered Credits→Trust action.
@@ -93,7 +132,10 @@ return [
     // Manual building repair — Regolith cost per click (1 SP), on top of 1 Construction-AP.
     // CommandCenter + Harvester are exempt (AP-only, bootstrap anchor against decay spiral).
     'repair' => [
-        'regolith_per_click' => 2,
+        // 2 → 1 (GDD §13.7, 2026-08-03): with repair also costing 1 Construction-AP,
+        // 1 Rg/click makes Instandhaltung [Rg/Sol] = Instandhaltung [AP/Sol] = Σ decay_rate —
+        // one number drives both currencies, no separate "feels expensive" multiplier needed.
+        'regolith_per_click' => 1,
 
         // Damage display threshold (fraction of max_status_points): tiles show the
         // damage badge/status tint only below this. The 16/20 (80%) starting damage
@@ -201,7 +243,10 @@ return [
     // level_max_concurrent: max simultaneous active offers per colony, keyed by bar level.
     // compounds_bias_at_rank3: probability that a credits→resource offer targets compounds at trader rank 3.
     'bar' => [
-        'base_prices' => [3 => 30, 4 => 60, 5 => 50], // regolith, compounds, organics
+        // Rg 30→25 / Or 50 (unverändert) / Wk 60→110 (GDD §13.7 "Korrektur durch die
+        // Knappheitsordnung", 2026-08-03): respektiert §3 Regolith < Organika < Werkstoffe —
+        // der Abstand Organika↔Werkstoffe war zu klein, um "deutlich knapper" zu zeigen.
+        'base_prices' => [3 => 25, 4 => 110, 5 => 50], // regolith, compounds, organics
         'price_variance' => 0.20,
         'trader_discount' => [0 => 0.00, 1 => 0.10, 2 => 0.20, 3 => 0.30],
         'guest_count' => [0 => [0, 1], 1 => [0, 1], 2 => [0, 2], 3 => [1, 2]],

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -23,12 +23,10 @@
 return [
 
     // levelup_costs: AP needed to reach that level (index = target level, 1–5).
-    // Cumulative: Lv0→1 = 12 AP, Lv0→5 = 152 AP total (raised from 101, playtest
-    // review 2026-07-14 — Lv1 at 5 AP completed inside a single Sol, which read
-    // as "too cheap"/instant; the whole point of Kenntnisse is a multi-Sol
-    // investment even at Lv1). Richtwert: Junior-Analytiker (10 AP/Sol, base 6 +
-    // Rang-1-Bonus 4) braucht ~2 Sole für Lv1, ~11-13 Sole für Lv5 inklusive der
-    // eigenen Rangaufstiege (Rang 2 bei 10 aktiven Ticks, Rang 3 bei 20).
+    // Raised 12/20/30/40/50 → 20/28/36/44/52 (GDD §13.7, 2026-08-03, Owner-Entscheidung):
+    // amortization ~7 Sole against the new AP-Ratenmodell sockel (ap.base=12). credits
+    // dropped 100 → 0 in the same change (§4b Pfad-A-Credits-Lücke — Analytiker path
+    // has no other Credits sink to justify a per-level fee).
     // ⚠️ Diese Kurve ist an game.ap.base / advisor.ap_per_rank gekoppelt — bei
     // Änderung dort gegen die AP/Sol-Rate neu prüfen, nicht isoliert betrachten.
 
@@ -37,8 +35,8 @@ return [
         'trust_per_lv' => 0,
         'decay_rate' => 0,
         'max_status_points' => 20,
-        'credits' => 100,
-        'levelup_costs' => [1 => 12, 2 => 20, 3 => 30, 4 => 40, 5 => 50],
+        'credits' => 0,
+        'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
     ],
 
     'cartography' => [
@@ -46,8 +44,8 @@ return [
         'trust_per_lv' => 0,
         'decay_rate' => 0,
         'max_status_points' => 20,
-        'credits' => 100,
-        'levelup_costs' => [1 => 12, 2 => 20, 3 => 30, 4 => 40, 5 => 50],
+        'credits' => 0,
+        'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
     ],
 
     'geology' => [
@@ -55,8 +53,8 @@ return [
         'trust_per_lv' => 0,
         'decay_rate' => 0,
         'max_status_points' => 20,
-        'credits' => 100,
-        'levelup_costs' => [1 => 12, 2 => 20, 3 => 30, 4 => 40, 5 => 50],
+        'credits' => 0,
+        'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
     ],
 
     'agronomy' => [
@@ -64,8 +62,8 @@ return [
         'trust_per_lv' => 1,       // see GDD §13
         'decay_rate' => 0,
         'max_status_points' => 20,
-        'credits' => 100,
-        'levelup_costs' => [1 => 12, 2 => 20, 3 => 30, 4 => 40, 5 => 50],
+        'credits' => 0,
+        'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
     ],
 
     'health' => [
@@ -73,8 +71,8 @@ return [
         'trust_per_lv' => 2,       // see GDD §13
         'decay_rate' => 0,
         'max_status_points' => 20,
-        'credits' => 100,
-        'levelup_costs' => [1 => 12, 2 => 20, 3 => 30, 4 => 40, 5 => 50],
+        'credits' => 0,
+        'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
     ],
 
     'trade' => [
@@ -82,8 +80,8 @@ return [
         'trust_per_lv' => 0,
         'decay_rate' => 0,
         'max_status_points' => 20,
-        'credits' => 100,
-        'levelup_costs' => [1 => 12, 2 => 20, 3 => 30, 4 => 40, 5 => 50],
+        'credits' => 0,
+        'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
     ],
 
     'defense' => [
@@ -91,8 +89,8 @@ return [
         'trust_per_lv' => -1,      // see GDD §13 — vigilance dampens trust slightly
         'decay_rate' => 0,
         'max_status_points' => 20,
-        'credits' => 100,
-        'levelup_costs' => [1 => 12, 2 => 20, 3 => 30, 4 => 40, 5 => 50],
+        'credits' => 0,
+        'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
     ],
 
 ];

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -152,6 +152,7 @@ return [
     'error_tile_not_buildable' => 'Nur bebaubare Terrain-Tiles erlaubt.',
     'error_tile_outside_colony' => 'Dieses Tile liegt außerhalb der Koloniezone.',
     'error_harvester_needs_regolith' => 'Harvester kann nur auf Regolith-Tiles platziert werden.',
+    'error_harvester_second_instance_cc_gate' => 'Zweiter Harvester erst ab Kommandozentrale Level 3 möglich.',
     'harvester_move' => 'Verlegen',
     'harvester_move_mode_hint' => 'Erkundetes Regolith-Tile außerhalb der Koloniezone anklicken — zeigt Vorschaupfeil mit AP-Kosten. Gedrückt halten zum Verlegen.',
     'harvester_move_no_targets' => 'Kein freies erkundetes Regolith-Tile verfügbar — erst neue Tiles erkunden (Nav-AP).',

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -114,6 +114,7 @@ function colonyHexView(config) {
         exploreCostDefault: config.exploreCostDefault ?? 1,
         tileYields: config.tileYields ?? {},
         repairDisplayThreshold: config.repairDisplayThreshold ?? 0.7,
+        relocateApPerHex: config.relocateApPerHex ?? 2,
         phaseProgress: config.phaseProgress ?? null,
         nexusImportAmount: 10,
         selectedTile: null,
@@ -177,6 +178,7 @@ function colonyHexView(config) {
                 harvesterBuilding: this.harvesterMoveMode ? this.harvesterBuilding() : null,
                 tileYields: this.tileYields,
                 repairDisplayThreshold: this.repairDisplayThreshold,
+                relocateApPerHex: this.relocateApPerHex,
                 panState: this._panState,
             });
         },
@@ -1011,7 +1013,7 @@ function initHexGrid(container, tiles, opts = {}) {
 
             const hexPath = hexLinePath(hv.tile_x, hv.tile_y, tile.q, tile.r);
             const pixelPath = hexPath.map(([q, r]) => axialToPixel(q, r));
-            const apCost = Math.max(1, hexPath.length - 1);
+            const apCost = Math.max(1, hexPath.length - 1) * (opts.relocateApPerHex ?? 2);
             const targetYield = yields[tile.tile_type] ?? 0;
             const label = `${apCost} AP · ${currentYield}→${targetYield} Rg`;
             const targetPos = pixelPath[pixelPath.length - 1];

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -48,6 +48,7 @@
             exploreCostDefault: {{ (int) config("game.colony.explore_cost_default", 1) }},
             tileYields: @json(collect(config("tile_types"))->map(fn($t) => $t["base_yield"])->filter()),
             repairDisplayThreshold: {{ (float) config("game.repair.display_threshold", 0.7) }},
+            relocateApPerHex: {{ (int) config("game.harvester.relocate_ap_per_hex", 2) }},
             phaseProgress: @json($phaseProgress),
             routes: {
                 explore: '{{ route("colony.tile.explore") }}',

--- a/tests/Feature/Colony/BuildResourceSinkTest.php
+++ b/tests/Feature/Colony/BuildResourceSinkTest.php
@@ -15,9 +15,10 @@ use Tests\TestCase;
  *  - Erecting a building deducts Regolith (+ Werkstoffe on late buildings); CC/Harvester
  *    are bootstrap-exempt. A shortfall is rejected with no DB write.
  *  - Supply is a cap gate (free cap ≥ supply_cost), not a stockpile deduction.
- *  - Level-up deducts flat Regolith (25 % of erect cost; CC scales target_level × 30),
- *    charged only on the completing click — a shortfall never burns the AP.
- *  - Repair deducts 2 Regolith per click (hard gate); CC + Harvester are exempt.
+ *  - Level-up deducts flat Regolith (flat 25 for non-CC/non-Harvester; CC scales
+ *    target_level × 30), charged only on the completing click — a shortfall never
+ *    burns the AP.
+ *  - Repair deducts 1 Regolith per click (hard gate); CC + Harvester are exempt.
  *  - Nexus compound import: gated by Uplink Lv1, spends Credits, grants Werkstoffe.
  *
  * Fixture: Colony 1 (Springfield), user_id=3 (Bart). Start resources: 250 Regolith (3),
@@ -119,9 +120,9 @@ class BuildResourceSinkTest extends TestCase
         $rg = $this->colonyRes(self::RES_REGOLITH);
         $wk = $this->colonyRes(self::RES_COMPOUNDS);
 
-        $this->place(44, 1, 0)->assertOk()->assertJsonPath('ok', true);   // hangar = 80 Rg
+        $this->place(44, 1, 0)->assertOk()->assertJsonPath('ok', true);   // hangar = 120 Rg
 
-        $this->assertSame($rg - 80, $this->colonyRes(self::RES_REGOLITH));
+        $this->assertSame($rg - 120, $this->colonyRes(self::RES_REGOLITH));
         $this->assertSame($wk, $this->colonyRes(self::RES_COMPOUNDS));   // Wk unchanged
     }
 
@@ -150,19 +151,33 @@ class BuildResourceSinkTest extends TestCase
 
     public function test_cc_levelup_deducts_scaled_regolith(): void
     {
-        $this->setCc(['level' => 1, 'ap_spend' => 9, 'status_points' => 16]);   // 1 AP from Lv2 → 2×20 = 40 Rg
+        $this->setCc(['level' => 1, 'ap_spend' => 9, 'status_points' => 16]);   // 1 AP from Lv2 → 2×30 = 60 Rg
         $before = $this->colonyRes(self::RES_REGOLITH);
 
         $this->actingAs($this->bart())->postJson(route('colony.building.invest'), ['building_id' => 25])
             ->assertOk()->assertJsonPath('leveled_up', true);
 
-        $this->assertSame($before - 40, $this->colonyRes(self::RES_REGOLITH));
+        $this->assertSame($before - 60, $this->colonyRes(self::RES_REGOLITH));
+    }
+
+    public function test_non_cc_levelup_deducts_flat_regolith_regardless_of_build_cost(): void
+    {
+        // Sciencelab build_cost[3]=95 (25% would be 24) — GDD §13.7 flat 25 applies
+        // regardless of the erect cost.
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 31)
+            ->update(['level' => 1, 'ap_spend' => 9, 'status_points' => 10]);
+        $before = $this->colonyRes(self::RES_REGOLITH);
+
+        $this->actingAs($this->bart())->postJson(route('colony.building.invest'), ['building_id' => 31])
+            ->assertOk()->assertJsonPath('leveled_up', true);
+
+        $this->assertSame($before - 25, $this->colonyRes(self::RES_REGOLITH));
     }
 
     public function test_levelup_blocked_without_regolith_keeps_ap(): void
     {
         $this->setCc(['level' => 1, 'ap_spend' => 9, 'status_points' => 16]);
-        $this->setColonyRes(self::RES_REGOLITH, 10);   // < 40 needed for CC Lv2
+        $this->setColonyRes(self::RES_REGOLITH, 10);   // < 60 needed for CC Lv2
 
         $this->actingAs($this->bart())->postJson(route('colony.building.invest'), ['building_id' => 25])
             ->assertStatus(422)->assertJsonPath('ok', false)->assertJsonPath('error', 'resource_limit');
@@ -175,7 +190,7 @@ class BuildResourceSinkTest extends TestCase
 
     // ── Repair costs ─────────────────────────────────────────────────────────
 
-    public function test_repair_deducts_two_regolith(): void
+    public function test_repair_deducts_one_regolith(): void
     {
         $this->ensureBuildableTile(1, 0);
         config(['game.bypass.supply_checks' => true]);
@@ -187,7 +202,7 @@ class BuildResourceSinkTest extends TestCase
         $this->actingAs($this->bart())->postJson(route('colony.building.repair'), ['building_id' => 46])
             ->assertOk()->assertJsonPath('ok', true);
 
-        $this->assertSame($before - 2, $this->colonyRes(self::RES_REGOLITH));
+        $this->assertSame($before - 1, $this->colonyRes(self::RES_REGOLITH));
     }
 
     public function test_repair_hard_gate_without_regolith(): void

--- a/tests/Feature/Colony/HarvesterRelocateApCostTest.php
+++ b/tests/Feature/Colony/HarvesterRelocateApCostTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Colony;
+
+use App\Models\User;
+use App\Services\TickService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Harvester relocation AP cost (GDD §4c "Verlegekosten 1 → 2 AP je Hex",
+ * freigegeben 2026-08-03) — the relocation-frequency lever, not the
+ * depletion curve. A typical four-hex move now costs 8 Construction-AP
+ * instead of 4.
+ *
+ * Fixture: Colony 1 (Springfield), user_id=3 (Bart), harvester building_id=27.
+ */
+class HarvesterRelocateApCostTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const BART_USER_ID = 3;
+
+    private const HARVESTER_ID = 27;
+
+    private const TRUST_RES_ID = 12;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        // Neutral trust → AP multiplier 1.0.
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
+            ['amount' => 0]
+        );
+        DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
+
+        // phpunit.xml bypasses AP checks by default (GAME_BYPASS_AP=true) — disable it
+        // here so the real AP gate/lock path is exercised (see BuildingRepairTest).
+        config(['game.bypass.ap_checks' => false]);
+
+        // Ample Construction-AP so an 8-AP move is never blocked by the gate itself
+        // (isolates the AP-cost assertion from the availability check).
+        config(['game.ap.base' => 20]);
+
+        // Harvester at level 1 on tile (0,0) — 4 hexes from the (4,0) target.
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::HARVESTER_ID, 'instance_id' => 1],
+            ['level' => 1, 'status_points' => 16, 'ap_spend' => 0, 'tile_x' => 0, 'tile_y' => 0, 'pending_until_tick' => null]
+        );
+
+        DB::table('colony_tiles')->insertOrIgnore([
+            ['colony_id' => self::COLONY_ID, 'q' => 0, 'r' => 0, 'ring' => 0, 'tile_type' => 'terrain_empty', 'is_explored' => 1, 'is_colony_zone' => 1, 'is_deep_scanned' => 0, 'resource_amount' => null, 'resource_max' => null],
+            ['colony_id' => self::COLONY_ID, 'q' => 4, 'r' => 0, 'ring' => 4, 'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0, 'resource_amount' => 300, 'resource_max' => 300],
+        ]);
+    }
+
+    private function makeUser(): User
+    {
+        return User::where('user_id', self::BART_USER_ID)->firstOrFail();
+    }
+
+    private function currentTick(): int
+    {
+        return $this->app->make(TickService::class)->getTickCount();
+    }
+
+    private function lockedConstructionAp(): int
+    {
+        $tick = $this->currentTick();
+
+        return (int) DB::table('locked_actionpoints')
+            ->where('tick', $tick)
+            ->where('scope_type', 'colony')
+            ->where('scope_id', self::COLONY_ID)
+            ->where('personell_id', config('advisors.engineer.id', 35))
+            ->value('spend_ap') ?? 0;
+    }
+
+    public function test_four_hex_move_costs_eight_construction_ap(): void
+    {
+        $response = $this->actingAs($this->makeUser())
+            ->postJson(route('colony.building.place'), [
+                'building_id' => self::HARVESTER_ID,
+                'q' => 4,
+                'r' => 0,
+            ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+        $this->assertSame(8, $this->lockedConstructionAp(), 'A 4-hex relocation must cost 4 × 2 = 8 Construction-AP (GDD §4c)');
+    }
+}

--- a/tests/Feature/Colony/HarvesterSecondInstanceTest.php
+++ b/tests/Feature/Colony/HarvesterSecondInstanceTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Tests\Feature\Colony;
+
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Second Harvester instance gate (GDD §4c "Die zweite Instanz braucht ein Gate",
+ * freigegeben 2026-08-03).
+ *
+ * Instance 1 keeps the Regolith-free bootstrap exemption (§3). Instance 2 is a
+ * paid expansion: requires CommandCenter Lv3 AND costs a flat 100 Regolith —
+ * not the generic buildCostFor() path (Harvester has no build_cost entry).
+ *
+ * Fixture: Colony 1 (Springfield), user_id=3 (Bart), harvester building_id=27,
+ * CC building_id=25.
+ */
+class HarvesterSecondInstanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const BART_USER_ID = 3;
+
+    private const HARVESTER_ID = 27;
+
+    private const CC_ID = 25;
+
+    private const RES_REGOLITH = 3;
+
+    private const TRUST_RES_ID = 12;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
+            ['amount' => 0]
+        );
+        DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
+
+        // Instance 1 already placed and running.
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::HARVESTER_ID, 'instance_id' => 1],
+            ['level' => 1, 'status_points' => 16, 'ap_spend' => 0, 'tile_x' => 3, 'tile_y' => 0, 'pending_until_tick' => null]
+        );
+
+        // No instance 2 yet.
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)->where('building_id', self::HARVESTER_ID)->where('instance_id', 2)
+            ->delete();
+
+        DB::table('colony_tiles')->insertOrIgnore([
+            ['colony_id' => self::COLONY_ID, 'q' => 3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0, 'resource_amount' => 300, 'resource_max' => 300],
+            ['colony_id' => self::COLONY_ID, 'q' => -3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_poor', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0, 'resource_amount' => 160, 'resource_max' => 160],
+        ]);
+
+        // Ample Construction-AP so the AP gate never blocks these assertions.
+        config(['game.ap.base' => 20]);
+        config(['game.bypass.ap_checks' => false]);
+        config(['game.bypass.resource_costs' => false]);
+        config(['game.bypass.supply_checks' => true]);
+    }
+
+    private function makeUser(): User
+    {
+        return User::where('user_id', self::BART_USER_ID)->firstOrFail();
+    }
+
+    private function setCcLevel(int $level): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::CC_ID, 'instance_id' => 1],
+            ['level' => $level, 'status_points' => 20, 'ap_spend' => 0]
+        );
+    }
+
+    private function setRegolith(int $amount): void
+    {
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::RES_REGOLITH],
+            ['amount' => $amount]
+        );
+    }
+
+    private function regolithAmount(): int
+    {
+        return (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)->where('resource_id', self::RES_REGOLITH)
+            ->value('amount');
+    }
+
+    private function placeSecondInstance()
+    {
+        return $this->actingAs($this->makeUser())
+            ->postJson(route('colony.building.place'), [
+                'building_id' => self::HARVESTER_ID,
+                'q' => -3,
+                'r' => 0,
+                'instance_id' => 2,
+            ]);
+    }
+
+    private function instance2Row(): ?object
+    {
+        return DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)->where('building_id', self::HARVESTER_ID)->where('instance_id', 2)
+            ->first();
+    }
+
+    public function test_second_instance_rejected_before_cc_level_3(): void
+    {
+        $this->setCcLevel(2);
+        $this->setRegolith(500);
+
+        $response = $this->placeSecondInstance();
+
+        $response->assertStatus(422)->assertJsonPath('ok', false);
+        $this->assertSame('harvester_second_instance_cc_gate', $response->json('error'));
+        $this->assertNull($this->instance2Row(), 'No instance 2 row must be created when the CC gate fails');
+        $this->assertSame(500, $this->regolithAmount(), 'Regolith must not be deducted when the gate fails');
+    }
+
+    public function test_second_instance_accepted_after_cc_level_3_with_enough_regolith(): void
+    {
+        $this->setCcLevel(3);
+        $this->setRegolith(150);
+
+        $response = $this->placeSecondInstance();
+
+        $response->assertOk()->assertJsonPath('ok', true);
+        $row = $this->instance2Row();
+        $this->assertNotNull($row, 'Instance 2 must be created once the CC gate is met');
+        $this->assertSame(-3, (int) $row->tile_x);
+        $this->assertSame(150 - 100, $this->regolithAmount(), 'Second instance must cost exactly 100 Regolith');
+    }
+
+    /**
+     * Instance 2 is placed at level=0 (the same convention as every other
+     * instanced building, e.g. Housing) — it does not produce until levelled
+     * up via the generic investBuilding() endpoint. This is intentional per
+     * GDD §4c ("Sie ist eine Expansion und wird bezahlt wie jede andere") and
+     * NOT a dead end: harvester.ap_for_levelup=10 (testdata), so 10
+     * Construction-AP clicks bring it to level 1, after which it produces
+     * exactly like instance 1.
+     */
+    public function test_second_instance_produces_only_after_being_leveled_up_via_invest(): void
+    {
+        $this->setCcLevel(3);
+        $this->setRegolith(150);
+        $this->placeSecondInstance()->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertSame(0, $this->instance2Row()->level, 'Freshly placed instance 2 starts at level 0, same as any other instanced building');
+
+        // Disable instance 1 for this test so only instance 2's production is measured.
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)->where('building_id', self::HARVESTER_ID)->where('instance_id', 1)
+            ->update(['level' => 0]);
+
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::RES_REGOLITH],
+            ['amount' => 1000]
+        );
+        $before = $this->regolithAmount();
+
+        Artisan::call('game:tick', ['--tick' => 25000]);
+        $this->assertSame($before, $this->regolithAmount(), 'Level-0 instance 2 must not produce before being invested');
+
+        // ap_for_levelup for building 27 is 10 (testdata); placement already spent
+        // 1 (ap_spend=1) — 9 more Construction-AP clicks reach the threshold.
+        for ($i = 0; $i < 9; $i++) {
+            $this->actingAs($this->makeUser())
+                ->postJson(route('colony.building.invest'), ['building_id' => self::HARVESTER_ID, 'instance_id' => 2])
+                ->assertOk();
+        }
+        $this->assertSame(1, $this->instance2Row()->level, 'Instance 2 must reach level 1 after ap_for_levelup Construction-AP investments');
+
+        $before = $this->regolithAmount();
+        Artisan::call('game:tick', ['--tick' => 25001]);
+        $this->assertGreaterThan($before, $this->regolithAmount(), 'Instance 2 must produce once levelled to 1, exactly like instance 1');
+    }
+
+    public function test_second_instance_rejected_without_enough_regolith(): void
+    {
+        $this->setCcLevel(3);
+        $this->setRegolith(50);
+
+        $response = $this->placeSecondInstance();
+
+        $response->assertStatus(422)->assertJsonPath('ok', false);
+        $this->assertSame('resource_limit', $response->json('error'));
+        $this->assertNull($this->instance2Row(), 'No instance 2 row must be created when Regolith is insufficient');
+        $this->assertSame(50, $this->regolithAmount(), 'Regolith must not be deducted when the check fails');
+    }
+
+    public function test_first_instance_stays_regolith_free_regardless_of_cc_level(): void
+    {
+        // Regression guard: the gate/cost must apply ONLY to instance 2 — moving
+        // instance 1 stays free at any CC level (bootstrap exemption, GDD §3).
+        $this->setCcLevel(1);
+        $this->setRegolith(0);
+
+        $response = $this->actingAs($this->makeUser())
+            ->postJson(route('colony.building.place'), [
+                'building_id' => self::HARVESTER_ID,
+                'q' => -3,
+                'r' => 0,
+            ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+        $this->assertSame(0, $this->regolithAmount(), 'Instance 1 relocation must stay free');
+    }
+}

--- a/tests/Feature/Colony/HarvesterTransitTest.php
+++ b/tests/Feature/Colony/HarvesterTransitTest.php
@@ -53,12 +53,18 @@ class HarvesterTransitTest extends TestCase
             ['level' => 1, 'status_points' => 16, 'ap_spend' => 0, 'tile_x' => 1, 'tile_y' => 0, 'pending_until_tick' => null]
         );
 
-        // Tiles: start tile + two explored regolith targets outside the colony zone
+        // Tiles: start tile + two explored regolith targets outside the colony zone.
+        // Start tile is regolith (GDD §4c depletion wiring reads the Harvester's actual
+        // tile) — resource_amount/resource_max set so production is exercised, not a
+        // fixture artefact that happens to be terrain.
         DB::table('colony_tiles')->insertOrIgnore([
-            ['colony_id' => self::COLONY_ID, 'q' => 1, 'r' => 0, 'ring' => 1, 'tile_type' => 'terrain_empty', 'is_explored' => 1, 'is_colony_zone' => 1, 'is_deep_scanned' => 0],
-            ['colony_id' => self::COLONY_ID, 'q' => 3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0],
-            ['colony_id' => self::COLONY_ID, 'q' => -3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_poor', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0],
+            ['colony_id' => self::COLONY_ID, 'q' => 1, 'r' => 0, 'ring' => 1, 'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 1, 'is_deep_scanned' => 0, 'resource_amount' => 300, 'resource_max' => 300],
+            ['colony_id' => self::COLONY_ID, 'q' => 3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0, 'resource_amount' => 300, 'resource_max' => 300],
+            ['colony_id' => self::COLONY_ID, 'q' => -3, 'r' => 0, 'ring' => 3, 'tile_type' => 'regolith_poor', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0, 'resource_amount' => 160, 'resource_max' => 160],
         ]);
+        DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 1)->where('r', 0)
+            ->update(['tile_type' => 'regolith_normal', 'resource_amount' => 300, 'resource_max' => 300]);
     }
 
     private function makeUser(int $userId): User

--- a/tests/Feature/GameTick/GameTickDecayTest.php
+++ b/tests/Feature/GameTick/GameTickDecayTest.php
@@ -159,10 +159,16 @@ class GameTickDecayTest extends TestCase
      * SecurityHub recycles 10% of tradeable build costs back to the colony when any
      * building levels down.
      *
-     * harvester (building_id=27) build costs for tradeable resources (3,4,5):
-     *   resource 3 (regolith): 10 → 10% = 1
-     *   resource 4 (compounds): 10 → 10% = 1
+     * bioFacility (building_id=41) build costs for tradeable resources (3,4,5):
+     *   resource 3 (regolith): 40 → 10% = 4
      * SecurityHub must be present (level>0) in the colony.
+     *
+     * Uses bioFacility rather than Harvester (building_id=27) — the Harvester's
+     * only building_costs row is resource_id=2 (Supply, not tradeable), so it
+     * never had anything to recycle in the first place; the §4c depletion
+     * mechanic (2026-08-03) just stopped a coincidental Regolith-production
+     * side effect from masking that this test's Harvester-based assertion
+     * never actually exercised the recycle path.
      */
     public function test_security_hub_recycles_resources_on_building_level_down(): void
     {
@@ -172,10 +178,11 @@ class GameTickDecayTest extends TestCase
             ['level' => 1, 'status_points' => 20, 'ap_spend' => 0]
         );
 
-        // Drive harvester to level-down threshold
-        DB::table('colony_buildings')
-            ->where('colony_id', 1)->where('building_id', 27)
-            ->update(['level' => 2, 'status_points' => 0.1]);
+        // Drive bioFacility to level-down threshold
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => 1, 'building_id' => 41, 'instance_id' => 1],
+            ['level' => 2, 'status_points' => 0.1, 'ap_spend' => 0]
+        );
 
         // Record baseline colony resources
         $regolithBefore = (int) DB::table('colony_resources')
@@ -184,11 +191,11 @@ class GameTickDecayTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11004]);
 
         // Verify the building did level down
-        $row = $this->getBuildingRow(1, 27);
+        $row = $this->getBuildingRow(1, 41);
         $this->assertEquals(1, $row->level, 'Building must have leveled down for recycling to trigger');
 
         // Recycle amount = floor(base_amount × 0.10), min 1
-        // harvester costs resource 3: 10 → floor(10 × 0.10) = 1
+        // bioFacility costs resource 3: 40 → floor(40 × 0.10) = 4
         $regolithAfter = (int) DB::table('colony_resources')
             ->where('colony_id', 1)->where('resource_id', 3)->value('amount');
 

--- a/tests/Feature/GameTick/GameTickResourceGenerationTest.php
+++ b/tests/Feature/GameTick/GameTickResourceGenerationTest.php
@@ -11,12 +11,18 @@ use Tests\TestCase;
 /**
  * GameTick step 8 — Resource generation from industry buildings.
  *
- * Config (game.production_curve, bell-curve per level, cumulative — GDD §18, 2026-07-20):
- *   building_id 27 (harvester)    → resource 3 (Regolith): [8,10,12,12,10,8,6,4] per level 1-8
- *                                    cumulative: L1=8 L2=18 L3=30 L4=42 L5=52 L6=60 L7=66 L8=70
- *   building_id 41 (bioFacility)  → resource 5 (Organics): [8,12,12,9,7,5,3,2] per level 1-8
- *                                    cumulative: L1=8 L2=20 L3=32 L4=41 L5=48 L6=53 L7=56 L8=58
- *   Both capped at max_level=8 (config/buildings.php) — higher levels are not reachable.
+ * bioFacility (building_id 41) still follows the level-based bell curve
+ * (game.production_curve[41], GDD §18, 2026-07-20): [8,12,12,9,7,5,3,2] per
+ * level 1-8, cumulative — L1=8 L2=20 L3=32 …, capped at max_level=8.
+ *
+ * Harvester (building_id 27) production_curve is INERT since the §4c depletion
+ * mechanic (2026-08-03) — the Harvester no longer levels up (max_level=1,
+ * GDD §13.5) and instead produces from the specific regolith tile it is placed
+ * on: Ertrag = Frischwert × (0,5 + 0,5 × Restvorkommen / resource_max), see
+ * GameTick::harvesterYield() and GameTick::generateHarvesterYield(). Full
+ * depletion/geology-bonus coverage lives in HarvesterDepletionTest — this file
+ * covers only the interaction with the level-0 gate, the trust multiplier,
+ * and simultaneous production alongside bioFacility.
  *
  * Production is modified by a trust multiplier. To isolate production from trust
  * drift, these tests fix trust at 0 (multiplier = 1.0) by setting colony
@@ -24,21 +30,20 @@ use Tests\TestCase;
  *
  * Covered scenarios:
  *  Happy path:
- *  - harvester at level N generates N×10 Regolith per tick (neutral trust)
+ *  - harvester placed on a full-reserve regolith_normal tile produces its fresh value (18)
  *  - bioFacility at level N generates N×10 Organics per tick (neutral trust)
  *  - Stacking: both buildings produce in the same tick
  *
  *  Edge cases:
- *  - Building at level 0 produces nothing
- *  - Production rounds correctly (int rounding with multiplier)
+ *  - Building at level 0 produces nothing even when placed on a producing tile
+ *  - Yield does not depend on the stored level value beyond the level>0 gate
  *
  *  Adversarial:
  *  - NPC colony (user_id=null) still receives production (no user gate on this step)
- *  - Very high building level produces proportionally
  *
  * Fixture summary (TestSeeder):
  *   Colony 1 (Springfield), user_id=3
- *     harvester (building_id=27): level=1
+ *     harvester (building_id=27): level=1, unplaced (tile_x=NULL) by default
  *     bioFacility not seeded for colony 1 (must be inserted)
  *   Colony resource (id=3, colony 1): amount=250 initially
  *
@@ -59,6 +64,10 @@ class GameTickResourceGenerationTest extends TestCase
     private const RES_ORGANICS = 5;
 
     private const TRUST_RES_ID = 12;
+
+    private const HARVESTER_TILE_Q = 3;
+
+    private const HARVESTER_TILE_R = 0;
 
     protected function setUp(): void
     {
@@ -97,37 +106,53 @@ class GameTickResourceGenerationTest extends TestCase
         );
     }
 
+    /**
+     * Places the Harvester (instance 1) on a fresh regolith_normal tile
+     * (fresh_yield 18, resource_max 300) — the fixture's default harvester
+     * row has no tile_x/tile_y, so production requires explicit placement
+     * under the §4c depletion mechanic.
+     */
+    private function placeHarvesterOnFreshTile(int $level = 1): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::HARVESTER_ID, 'instance_id' => 1],
+            [
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+                'tile_x' => self::HARVESTER_TILE_Q,
+                'tile_y' => self::HARVESTER_TILE_R,
+                'pending_until_tick' => null,
+            ]
+        );
+
+        DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('q', self::HARVESTER_TILE_Q)->where('r', self::HARVESTER_TILE_R)
+            ->delete();
+        DB::table('colony_tiles')->insert([
+            'colony_id' => self::COLONY_ID, 'q' => self::HARVESTER_TILE_Q, 'r' => self::HARVESTER_TILE_R, 'ring' => 3,
+            'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0,
+            'resource_amount' => 300, 'resource_max' => 300,
+        ]);
+    }
+
     // ── Happy path ─────────────────────────────────────────────────────────────
 
     /**
-     * harvester at level 1 produces exactly 8 Regolith per tick (curve[1]=8, multiplier 1.0).
+     * Harvester placed on a full-reserve regolith_normal tile produces exactly
+     * its fresh value (18) per tick at neutral trust — GDD §4c.
      */
-    public function test_harvester_generates_regolith_per_level(): void
+    public function test_harvester_generates_regolith_from_placed_tile(): void
     {
-        $this->setBuildingLevel(self::HARVESTER_ID, 1);
+        $this->placeHarvesterOnFreshTile();
         $before = $this->getColonyResource(self::RES_REGOLITH);
 
         Artisan::call('game:tick', ['--tick' => 11200]);
 
         $after = $this->getColonyResource(self::RES_REGOLITH);
-        // At multiplier 1.0: yield = round(8 × 1.0) = 8
-        $this->assertEquals($before + 8, $after,
-            'Harvester level 1 must produce exactly 8 Regolith per tick');
-    }
-
-    /**
-     * harvester at level 3 produces 30 Regolith per tick (cumulative curve 8+10+12, multiplier 1.0).
-     */
-    public function test_harvester_production_scales_with_level(): void
-    {
-        $this->setBuildingLevel(self::HARVESTER_ID, 3);
-        $before = $this->getColonyResource(self::RES_REGOLITH);
-
-        Artisan::call('game:tick', ['--tick' => 11201]);
-
-        $after = $this->getColonyResource(self::RES_REGOLITH);
-        $this->assertEquals($before + 30, $after,
-            'Harvester level 3 must produce 30 Regolith per tick');
+        $this->assertEquals($before + 18, $after,
+            'Harvester on a full-reserve regolith_normal tile must produce exactly 18 Regolith per tick');
     }
 
     /**
@@ -149,11 +174,12 @@ class GameTickResourceGenerationTest extends TestCase
     }
 
     /**
-     * Both harvester and bioFacility produce in the same tick.
+     * Both harvester (tile-based, §4c) and bioFacility (level-based curve) produce
+     * in the same tick.
      */
     public function test_multiple_production_buildings_produce_simultaneously(): void
     {
-        $this->setBuildingLevel(self::HARVESTER_ID, 2);
+        $this->placeHarvesterOnFreshTile();
         $this->setBuildingLevel(self::BIO_FACILITY_ID, 1);
 
         DB::table('colony_resources')->updateOrInsert(
@@ -170,19 +196,21 @@ class GameTickResourceGenerationTest extends TestCase
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
         $organics = $this->getColonyResource(self::RES_ORGANICS);
 
-        // harvester level 2 → cumulative 8+10=18 Regolith; bioFacility level 1 → 8 Organics
-        $this->assertEquals(18, $regolith, 'Harvester level 2 must produce 18 Regolith');
+        // harvester on full-reserve regolith_normal tile → 18 Regolith; bioFacility level 1 → 8 Organics
+        $this->assertEquals(18, $regolith, 'Harvester on full-reserve regolith_normal tile must produce 18 Regolith');
         $this->assertEquals(8, $organics, 'BioFacility level 1 must produce 8 Organics');
     }
 
     // ── Edge cases ─────────────────────────────────────────────────────────────
 
     /**
-     * A building at level 0 must not produce any resources.
+     * A building at level 0 must not produce any resources — even when placed
+     * on a tile that would otherwise yield Regolith (the level>0 gate applies
+     * before the tile-based yield is computed).
      */
     public function test_building_at_level_zero_produces_nothing(): void
     {
-        $this->setBuildingLevel(self::HARVESTER_ID, 0);
+        $this->placeHarvesterOnFreshTile(level: 0);
         DB::table('colony_resources')->updateOrInsert(
             ['colony_id' => self::COLONY_ID, 'resource_id' => self::RES_REGOLITH],
             ['amount' => 50]
@@ -200,19 +228,18 @@ class GameTickResourceGenerationTest extends TestCase
     }
 
     /**
-     * Production is capped at max_level=8 — a level beyond the cap (10, which is not
-     * actually reachable via levelup since max_level=8 gates it) must not produce more
-     * than the level-8 cumulative yield (70 Regolith). Guards against the curve lookup
-     * indexing past its highest defined level.
+     * Harvester no longer levels up beyond 1 (GDD §13.5) — the tile-based yield
+     * does not depend on the stored level at all beyond the level>0 gate. A
+     * stale/invalid level value (e.g. leftover from before the §13.5 change)
+     * must not inflate or otherwise change the yield.
      */
-    public function test_production_scales_proportionally_at_high_levels(): void
+    public function test_harvester_yield_is_independent_of_stored_level_beyond_one(): void
     {
-        $this->setBuildingLevel(self::HARVESTER_ID, 10);
+        $this->placeHarvesterOnFreshTile(level: 10);
         DB::table('colony_resources')->updateOrInsert(
             ['colony_id' => self::COLONY_ID, 'resource_id' => self::RES_REGOLITH],
             ['amount' => 0]
         );
-        // Disable bioFacility for clean isolation
         DB::table('colony_buildings')
             ->where('colony_id', self::COLONY_ID)->where('building_id', self::BIO_FACILITY_ID)
             ->update(['level' => 0]);
@@ -220,18 +247,18 @@ class GameTickResourceGenerationTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11211]);
 
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
-        $this->assertEquals(70, $regolith, 'Harvester level 10 (beyond cap) must produce the level-8 cap yield of 70 Regolith');
+        $this->assertEquals(18, $regolith, 'Yield must stay at the tile fresh value regardless of the stored level');
     }
 
     // ── Trust multiplier interaction ────────────────────────────────────────────
 
     /**
      * High trust (>60) applies a 1.20× production multiplier.
-     * harvester level 5 × 10 × 1.20 = round(60) = 60.
+     * harvester fresh yield 18 × 1.20 = round(21.6) = 22.
      */
     public function test_high_trust_applies_production_bonus(): void
     {
-        $this->setBuildingLevel(self::HARVESTER_ID, 5);
+        $this->placeHarvesterOnFreshTile();
         DB::table('colony_buildings')
             ->where('colony_id', self::COLONY_ID)->where('building_id', self::BIO_FACILITY_ID)
             ->update(['level' => 0]);
@@ -249,18 +276,18 @@ class GameTickResourceGenerationTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11220]);
 
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
-        // cumulative curve at level 5 = 52; yield = round(52 × 1.20) = 62
-        $this->assertEquals(62, $regolith,
-            'Production at trust=75 must apply 1.20× multiplier → 62 Regolith');
+        // fresh yield 18; yield = round(18 × 1.20) = 22
+        $this->assertEquals(22, $regolith,
+            'Production at trust=75 must apply 1.20× multiplier → 22 Regolith');
     }
 
     /**
      * Low trust (<-60) applies a 0.70× production penalty.
-     * harvester level 5 cumulative curve (52) × 0.70 = round(36.4) = 36.
+     * harvester fresh yield 18 × 0.70 = round(12.6) = 13.
      */
     public function test_low_trust_applies_production_penalty(): void
     {
-        $this->setBuildingLevel(self::HARVESTER_ID, 5);
+        $this->placeHarvesterOnFreshTile();
         DB::table('colony_buildings')
             ->where('colony_id', self::COLONY_ID)->where('building_id', self::BIO_FACILITY_ID)
             ->update(['level' => 0]);
@@ -278,8 +305,8 @@ class GameTickResourceGenerationTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11221]);
 
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
-        // cumulative curve at level 5 = 52; yield = round(52 × 0.70) = 36
-        $this->assertEquals(36, $regolith,
-            'Production at trust=-80 must apply 0.70× penalty → 36 Regolith');
+        // fresh yield 18; yield = round(18 × 0.70) = 13
+        $this->assertEquals(13, $regolith,
+            'Production at trust=-80 must apply 0.70× penalty → 13 Regolith');
     }
 }

--- a/tests/Feature/GameTick/HarvesterDepletionTest.php
+++ b/tests/Feature/GameTick/HarvesterDepletionTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace Tests\Feature\GameTick;
+
+use App\Console\Commands\GameTick;
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Harvester depletion mechanic (GDD §4c "Erschöpfungskurve und Umzugstakt",
+ * freigegeben 2026-08-03) and the geology Kenntnis bonus (GDD §13.7).
+ *
+ *   Ertrag = Frischwert × (0,5 + 0,5 × Restvorkommen / resource_max)
+ *
+ * Fixture: Colony 1 (Springfield), user_id=3 (Bart), harvester building_id=27.
+ */
+class HarvesterDepletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const BART_USER_ID = 3;
+
+    private const HARVESTER_ID = 27;
+
+    private const RES_REGOLITH = 3;
+
+    private const TRUST_RES_ID = 12;
+
+    private const GEOLOGY_RESEARCH_ID = 92;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        // Neutral trust → production multiplier 1.0.
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::TRUST_RES_ID],
+            ['amount' => 0]
+        );
+        DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
+
+        DB::table('colony_researches')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('research_id', self::GEOLOGY_RESEARCH_ID)
+            ->delete();
+
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::RES_REGOLITH],
+            ['amount' => 0]
+        );
+
+        // Single Harvester instance on a regolith_normal tile (fresh_yield 18, resource_max 300).
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::HARVESTER_ID, 'instance_id' => 1],
+            ['level' => 1, 'status_points' => 16, 'ap_spend' => 0, 'tile_x' => 3, 'tile_y' => 0, 'pending_until_tick' => null]
+        );
+
+        DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)->delete();
+        DB::table('colony_tiles')->insert([
+            'colony_id' => self::COLONY_ID, 'q' => 3, 'r' => 0, 'ring' => 3,
+            'tile_type' => 'regolith_normal', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0,
+            'resource_amount' => 300, 'resource_max' => 300,
+        ]);
+    }
+
+    private function makeUser(): User
+    {
+        return User::where('user_id', self::BART_USER_ID)->firstOrFail();
+    }
+
+    private function regolithAmount(): int
+    {
+        return (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('resource_id', self::RES_REGOLITH)
+            ->value('amount');
+    }
+
+    private function tileRemaining(): int
+    {
+        return (int) DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)
+            ->value('resource_amount');
+    }
+
+    // ── Teil A — pure formula ────────────────────────────────────────────────
+
+    public function test_harvester_yield_at_full_reserves_equals_fresh_value(): void
+    {
+        // regolith_normal: fresh 18, resource_max 300, remaining 300 → ratio 1.0 → 18.
+        $this->assertSame(18, GameTick::harvesterYield('regolith_normal', 300, 300, 0));
+    }
+
+    public function test_harvester_yield_near_depletion_approaches_half_fresh_value(): void
+    {
+        // remaining=10/300 → ratio ~0.033 → 18*(0.5+0.5*0.033) ≈ 9.3 → round 9.
+        $this->assertSame(9, GameTick::harvesterYield('regolith_normal', 10, 300, 0));
+    }
+
+    public function test_harvester_yield_is_zero_when_exhausted(): void
+    {
+        $this->assertSame(0, GameTick::harvesterYield('regolith_normal', 0, 300, 0));
+    }
+
+    public function test_harvester_yield_never_returns_negative_for_over_cap_remaining(): void
+    {
+        // Legacy tile with resource_amount > resource_max (pre-2026-08-03 seed) — ratio
+        // clamps at 1.0, never exceeds the fresh value.
+        $this->assertSame(18, GameTick::harvesterYield('regolith_normal', 500, 300, 0));
+    }
+
+    // ── Teil A — integration via game:tick ──────────────────────────────────
+
+    public function test_tick_credits_regolith_from_tile_at_full_reserves(): void
+    {
+        Artisan::call('game:tick', ['--tick' => 20001]);
+
+        $this->assertSame(18, $this->regolithAmount());
+        $this->assertSame(300 - 18, $this->tileRemaining());
+    }
+
+    public function test_tick_credits_reduced_yield_near_depletion(): void
+    {
+        DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)
+            ->update(['resource_amount' => 10]);
+
+        Artisan::call('game:tick', ['--tick' => 20002]);
+
+        $this->assertSame(9, $this->regolithAmount());
+        $this->assertSame(1, $this->tileRemaining());
+    }
+
+    public function test_tick_credits_nothing_once_tile_exhausted(): void
+    {
+        DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)
+            ->update(['resource_amount' => 0]);
+
+        Artisan::call('game:tick', ['--tick' => 20003]);
+
+        $this->assertSame(0, $this->regolithAmount());
+        $this->assertSame(0, $this->tileRemaining());
+    }
+
+    public function test_tick_clamps_stale_resource_max_down_to_current_config(): void
+    {
+        // Legacy tile seeded before the 500/300/160 reduction (old regolith_normal max: 500).
+        DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)
+            ->update(['resource_amount' => 500, 'resource_max' => 500]);
+
+        Artisan::call('game:tick', ['--tick' => 20004]);
+
+        $this->assertSame(18, $this->regolithAmount(), 'yield must not exceed fresh value even with a stale over-cap remaining');
+        $this->assertSame(
+            300,
+            (int) DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)->value('resource_max'),
+            'resource_max must be clamped down to the current config value'
+        );
+    }
+
+    // ── Teil D — geology Kenntnis bonus ──────────────────────────────────────
+
+    public function test_harvester_yield_pure_function_adds_geology_bonus(): void
+    {
+        $this->assertSame(18 + 3, GameTick::harvesterYield('regolith_normal', 300, 300, 1));
+        $this->assertSame(18 + 6, GameTick::harvesterYield('regolith_normal', 300, 300, 2));
+        $this->assertSame(18 + 8, GameTick::harvesterYield('regolith_normal', 300, 300, 3));
+        $this->assertSame(18 + 12, GameTick::harvesterYield('regolith_normal', 300, 300, 5));
+        // Cap: level beyond the configured curve does not add further bonus.
+        $this->assertSame(18 + 12, GameTick::harvesterYield('regolith_normal', 300, 300, 99));
+    }
+
+    public function test_tick_applies_geology_bonus_once_per_colony_not_per_instance(): void
+    {
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => self::GEOLOGY_RESEARCH_ID],
+            ['level' => 2, 'status_points' => 20, 'ap_spend' => 0]
+        );
+
+        // Second Harvester instance on a regolith_poor tile (fresh 12, max 160).
+        DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->where('q', -3)->where('r', 0)->delete();
+        DB::table('colony_tiles')->insert([
+            'colony_id' => self::COLONY_ID, 'q' => -3, 'r' => 0, 'ring' => 3,
+            'tile_type' => 'regolith_poor', 'is_explored' => 1, 'is_colony_zone' => 0, 'is_deep_scanned' => 0,
+            'resource_amount' => 160, 'resource_max' => 160,
+        ]);
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::HARVESTER_ID, 'instance_id' => 2],
+            ['level' => 1, 'status_points' => 16, 'ap_spend' => 0, 'tile_x' => -3, 'tile_y' => 0, 'pending_until_tick' => null]
+        );
+
+        Artisan::call('game:tick', ['--tick' => 20005]);
+
+        // Without any bonus: 18 (normal, instance 1) + 12 (poor, instance 2) = 30.
+        // Geology level 2 bonus is +6 applied ONCE per colony → 36 total.
+        // (If it were applied per instance instead, the total would be 30 + 12 = 42.)
+        $this->assertSame(36, $this->regolithAmount());
+    }
+
+    public function test_geology_bonus_not_credited_when_no_harvester_active(): void
+    {
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => self::GEOLOGY_RESEARCH_ID],
+            ['level' => 2, 'status_points' => 20, 'ap_spend' => 0]
+        );
+        DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)
+            ->update(['resource_amount' => 0]);
+
+        Artisan::call('game:tick', ['--tick' => 20006]);
+
+        $this->assertSame(0, $this->regolithAmount(), 'no active harvester → no yield, no flat geology trickle');
+    }
+}

--- a/tests/Feature/GameTick/HarvesterSol1BootstrapTest.php
+++ b/tests/Feature/GameTick/HarvesterSol1BootstrapTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\GameTick;
+
+use App\Models\User;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Sol-1 Harvester economics under the §4c depletion mechanic (2026-08-03).
+ *
+ * The bootstrap Harvester is seeded on tile (1,0), a colony-zone tile that is
+ * deliberately terrain_empty (colony-zone tiles are never regolith, see
+ * ColonyTileService::computeColonyZoneCoords()). Since the depletion mechanic
+ * requires the Harvester's actual tile to be a regolith_* deposit, this is a
+ * real pacing change from the old level-curve mechanic (which produced
+ * regardless of tile type): the Sol-1 Harvester produces ZERO Regolith until
+ * the player relocates it — the exact action onboarding's hint_2
+ * (OnboardingHintService::checkHint2()) already teaches. Confirmed intentional
+ * by cross-checking against OnboardingE2ETest's existing hint_2 flow, not
+ * assumed — flag this pacing shift to game-designer/owner if it wasn't
+ * expected to bite this hard (0 income, not just reduced income, until move).
+ */
+class HarvesterSol1BootstrapTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const USER_ID = 3;
+
+    private const RES_REGOLITH = 3;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+
+        DB::table('runs')->where('user_id', self::USER_ID)->delete();
+        DB::table('user_resources')->updateOrInsert(
+            ['user_id' => self::USER_ID],
+            ['credits' => 10000, 'supply' => 20]
+        );
+
+        // Isolate production from the Organika sink and trust drift.
+        config(['game.food.supply_per_eater' => PHP_INT_MAX]);
+        DB::table('trust_events')->where('colony_id', self::COLONY_ID)->delete();
+    }
+
+    private function user(): User
+    {
+        return User::where('user_id', self::USER_ID)->firstOrFail();
+    }
+
+    private function regolithAmount(): int
+    {
+        return (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)->where('resource_id', self::RES_REGOLITH)
+            ->value('amount');
+    }
+
+    public function test_sol1_seeded_harvester_produces_nothing_before_relocation(): void
+    {
+        $this->actingAs($this->user())->post(route('run.new'))->assertRedirect();
+
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => 12],
+            ['amount' => 0]
+        );
+
+        $before = $this->regolithAmount();
+        Artisan::call('game:tick', ['--tick' => 30001]);
+
+        $this->assertSame(
+            $before,
+            $this->regolithAmount(),
+            'The Sol-1 Harvester sits on a colony-zone (terrain_empty) tile by design and must not produce Regolith before relocation'
+        );
+    }
+
+    public function test_harvester_produces_after_relocating_to_the_preexplored_regolith_tile(): void
+    {
+        $this->actingAs($this->user())->post(route('run.new'))->assertRedirect();
+
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => 12],
+            ['amount' => 0]
+        );
+
+        // Same lookup OnboardingE2ETest uses: the guaranteed pre-explored ring-3
+        // regolith tile (Nexus-Scout Harvester relocation target).
+        $target = DB::table('colony_tiles')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('is_explored', 1)
+            ->where('tile_type', 'like', 'regolith_%')
+            ->first();
+        $this->assertNotNull($target, 'Sol-1 seeding must guarantee one pre-explored regolith tile');
+
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID)->where('building_id', 27)
+            ->update(['tile_x' => $target->q, 'tile_y' => $target->r, 'pending_until_tick' => null]);
+
+        $before = $this->regolithAmount();
+        Artisan::call('game:tick', ['--tick' => 30002]);
+
+        $this->assertGreaterThan(
+            $before,
+            $this->regolithAmount(),
+            'Once relocated to its regolith tile, the Sol-1 Harvester must produce Regolith'
+        );
+    }
+}

--- a/tests/Feature/Hangar/HangarMissionResolutionTest.php
+++ b/tests/Feature/Hangar/HangarMissionResolutionTest.php
@@ -224,13 +224,12 @@ class HangarMissionResolutionTest extends TestCase
     public function test_completion_grants_research_ap_capped_at_levelup_threshold(): void
     {
         // mission_data_sweep reward: research_ap => 8, invested into cartography (id 91).
-        // Lv0→1 threshold is 12 (config/knowledge.php) — the reward alone (8) no
-        // longer exceeds it, so seed a partial 6 ap_spend first: 6+8=14 would
-        // overshoot the 12 threshold, proving the reward still caps rather than
-        // overflowing past the level-up requirement.
+        // Lv0→1 threshold is 20 (config/knowledge.php) — seed a partial 15 ap_spend first:
+        // 15+8=23 would overshoot the 20 threshold, proving the reward still caps rather
+        // than overflowing past the level-up requirement.
         DB::table('colony_researches')->updateOrInsert(
             ['colony_id' => self::COLONY_ID, 'research_id' => 91],
-            ['level' => 0, 'ap_spend' => 6, 'status_points' => 20]
+            ['level' => 0, 'ap_spend' => 15, 'status_points' => 20]
         );
         $this->dispatchFixture('mission_data_sweep', 3, dispatchTick: 20500, target: ['research_id' => 91]);
 
@@ -239,7 +238,7 @@ class HangarMissionResolutionTest extends TestCase
         $row = DB::table('colony_researches')
             ->where('colony_id', self::COLONY_ID)->where('research_id', 91)->first();
 
-        $this->assertSame(12, (int) $row->ap_spend, 'ap_spend must cap at the Lv1 threshold, not reach the full 6+8');
+        $this->assertSame(20, (int) $row->ap_spend, 'ap_spend must cap at the Lv1 threshold, not reach the full 15+8');
         $this->assertSame(0, (int) $row->level, 'research_ap reward must not auto-levelup');
     }
 

--- a/tests/Feature/Security/CrossColonyAccessTest.php
+++ b/tests/Feature/Security/CrossColonyAccessTest.php
@@ -66,11 +66,11 @@ class CrossColonyAccessTest extends TestCase
         $this->assertSame(3, $ccLevel, 'precondition: CC must be at level 3 for this test');
 
         // Manually set knowledge to level 3, ap_spend to full for level 3→4 transition.
-        // config/knowledge.php: levelup_costs[4] = 40 → ap_spend must reach 40.
+        // config/knowledge.php: levelup_costs[4] = 44 → ap_spend must reach 44.
         // Setting it to the full threshold means only the CC-gate is the blocking condition.
         DB::table('colony_researches')->updateOrInsert(
             ['colony_id' => $colonyId, 'research_id' => $knowledgeId],
-            ['level' => 3, 'status_points' => 20, 'ap_spend' => 40]
+            ['level' => 3, 'status_points' => 20, 'ap_spend' => 44]
         );
 
         // Config: knowledge_cc_level_cap[4] = 4, but CC is 3 → must block
@@ -116,10 +116,10 @@ class CrossColonyAccessTest extends TestCase
             'active_ticks' => 0,
         ]);
 
-        // Set knowledge to level 3, ap_spend satisfied: levelup_costs[4] = 40
+        // Set knowledge to level 3, ap_spend satisfied: levelup_costs[4] = 44
         DB::table('colony_researches')->updateOrInsert(
             ['colony_id' => $colonyId, 'research_id' => $knowledgeId],
-            ['level' => 3, 'status_points' => 20, 'ap_spend' => 40]
+            ['level' => 3, 'status_points' => 20, 'ap_spend' => 44]
         );
 
         $service = $this->app->make(ResearchService::class);
@@ -164,10 +164,10 @@ class CrossColonyAccessTest extends TestCase
             'active_ticks' => 0,
         ]);
 
-        // Set knowledge to level 4, ap_spend satisfied: levelup_costs[5] = 50
+        // Set knowledge to level 4, ap_spend satisfied: levelup_costs[5] = 52
         DB::table('colony_researches')->updateOrInsert(
             ['colony_id' => $colonyId, 'research_id' => $knowledgeId],
-            ['level' => 4, 'status_points' => 20, 'ap_spend' => 50]
+            ['level' => 4, 'status_points' => 20, 'ap_spend' => 52]
         );
 
         $service = $this->app->make(ResearchService::class);
@@ -206,10 +206,10 @@ class CrossColonyAccessTest extends TestCase
             ->value('level');
         $this->assertSame(4, $ccLevel, 'precondition: CC must be at level 4 for this test');
 
-        // Set knowledge to level 4, ap_spend satisfied: levelup_costs[5] = 50
+        // Set knowledge to level 4, ap_spend satisfied: levelup_costs[5] = 52
         DB::table('colony_researches')->updateOrInsert(
             ['colony_id' => $colonyId, 'research_id' => $knowledgeId],
-            ['level' => 4, 'status_points' => 20, 'ap_spend' => 50]
+            ['level' => 4, 'status_points' => 20, 'ap_spend' => 52]
         );
 
         // Config: knowledge_cc_level_cap[5] = 5, but CC is 4 → must block

--- a/tests/Feature/Techtree/KnowledgeServiceTest.php
+++ b/tests/Feature/Techtree/KnowledgeServiceTest.php
@@ -77,7 +77,7 @@ class KnowledgeServiceTest extends TestCase
 
     public function test_invest_accumulates_ap_spend(): void
     {
-        // Lv0→1 costs 12 AP; invest 3 → ap_spend=3
+        // Lv0→1 costs 20 AP; invest 3 → ap_spend=3
         $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 1);
         $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 1);
         $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 1);
@@ -92,7 +92,7 @@ class KnowledgeServiceTest extends TestCase
 
     public function test_levelup_requires_full_ap_investment(): void
     {
-        // Lv0→1 costs 12 AP; only 11 invested — levelup must fail
+        // Lv0→1 costs 20 AP; only 11 invested — levelup must fail
         $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 11);
 
         $result = $this->service->levelup($this->colonyId, $this->knowledgeId);
@@ -107,8 +107,8 @@ class KnowledgeServiceTest extends TestCase
 
     public function test_levelup_succeeds_after_full_ap_investment(): void
     {
-        // Lv0→1 costs 12 AP (config/knowledge.php → levelup_costs[1])
-        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 12);
+        // Lv0→1 costs 20 AP (config/knowledge.php → levelup_costs[1])
+        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 20);
 
         $result = $this->service->levelup($this->colonyId, $this->knowledgeId);
         $this->assertTrue($result);
@@ -122,19 +122,19 @@ class KnowledgeServiceTest extends TestCase
 
     public function test_levelup_costs_increase_per_level(): void
     {
-        // Lv0→1 = 12 AP. Tick 9201 to invest, tick 9202 to clear AP locks for next round.
-        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 12);
+        // Lv0→1 = 20 AP. Tick 9201 to invest, tick 9202 to clear AP locks for next round.
+        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 20);
         $this->service->levelup($this->colonyId, $this->knowledgeId);
         Artisan::call('game:tick', ['--tick' => 9201]); // clears AP locks, knowledge stays at Lv1
 
-        // Lv1→2 = 20 AP. Rank-2 scientist provides 13 AP/tick — invest in two
+        // Lv1→2 = 28 AP. Rank-2 scientist provides 13 AP/tick — invest in two
         // chunks across tick boundaries (a single invest() call is capped at the
         // AP available that tick, it does not partially invest beyond it).
         $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 13);
         $this->assertFalse($this->service->levelup($this->colonyId, $this->knowledgeId));
         Artisan::call('game:tick', ['--tick' => 9202]); // clear locks again
 
-        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 7); // cumulative = 20
+        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 15); // cumulative = 28
         $this->assertTrue($this->service->levelup($this->colonyId, $this->knowledgeId));
 
         $level = (int) DB::table('colony_researches')
@@ -148,8 +148,8 @@ class KnowledgeServiceTest extends TestCase
 
     public function test_knowledge_does_not_decay_after_tick(): void
     {
-        // Unlock the knowledge (Lv0→1 = 12 AP)
-        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 12);
+        // Unlock the knowledge (Lv0→1 = 20 AP)
+        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 20);
         $this->service->levelup($this->colonyId, $this->knowledgeId);
 
         // Run a tick — decay_rate=0, so level must remain 1
@@ -173,7 +173,7 @@ class KnowledgeServiceTest extends TestCase
         $this->assertEquals(26, $before);
 
         // Unlock knowledge_health (level 1 → +3 cap per config knowledge_cap_per_level[1])
-        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 12);
+        $this->service->invest($this->colonyId, $this->knowledgeId, 'add', 20);
         $this->service->levelup($this->colonyId, $this->knowledgeId);
 
         Artisan::call('game:tick', ['--tick' => 9102]);

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -381,19 +381,27 @@ class TechtreeControllerTest extends TestCase
 
         // cartography (research id 91): requires Analytik-Labor Lv1 (building 31) +
         // Hangar Lv1 (building 44) — both already built for colony 1 in test data.
-        // levelup_costs[1] = 12 (config/knowledge.php).
+        // levelup_costs[1] = 20 (config/knowledge.php).
         DB::table('advisors')->where('colony_id', $this->colonyIdBart)->where('personell_id', 36)->delete();
         DB::table('advisors')->insert([
             'user_id' => $this->userIdBart,
-            'personell_id' => 36, // scientist (research AP), rank 3 = 12 AP/tick
+            'personell_id' => 36, // scientist (research AP), rank 3 = 12 AP/tick advisor bonus
             'colony_id' => $this->colonyIdBart,
             'rank' => 3,
             'active_ticks' => 0,
             'unavailable_until_tick' => null,
         ]);
 
+        // Available research AP (base 6 + rank-3 advisor 12 = 18, at neutral trust) is
+        // below the 20-AP threshold in a single request — pre-seed 19 already invested
+        // so the final AP (1) is what pushes it over, exactly what auto-levelup proves.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => $this->colonyIdBart, 'research_id' => 91],
+            ['level' => 0, 'ap_spend' => 19, 'status_points' => 20]
+        );
+
         $response = $this->actingAs(User::find($this->userIdBart))
-            ->postJson(route('techtree.order', ['type' => 'research', 'id' => 91]), ['order' => 'add', 'ap' => 12]);
+            ->postJson(route('techtree.order', ['type' => 'research', 'id' => 91]), ['order' => 'add', 'ap' => 1]);
 
         $response->assertOk();
         $response->assertJsonPath('success', true);
@@ -401,9 +409,9 @@ class TechtreeControllerTest extends TestCase
         $response->assertJsonPath('levelup_blocked_reason', null);
         $response->assertJsonPath('tech.level', 1);
         $response->assertJsonPath('tech.ap_spend', 0);
-        // Next level (1->2) costs 20 per config/knowledge.php — the bar must rescale,
-        // not stay capped at the Lv0->1 threshold (12).
-        $response->assertJsonPath('tech.ap_for_levelup', 20);
+        // Next level (1->2) costs 28 per config/knowledge.php — the bar must rescale,
+        // not stay capped at the Lv0->1 threshold (20).
+        $response->assertJsonPath('tech.ap_for_levelup', 28);
 
         $this->assertSame(1, DB::table('colony_researches')
             ->where('colony_id', $this->colonyIdBart)->where('research_id', 91)->value('level'));


### PR DESCRIPTION
## Zusammenfassung

Gestapelt auf #234 (Stufe 1c). Setzt den freigegebenen §13.7-Zahlensatz und die §4c-Harvester-Mechanik in einem PR um, wie der Handoff (`docs/handoff-ap-ratenmodell.md`) fordert: Sockel ohne neue Baukosten wäre trivial, neue Baukosten ohne Sockel unspielbar.

**Zahlensatz (§13.7):**
- `config/buildings.php`: `decay_rate` in vier Klassen (0,40/0,60/0,80/1,20), Errichtungskosten der Sol-1-4-Rampe (Agrardom 70, Sciencelab/Cantina 95, Hangar 120), `cc_upgrade_regolith_per_level` 20→30, Hangar `max_level=3` (Schiffsklasse), Temple/Monument `max_level=1`
- `config/game.php`: `repair.regolith_per_click` 2→1, `bar.base_prices`/`compound_import_price` nach Knappheitsordnung
- `config/knowledge.php`: `levelup_costs` 20/28/36/44/52, `credits` 100→0
- `ColonyController::levelupRegolithFor()`: Level-Up-Kosten flach 25 statt 25% von `build_cost`

**Harvester-Erschöpfung (§4c) — bisher komplett unverdrahtet:**
- `GameTick::harvesterYield()`: Ertrag = Frischwert × (0,5 + 0,5 × Restvorkommen/resource_max), tile-gespeist statt aus der jetzt inerten `production_curve[27]`
- Verlegekosten 1 → 2 AP je Hex
- Zweitinstanz-Gate: Instanz 1 regolithfrei (Bootstrap), Instanz 2 CC Lv3 + 100 Rg
- Geologie-Kenntnis: erster hartverdrahteter Kenntniseffekt (+3/3/2/2/2, max 12, pro Kolonie)
- `colony-hexgrid.js`: Verlege-AP-Vorschau folgt jetzt der Config

Elf Tests mit hardcodierten Alt-Werten auf den neuen Zahlensatz nachgezogen — erwarteter Fallout (Handoff §2 Platzhalter-Regel), keine Regression.

**Bewusst nicht in diesem PR:** Agrardom Level→Instanz-Umstellung (Deckel + Produktionskurve noch offen, verschoben auf Stufe 1d — Owner-Entscheidung).

## Offene Punkte für Owner/Design (nicht in diesem PR gelöst)

- **Sol-1-Pacing-Änderung:** Start-Harvester steht auf regolithfreiem Koloniezonen-Tile und produziert jetzt 0 Rg bis zur ersten Verlegung — macht `hint_2` vom weichen Hinweis zum harten Wirtschafts-Gate. War niemandes explizite Entscheidung, siehe `HarvesterSol1BootstrapTest`.
- **SecurityHub-Recycling:** war für den Harvester (nicht-handelbare Baukosten) schon vorher wirkungslos, jetzt sichtbar statt durch Harvester-Zufallsproduktion im selben Tick maskiert. Test auf Agrardom umgestellt, die Grundsatzfrage bleibt offen.
- Neuer lang-Key `colony.error_harvester_second_instance_cc_gate` — kurze Prüfung durch content-writer sinnvoll, falls Tonalität nicht passt.

## Test plan

- [x] `bin/phpunit` — 916/916 grün (2 bekannte, bedingte Skips)
- [x] `bin/pint --test` — clean
- [x] `bin/phpstan analyse` — keine Fehler
- [x] `migrate:fresh --seed` erfolgreich