### PR TITLE
Fix: task_expedition_coverage-Ziel war unerreichbar (19→16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-14
+
+**Fix: `task_expedition_coverage`-Ziel (19) war unerreichbar, jetzt 16** (`app/Services/RunProgressService.php`). Bei der Phase-2-Pacing-Untersuchung (Punkt 1 von gestern) fiel auf: alle 3 PlaytestBot-Seeds blieben identisch bei 13/19 Colony-Zone-Tiles stehen — die maximale Zonengröße über alle 5 CC-Level (`config('game.colony_zone_expansion')`, Summe 15) plus das immer-Zone-und-vorerkundete CC-Ring-0-Tile ergibt maximal 16, nicht 19. War also seit der Einführung strukturell nie erreichbar, kein Balance-Problem. Regressionstest ergänzt, der künftige `colony_zone_expansion`-Änderungen gegen den Zielwert prüft. GDD-Balance-Concern (hatte das Risiko bereits vor Finalisierung benannt) als behoben markiert. Suite grün (981 Tests, 0 Skips).
+
 ## 2026-08-13
 
 **Regolith-Startbestand 200→300 umgesetzt** (GDD §13.7 Nachtrag 2026-08-12, `OnboardingService::seedResources()`). Einziger identifizierter Hebel für die Phase-1-Sol-15-20-Zielsetzung. Dabei zwei zusammenhängende PlaytestBot-Bugs gefunden und gefixt (`BotStrategy.php`): (1) `bioFacility` hatte Priorität 0 ohne Instanz-Obergrenze — mit mehr Start-Regolith baute der Bot noch öfter bioFacility-Kopien statt Pfadgebäude zu erreichen, jetzt Priorität 0 nur für die erste Pflicht-Instanz; (2) `placeCandidate()` hatte anders als die Invest-/Research-Regeln keinen Regolith-Puffer für noch fehlende Pfadgebäude und kaufte stattdessen das nächstgünstigste leistbare Gebäude, was Rg nie auf 95 anwachsen ließ — Pufferlogik ergänzt. Ergebnis: Bot erreicht jetzt zuverlässig den 2. Berater in allen 3 Test-Seeds (vorher nie mit dem neuen Sol-30-Deadline). 3. Berater/Phase-2 wird in den ~25 verfügbaren Solen noch knapp verfehlt — weitere Balance-Iteration nötig, kein Bot-Bug mehr. Suite grün (978 Tests, 2 vorbestehende Skips).

--- a/app/Services/RunProgressService.php
+++ b/app/Services/RunProgressService.php
@@ -39,7 +39,11 @@ class RunProgressService
         'task_colony_prosperity' => 10,
         'task_research_lead' => 3,
         'task_self_sufficiency' => 15,
-        'task_expedition_coverage' => 19,
+        // Max reachable is 1 (CC ring-0, always colony zone + pre-explored) + Σ
+        // config('game.colony_zone_expansion') over all 5 CC levels (15) = 16.
+        // Was 19 — mathematically unwinnable regardless of play skill (found
+        // empirically 2026-08-14, PlaytestBot stalled at 13/19 across all seeds).
+        'task_expedition_coverage' => 16,
         'task_engineering_output' => 200,
         'task_trade_volume' => 5,
     ];

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -3766,7 +3766,7 @@ Bei Phase-1-Ende Sol 20 fällt Phase-2-Sol 80 exakt auf Gesamt-Sol 100 — das i
 | Typischer Sieg > Sol 90 | `TASK_TARGETS`-Werte in `RunProgressService` senken (Objectives zu schwer) |
 | Typischer Sieg < Sol 55 | `TASK_TARGETS`-Werte erhöhen oder tick_limit auf 80 senken |
 
-> ⚠️ BALANCE CONCERN: `task_expedition_coverage: 19` (alle Colony-Zone-Tiles erkundet) ist der schwierigste Task-Target-Wert und braucht als erstes Playtest-Validierung. 19 Tiles bei ring-gestaffelten Kosten (1/2/3 Nav-AP/Ring) und einem Junior-Raumfahrer mit ~7 Nav-AP/Sol ergibt rechnerisch ~3–5 Sole reiner Erkundungsarbeit, was realistisch ist — aber stark von der Tile-Verteilung der Karte abhängt (impassable Tiles zählen nicht; auf vulkanischen Planeten könnten sehr viele Tiles aus der Zone fallen). Vor dem Finalisieren dieses Task-Targets den Colony-Zone-Expansion-Mechanismus (§4a) gegen typische Karten durchrechnen.
+> ✅ BEHOBEN (2026-08-14): `task_expedition_coverage: 19` war **mathematisch unerreichbar**, nicht nur schwierig — die Colony-Zone wächst über `config('game.colony_zone_expansion')` (Summe 15 Terrain-Tiles über alle 5 CC-Level) plus das immer-Zone-und-vorerkundete CC-Ring-0-Tile, macht maximal **16** je erreichbare `is_colony_zone=1`-Tiles. PlaytestBot bestätigte den Deadlock empirisch: alle 3 Testseeds blieben identisch bei 13/19 stehen (Phase-2-Pacing-Untersuchung, 2026-08-14). `RunProgressService::TASK_TARGETS['task_expedition_coverage']` auf **16** korrigiert, Regressionstest ergänzt (`RunProgressServiceTest::test_task_expedition_coverage_target_does_not_exceed_max_reachable_colony_zone_tiles`), der jede künftige `colony_zone_expansion`-Änderung gegen diesen Zielwert prüft.
 
 > **Entschieden (2026-07-19):** `task_credit_reserve: 10` (10 aufeinanderfolgende Sole mit Credits > 5.000) war mit der alten Ökonomie strukturell unerreichbar — Playtest-Bot-Befund PR #218 bestätigt: Credits fielen auf 0 und blieben dort geklemmt, der dritte Berater wurde nie leistbar, Phase 1 nie abgeschlossen. Fix über drei Hebel (Details siehe §13 "Rang-System" und §12 "Kanal 1: Bar/Cantina"):
 >
@@ -3869,7 +3869,7 @@ Stellen, die noch von getrennten AP-Pools ausgehen und nachzuziehen sind.
 | Run-Aufgabenpool: Wirtschafts-Cluster (1, 7, 9), Kollision Aufgabe 11 mit 2/8 | §15 |
 | Highscore-Formel: Gewichtung | §15 |
 | Fail-State: −20-Trust-Schwelle, `nexus_debt`-Mechanik | §18 |
-| `task_expedition_coverage: 19` als schwierigster Task-Target-Wert | §18 |
+| ~~`task_expedition_coverage: 19` als schwierigster Task-Target-Wert~~ — ✅ behoben 2026-08-14, war unerreichbar, jetzt 16 (s. §18) | §18 |
 | Run-Ende: „Kolonie ansehen" setzt voraus, dass Koloniedaten erhalten bleiben | §18 |
 
 ### A.4 Offene Designfragen (kein Playtest nötig, Entscheidung steht aus)

--- a/tests/Feature/RunProgressServiceTest.php
+++ b/tests/Feature/RunProgressServiceTest.php
@@ -844,6 +844,30 @@ class RunProgressServiceTest extends TestCase
 
     // ── task_expedition_coverage (counter) ──────────────────────────────────────
 
+    /**
+     * Regression guard: the hardcoded TASK_TARGETS value must never exceed the
+     * maximum number of is_colony_zone=1 tiles a colony can ever have (1 CC ring-0
+     * tile, always colony zone and pre-explored, + config('game.colony_zone_expansion')
+     * summed over all 5 CC levels) — otherwise the objective is mathematically
+     * unwinnable regardless of play skill. Found empirically 2026-08-14: target was
+     * 19, real max was 16 (colony_zone_expansion sums to 15 + the CC tile).
+     */
+    public function test_task_expedition_coverage_target_does_not_exceed_max_reachable_colony_zone_tiles(): void
+    {
+        $maxExpansion = array_sum(config('game.colony_zone_expansion'));
+        $maxReachable = $maxExpansion + 1; // +1 for the always-zone, pre-explored CC ring-0 tile
+
+        $reflection = new \ReflectionClass(RunProgressService::class);
+        $targets = $reflection->getConstant('TASK_TARGETS');
+        $realTarget = $targets['task_expedition_coverage'];
+
+        $this->assertLessThanOrEqual(
+            $maxReachable,
+            $realTarget,
+            "RunProgressService::TASK_TARGETS['task_expedition_coverage'] ({$realTarget}) must not exceed the maximum reachable colony-zone tile count ({$maxReachable}), or the objective can never complete."
+        );
+    }
+
     public function test_task_expedition_coverage_completes_when_19_explored_colony_zone_tiles_exist(): void
     {
         $run = $this->makeRun(['current_tick' => 10, 'phase' => 2]);


### PR DESCRIPTION
## Summary
- `task_expedition_coverage`-Zielwert (19) überstieg die maximal erreichbare Anzahl Colony-Zone-Tiles (16 = 15 aus `colony_zone_expansion` über alle 5 CC-Level + CC-Ring-0) — strukturell unerreichbar, kein Balance-Problem.
- Gefunden bei der Phase-2-Pacing-Untersuchung: alle 3 PlaytestBot-Seeds blieben identisch bei 13/19 stehen (Signal für strukturellen statt spielerischen Deadlock).
- Regressionstest ergänzt, GDD-Balance-Concern als behoben markiert.

## Test plan
- [x] `php artisan test` — 981 passed, 0 skipped, keine Regression