### PR TITLE
Fix: CC-Levelup Lv5 Regolith-Deckel (statt 150 → 120 Rg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-14
 
+- Fix: CC-Levelup Lv4→Lv5 kostete unverhältnismäßig 150 Regolith (teuerster Einzelposten des Runs für nur 1 von 16 Colony-Zone-Tiles) — jetzt auf Lv4-Niveau (120 Rg) gedeckelt, per game-designer-Review nach PlaytestBot-Befund (`task_expedition_coverage` hing bei 15/16 fest).
 - PlaytestBot: `BotProfile`-Mechanismus (Playstyle-Parameter, startet mit `savingsAggressiveness`) + neuer `game:playtest`-Command zum Vergleich mehrerer Seeds/Profile. Siehe `docs/superpowers/specs/2026-08-14-bot-playstyle-profiles-design.md`.
 - Fix PlaytestBot: Explore-Priorität nach `is_colony_zone` + CC-Investitionsdeckel nach Phase 1 auf Lv5 gelöst — `task_expedition_coverage` 13/16 → 15/16 über 3 Seeds, Phase 1 bleibt sauber. PR #249.
 - Fix: `task_expedition_coverage`-Ziel (19) war unerreichbar (max. 16 Colony-Zone-Tiles) — auf 16 korrigiert, Regressionstest ergänzt. PR #247.

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -70,8 +70,13 @@ class ColonyController extends BaseController
 
     /**
      * Regolith consumed when a building completes a level-up.
-     * Rules: CommandCenter scales as target_level × cc_upgrade_regolith_per_level;
-     * Harvester is free (bootstrap); all others pay a flat rate, independent of build_cost.
+     * Rules: CommandCenter scales as target_level × cc_upgrade_regolith_per_level, capped
+     * at max_level−1 so the final step never costs more than the previous one — otherwise
+     * it becomes the single most expensive action of the run for a marginal payoff
+     * (game-designer review 2026-08-14: expedition_coverage plateaued at 15/16 because the
+     * last colony-zone tile requires CC max_level and its uncapped cost (150 Rg) outweighed
+     * the 1-tile gain it unlocks). Harvester is free (bootstrap); all others pay a flat
+     * rate, independent of build_cost.
      */
     private function levelupRegolithFor(int $buildingId, int $targetLevel): int
     {
@@ -80,9 +85,11 @@ class ColonyController extends BaseController
         }
 
         if ($buildingId === BuildingId::CommandCenter->value) {
-            $perLevel = (int) (collect(config('buildings'))->firstWhere('id', $buildingId)['cc_upgrade_regolith_per_level'] ?? 30);
+            $cfg = collect(config('buildings'))->firstWhere('id', $buildingId);
+            $perLevel = (int) ($cfg['cc_upgrade_regolith_per_level'] ?? 30);
+            $maxLevel = (int) ($cfg['max_level'] ?? 5);
 
-            return $targetLevel * $perLevel;
+            return min($targetLevel, $maxLevel - 1) * $perLevel;
         }
 
         return self::LEVELUP_REGOLITH_FLAT;

--- a/tests/Feature/Colony/BuildResourceSinkTest.php
+++ b/tests/Feature/Colony/BuildResourceSinkTest.php
@@ -160,6 +160,21 @@ class BuildResourceSinkTest extends TestCase
         $this->assertSame($before - 60, $this->colonyRes(self::RES_REGOLITH));
     }
 
+    public function test_cc_levelup_to_max_level_is_capped_at_previous_step_cost(): void
+    {
+        // Uncapped formula would charge 5×30=150; degressive cap charges the same as
+        // Lv4 (4×30=120) so the final CC step isn't the run's single most expensive
+        // action for a marginal 1-of-16 expedition tile (game-designer review 2026-08-14,
+        // PlaytestBot: expedition_coverage plateaued at 15/16 across most seeds).
+        $this->setCc(['level' => 4, 'ap_spend' => 9, 'status_points' => 16]);
+        $before = $this->colonyRes(self::RES_REGOLITH);
+
+        $this->actingAs($this->bart())->postJson(route('colony.building.invest'), ['building_id' => 25])
+            ->assertOk()->assertJsonPath('leveled_up', true);
+
+        $this->assertSame($before - 120, $this->colonyRes(self::RES_REGOLITH));
+    }
+
     public function test_non_cc_levelup_deducts_flat_regolith_regardless_of_build_cost(): void
     {
         // Sciencelab build_cost[3]=95 (25% would be 24) — GDD §13.7 flat 25 applies


### PR DESCRIPTION
## Summary
- `ColonyController::levelupRegolithFor()`: CC-Levelup Lv4→Lv5 kostete 150 Regolith (target_level × 30, unlimitiert), der teuerste Einzelposten des gesamten Runs — für nur 1 von 16 Colony-Zone-Tiles (`task_expedition_coverage`).
- Neue Regel: letzte CC-Stufe kostet nie mehr als die vorletzte (Kappung bei `max_level - 1`). Lv5 jetzt 120 Rg statt 150.
- Ausgelöst durch PlaytestBot-Balance-Runs (`game:playtest`, PR #250): `task_expedition_coverage` hing in 4 von 6 Seeds konsequent bei 15/16 fest. game-designer-Review identifizierte den CC-Lv5-Sprung als spezifischen Engpass (nicht generischer AP-Mangel — AP-Knappheit ist gewollt).

## Test plan
- [x] TDD: `test_cc_levelup_to_max_level_is_capped_at_previous_step_cost` — rot (150) → grün (120)
- [x] Bestehende `test_cc_levelup_deducts_scaled_regolith` (Lv1→Lv2 = 60) unverändert grün
- [x] `php artisan test` — 988 passed, 0 failed
- [x] `game:playtest`-Vergleichsläufe: erste Beobachtung eines bisher nie erreichten 16/16-Ergebnisses (seed 1337, thrifty); breitere Bestätigung braucht mehr Läufe wegen bekannter Tile-Layout-Nondeterminismus (siehe SDD-Ledger PR #250)

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9