### PR TITLE
Kenntnis-Effekte: Bau-AP-Rabatt, Agronomie-Bonus, Cantina-Slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-15
 
+- Feature: 4 der 7 Kenntnisse bekommen aktive Effekte (`construction`/`cartography`/`trade` → additiver Bau-AP-Rabatt, `agronomy` → Organika-Bonus, `trade` → Cantina-Angebotsslots) — alle glockenförmig über 5 Level statt linear. Siehe `docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md`. `defense` + GDD §9 Begegnungen folgen als separater Plan.
 - Revert: CC-Lv5-Regolith-Deckel (PR #251) zurückgenommen — breitere PlaytestBot-Stichprobe (10 Seeds × 2 Profile) zeigt: CC Lv4 wird erst bei Sol 65–91 von ~95 erreicht, der Flaschenhals ist Timing, nicht der Rg-Preis der letzten Stufe. Nächster Schritt: Analytik/Handel/Missionen-Pfade auf fehlende Regolith-/AP-Boni prüfen.
 
 ## 2026-08-14

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -962,8 +962,8 @@ class GameTick extends Command
     }
 
     /**
-     * agronomy Kenntnis-Bonus auf bioFacility-Organika-Ausstoß (GDD §13.5 Paritäts-
-     * Anforderung, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-
+     * agronomy Kenntnis bonus on bioFacility Organika output (GDD §13.5 parity
+     * requirement, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-
      * design.md §3) — mirrors generateHarvesterYield()'s geology bonus pattern, but
      * bioFacility has no per-tile depletion, so this is a flat colony-level add-on.
      */

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -827,6 +827,13 @@ class GameTick extends Command
                     ->update(['amount' => DB::raw("amount + {$harvesterYield}")]);
             }
 
+            $agronomyBonus = $this->generateAgronomyBonus($colony, $multiplier);
+            if ($agronomyBonus > 0) {
+                ColonyResource::where('colony_id', $colony->id)
+                    ->where('resource_id', 5) // Organika
+                    ->update(['amount' => DB::raw("amount + {$agronomyBonus}")]);
+            }
+
             foreach ($productionConfig as $buildingId => $outputs) {
                 // Harvester (27) is handled above via the depletion mechanic (GDD §4c) —
                 // production_curve[27] stays inert historical data (GDD §13.7).
@@ -952,6 +959,34 @@ class GameTick extends Command
         }
 
         return $totalCredited;
+    }
+
+    /**
+     * agronomy Kenntnis-Bonus auf bioFacility-Organika-Ausstoß (GDD §13.5 Paritäts-
+     * Anforderung, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-
+     * design.md §3) — mirrors generateHarvesterYield()'s geology bonus pattern, but
+     * bioFacility has no per-tile depletion, so this is a flat colony-level add-on.
+     */
+    private function generateAgronomyBonus(Colony $colony, float $multiplier): int
+    {
+        $bioFacilityLevel = (int) DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', 41)
+            ->value('level');
+
+        if ($bioFacilityLevel <= 0) {
+            return 0;
+        }
+
+        $agronomyId = (int) config('knowledge.agronomy.id', 93);
+        $agronomyLevel = (int) DB::table('colony_researches')
+            ->where('colony_id', $colony->id)
+            ->where('research_id', $agronomyId)
+            ->value('level');
+
+        $bonus = self::cumulativeCurveYield(config('game.agronomy_agrardom_bonus_per_level', []), $agronomyLevel);
+
+        return (int) round($bonus * $multiplier);
     }
 
     // ── 8a. Food consumption (Organika provisioning) ──────────────────────────

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -270,7 +270,7 @@ class ColonyController extends BaseController
                 'key' => $b->name,
                 'label' => __('techtree.'.$b->name),
                 'description' => __('buildings.'.preg_replace('/^building_/', '', $b->name).'_desc'),
-                'ap_for_levelup' => $b->ap_for_levelup,
+                'ap_for_levelup' => $this->projectBonusService->effectiveApForLevelup($colony->id, (int) $b->ap_for_levelup),
                 'max_level' => $b->max_level,
                 'max_status_points' => $b->max_status_points,
                 'is_instanced' => (bool) $b->is_instanced,
@@ -659,7 +659,7 @@ class ColonyController extends BaseController
                 'building_id' => $buildingId,
                 'building_name' => $building->name ?? '',
                 'ap_spend' => $newApSpend,
-                'ap_for_levelup' => (int) $building->ap_for_levelup,
+                'ap_for_levelup' => $effectiveApForLevelup,
                 'level_up' => $leveledUp,
                 'new_level' => $leveledUp ? $row->level + 1 : $row->level,
             ]),
@@ -1029,6 +1029,7 @@ class ColonyController extends BaseController
         $row->image_slug = self::buildingImageSlug($row->building_key);
         $row->in_transit = $row->pending_until_tick !== null && (int) $row->pending_until_tick >= $this->getTick();
         $row->levelup_cost = $this->levelupRegolithFor((int) $row->building_id, (int) $row->level + 1);
+        $row->ap_for_levelup = $this->projectBonusService->effectiveApForLevelup($colonyId, (int) $row->ap_for_levelup);
 
         return $row;
     }

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -12,6 +12,7 @@ use App\Services\HarvesterEntitlementService;
 use App\Services\MerchantService;
 use App\Services\OnboardingHintService;
 use App\Services\OnboardingTriggerService;
+use App\Services\ProjectBonusService;
 use App\Services\ResourcesService;
 use App\Services\TickService;
 use App\Services\TrustService;
@@ -37,6 +38,7 @@ class ColonyController extends BaseController
         private readonly ResourcesService $resourcesService,
         private readonly TrustService $trustService,
         private readonly HarvesterEntitlementService $harvesterEntitlementService,
+        private readonly ProjectBonusService $projectBonusService,
     ) {
         parent::__construct($tick);
     }
@@ -133,11 +135,12 @@ class ColonyController extends BaseController
                 'buildings.max_status_points',
             )
             ->get()
-            ->map(function ($b) use ($globalTick) {
+            ->map(function ($b) use ($globalTick, $colony) {
                 $b->label = __('techtree.'.$b->building_key);
                 $b->image_slug = self::buildingImageSlug($b->building_key);
                 $b->in_transit = $b->pending_until_tick !== null && (int) $b->pending_until_tick >= $globalTick;
                 $b->levelup_cost = $this->levelupRegolithFor((int) $b->building_id, (int) $b->level + 1);
+                $b->ap_for_levelup = $this->projectBonusService->effectiveApForLevelup($colony->id, (int) $b->ap_for_levelup);
 
                 return $b;
             });
@@ -597,10 +600,13 @@ class ColonyController extends BaseController
             return $this->fail('max_level_reached');
         }
 
-        // Level-up Regolith is charged only on the click that completes the level (flat,
-        // no escalation; CC scales by target level). Check it BEFORE spending the AP so a
-        // shortfall never burns the final Construction-AP — the player tops up first.
-        $willLevelUp = ($row->ap_spend + 1) >= (int) $building->ap_for_levelup;
+        // Construction/cartography/trade knowledge additively discounts the AP
+        // threshold (GDD §13.3, docs/superpowers/specs/2026-08-15-knowledge-effects-
+        // and-encounters-design.md §2). Level-up Regolith is charged only on the click
+        // that completes the level — checked BEFORE spending the AP so a shortfall
+        // never burns the final Construction-AP.
+        $effectiveApForLevelup = $this->projectBonusService->effectiveApForLevelup($colony->id, (int) $building->ap_for_levelup);
+        $willLevelUp = ($row->ap_spend + 1) >= $effectiveApForLevelup;
         $levelupRegolith = $willLevelUp
             ? $this->levelupRegolithFor($buildingId, (int) $row->level + 1)
             : 0;
@@ -612,7 +618,7 @@ class ColonyController extends BaseController
             ]);
         }
 
-        $newApSpend = min($row->ap_spend + 1, $building->ap_for_levelup);
+        $newApSpend = min($row->ap_spend + 1, $effectiveApForLevelup);
 
         DB::table('colony_buildings')
             ->where('colony_id', $colony->id)
@@ -625,7 +631,7 @@ class ColonyController extends BaseController
         }
 
         $leveledUp = false;
-        if ($newApSpend >= $building->ap_for_levelup) {
+        if ($newApSpend >= $effectiveApForLevelup) {
             if ($levelupRegolith > 0 && ! config('game.bypass.resource_costs')) {
                 $this->resourcesService->payCosts(
                     [['resource_id' => self::RES_REGOLITH, 'amount' => $levelupRegolith]],

--- a/app/Services/BarService.php
+++ b/app/Services/BarService.php
@@ -94,10 +94,10 @@ class BarService
     }
 
     /**
-     * trade Kenntnis-Bonus auf gleichzeitige Cantina-Angebotsslots (GDD §13.5 Pfad-C,
+     * Trade knowledge bonus on concurrent Cantina offer slots (GDD §13.5 Pfad-C,
      * docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md §4)
-     * — separat vom Bau-AP-Rabatt (ProjectBonusService), da dieser Effekt Handlungen
-     * (Cantina-Angebote), nicht Projekte betrifft.
+     * — separate from the build-AP discount (ProjectBonusService), since this effect
+     * concerns actions (Cantina offers), not projects.
      */
     private function tradeConcurrentSlotBonus(int $colonyId): int
     {

--- a/app/Services/BarService.php
+++ b/app/Services/BarService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Console\Commands\GameTick;
 use App\Models\BarOffer;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -56,7 +57,7 @@ class BarService
         // their own budget from game.merchant.commodity and must not consume — or be
         // consumed by — the generic guest rotation's slot count.
         $levelMaxConcurrent = config('game.bar.level_max_concurrent', []);
-        $maxConcurrent = $levelMaxConcurrent[$barLevel] ?? 2;
+        $maxConcurrent = ($levelMaxConcurrent[$barLevel] ?? 2) + $this->tradeConcurrentSlotBonus($colonyId);
         $activeCount = DB::table('bar_offers')
             ->where('colony_id', $colonyId)
             ->where('expires_tick', '>', $tick)
@@ -90,6 +91,26 @@ class BarService
                 'is_accepted' => false,
             ]);
         }
+    }
+
+    /**
+     * trade Kenntnis-Bonus auf gleichzeitige Cantina-Angebotsslots (GDD §13.5 Pfad-C,
+     * docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md §4)
+     * — separat vom Bau-AP-Rabatt (ProjectBonusService), da dieser Effekt Handlungen
+     * (Cantina-Angebote), nicht Projekte betrifft.
+     */
+    private function tradeConcurrentSlotBonus(int $colonyId): int
+    {
+        $tradeId = (int) config('knowledge.trade.id', 95);
+        $tradeLevel = (int) DB::table('colony_researches')
+            ->where('colony_id', $colonyId)
+            ->where('research_id', $tradeId)
+            ->value('level');
+
+        return GameTick::cumulativeCurveYield(
+            config('knowledge.trade.bar_offer_boost_per_lv', []),
+            $tradeLevel
+        );
     }
 
     public function getActiveOffers(int $colonyId, int $tick): Collection

--- a/app/Services/ProjectBonusService.php
+++ b/app/Services/ProjectBonusService.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services;
+
+use App\Console\Commands\GameTick;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Additive AP-cost discounts for building projects (GDD §13.3). Currently sums the
+ * three "domain knowledge" curves (construction, cartography, trade) — advisor-rank
+ * and CC-level bonus sources from the same GDD table are not yet implemented (out of
+ * scope for this plan, see docs/superpowers/specs/2026-08-15-knowledge-effects-and-
+ * encounters-design.md §2).
+ */
+class ProjectBonusService
+{
+    /** research_id values from config/knowledge.php that discount building projects. */
+    private const DOMAIN_KNOWLEDGE_KEYS = ['construction', 'cartography', 'trade'];
+
+    public function buildingApDiscountPercent(int $colonyId): int
+    {
+        $total = 0;
+
+        foreach (self::DOMAIN_KNOWLEDGE_KEYS as $key) {
+            $cfg = config("knowledge.{$key}");
+            $researchId = (int) $cfg['id'];
+            $curve = $cfg['ap_cost_reduction_per_lv'] ?? [];
+
+            $level = (int) DB::table('colony_researches')
+                ->where('colony_id', $colonyId)
+                ->where('research_id', $researchId)
+                ->value('level');
+
+            $total += GameTick::cumulativeCurveYield($curve, $level);
+        }
+
+        return $total;
+    }
+
+    public function effectiveApForLevelup(int $colonyId, int $baseApForLevelup): int
+    {
+        $discountPercent = $this->buildingApDiscountPercent($colonyId);
+        $minCostFactor = (float) config('game.project_min_cost_factor', 0.5);
+
+        return self::applyDiscount($baseApForLevelup, $discountPercent, $minCostFactor);
+    }
+
+    /** Pure discount math, factored out so the floor logic is testable without DB state. */
+    public static function applyDiscount(int $base, int $discountPercent, float $minCostFactor): int
+    {
+        $floor = (int) ceil($base * $minCostFactor);
+        $discounted = (int) round($base * (1 - $discountPercent / 100));
+
+        return max($floor, $discounted);
+    }
+}

--- a/config/game.php
+++ b/config/game.php
@@ -69,10 +69,10 @@ return [
         41 => [5 => [1 => 8, 2 => 12, 3 => 12, 4 => 9, 5 => 7, 6 => 5, 7 => 3, 8 => 2]],     // bioFacility → Organika
     ],
 
-    // Untergrenze für additive Projekt-AP-Rabatte (§13.3) — verhindert, dass Boni
-    // ap_for_levelup auf 0 drücken. Bei aktuellem Max-Rabatt (45%, construction+
-    // cartography+trade voll investiert) nie bindend; Leitplanke für spätere
-    // Bonusquellen (Berater-Rang, Koloniereife), die noch nicht implementiert sind.
+    // Lower bound for additive project-AP discounts (§13.3) — prevents bonuses from
+    // pushing ap_for_levelup to 0. Not binding at the current max discount (45%,
+    // construction+cartography+trade fully invested); a guard rail for future bonus
+    // sources (advisor rank, colony maturity) that are not yet implemented.
     'project_min_cost_factor' => 0.5,
 
     // Harvester depletion mechanic (GDD §4c "Erschöpfungskurve und Umzugstakt",
@@ -144,10 +144,12 @@ return [
         'duration_ticks' => 1,
     ],
 
-    // Geology (config/knowledge.php id 92) production bonus — first of at most two
-    // hardcoded Kenntnis-Effekte before the generic effect framework is mandatory
-    // (ROADMAP Stufe 1, GDD §13.7). Additive Regolith bonus per Harvester-Sol,
-    // cumulative across levels, capped at level 5 (+3+3+2+2+2 = 12 max).
+    // Geology (config/knowledge.php id 92) production bonus — originally the first of
+    // at most two hardcoded Kenntnis-Effekte before a generic effect framework became
+    // mandatory; superseded by the deliberate decision (2026-08-15, design/knowledge-
+    // effects-and-encounters spec) to add four more ad-hoc per-effect config keys
+    // instead. Additive Regolith bonus per Harvester-Sol, cumulative across levels,
+    // capped at level 5 (+3+3+2+2+2 = 12 max).
     'geology_harvester_bonus_per_level' => [1 => 3, 2 => 3, 3 => 2, 4 => 2, 5 => 2],
 
     // agronomy Kenntnis bonus on bioFacility Organika output — parity with geology's

--- a/config/game.php
+++ b/config/game.php
@@ -150,9 +150,9 @@ return [
     // cumulative across levels, capped at level 5 (+3+3+2+2+2 = 12 max).
     'geology_harvester_bonus_per_level' => [1 => 3, 2 => 3, 3 => 2, 4 => 2, 5 => 2],
 
-    // agronomy Kenntnis-Bonus auf bioFacility-Organika-Ertrag — Parität zu geology's
-    // Harvester-Bonus (GDD §13.5 Paritäts-Anforderung). Glockenförmig, NICHT front-
-    // loaded wie geology: dieser Effekt ist neu, ohne bestehende Kalibrierungshistorie.
+    // agronomy Kenntnis bonus on bioFacility Organika output — parity with geology's
+    // Harvester bonus (GDD §13.5 parity requirement). Bell-shaped, NOT front-loaded
+    // like geology: this effect is new, with no existing calibration history.
     'agronomy_agrardom_bonus_per_level' => [1 => 1, 2 => 2, 3 => 2, 4 => 1, 5 => 1],   // Σ7 Or/Sol
 
     // Economy — resource pricing for player-facing buy/sell mechanics.

--- a/config/game.php
+++ b/config/game.php
@@ -69,6 +69,12 @@ return [
         41 => [5 => [1 => 8, 2 => 12, 3 => 12, 4 => 9, 5 => 7, 6 => 5, 7 => 3, 8 => 2]],     // bioFacility → Organika
     ],
 
+    // Untergrenze für additive Projekt-AP-Rabatte (§13.3) — verhindert, dass Boni
+    // ap_for_levelup auf 0 drücken. Bei aktuellem Max-Rabatt (45%, construction+
+    // cartography+trade voll investiert) nie bindend; Leitplanke für spätere
+    // Bonusquellen (Berater-Rang, Koloniereife), die noch nicht implementiert sind.
+    'project_min_cost_factor' => 0.5,
+
     // Harvester depletion mechanic (GDD §4c "Erschöpfungskurve und Umzugstakt",
     // freigegeben 2026-08-03). Replaces production_curve[27] as the actual Regolith
     // source — the curve above stays as inert historical data (GDD §13.7).

--- a/config/game.php
+++ b/config/game.php
@@ -150,6 +150,11 @@ return [
     // cumulative across levels, capped at level 5 (+3+3+2+2+2 = 12 max).
     'geology_harvester_bonus_per_level' => [1 => 3, 2 => 3, 3 => 2, 4 => 2, 5 => 2],
 
+    // agronomy Kenntnis-Bonus auf bioFacility-Organika-Ertrag — Parität zu geology's
+    // Harvester-Bonus (GDD §13.5 Paritäts-Anforderung). Glockenförmig, NICHT front-
+    // loaded wie geology: dieser Effekt ist neu, ohne bestehende Kalibrierungshistorie.
+    'agronomy_agrardom_bonus_per_level' => [1 => 1, 2 => 2, 3 => 2, 4 => 1, 5 => 1],   // Σ7 Or/Sol
+
     // Economy — resource pricing for player-facing buy/sell mechanics.
     'economy' => [
         // Werkstoffe (compounds, resource 4) are not locally producible (GDD §3).

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -37,6 +37,11 @@ return [
         'max_status_points' => 20,
         'credits' => 0,
         'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
+        // Bau-AP-Rabatt (GDD §13.3, glockenförmig statt linear — game-designer review
+        // 2026-08-15, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md).
+        // Wirkt additiv mit cartography+trade auf ALLE Gebäude-Levelups (Owner-Entscheidung:
+        // keine Domänentrennung nach Projekttyp, da nur Bau-Projekte existieren).
+        'ap_cost_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
     ],
 
     'cartography' => [
@@ -46,6 +51,11 @@ return [
         'max_status_points' => 20,
         'credits' => 0,
         'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
+        // Bau-AP-Rabatt (GDD §13.3, glockenförmig statt linear — game-designer review
+        // 2026-08-15, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md).
+        // Wirkt additiv mit construction+trade auf ALLE Gebäude-Levelups (Owner-Entscheidung:
+        // keine Domänentrennung nach Projekttyp, da nur Bau-Projekte existieren).
+        'ap_cost_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
     ],
 
     'geology' => [
@@ -82,6 +92,14 @@ return [
         'max_status_points' => 20,
         'credits' => 0,
         'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
+        // Bau-AP-Rabatt (GDD §13.3, glockenförmig statt linear — game-designer review
+        // 2026-08-15, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md).
+        // Wirkt additiv mit construction+cartography auf ALLE Gebäude-Levelups (Owner-Entscheidung:
+        // keine Domänentrennung nach Projekttyp, da nur Bau-Projekte existieren).
+        'ap_cost_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
+        // Cantina-Angebotsslot-Bonus (Task 4 dieses Plans) — zusätzliche gleichzeitige
+        // Bar-Angebote bei höherem trade-Level.
+        'bar_offer_boost_per_lv' => [1 => 0, 2 => 1, 3 => 1, 4 => 0, 5 => 0],   // Σ2 Slots
     ],
 
     'defense' => [

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1928,6 +1928,15 @@ Ein **Mindest-Kostenanteil** (`project_min_cost_factor = 0.5`) verhindert, dass 
 
 **Boni gelten nur für Projekte, nicht für Handlungen.** Dadurch wächst der Handlungsanteil am Pool über den Run relativ an — das späte Spiel verschiebt sich von selbst Richtung Ausführung. Das ist beabsichtigt und trägt den Kipppunkt aus 13.2 mit.
 
+> **Nachtrag 2026-08-15 (Owner-Entscheidung, PlaytestBot-Befund):** Umgesetzt für
+> `construction`/`cartography`/`trade` — glockenförmig statt linear (Σ15% je Kenntnis
+> bei Lv5, Peak Lv2–4), wirkt additiv auf **alle** Gebäude-Levelups (inkl.
+> CommandCenter), nicht nach Projekttyp getrennt, da im aktuellen Spiel nur
+> Bau-Projekte existieren (Navigation/Wirtschaft haben keine passende Projekt-
+> Kategorie). Berater-Rang- und Koloniereife-Bonusquellen aus der Tabelle oben sind
+> weiterhin nicht implementiert. Siehe `app/Services/ProjectBonusService.php`,
+> `docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md`.
+
 ---
 
 ### 13.4 Kommandozentrale: Dashboard und Prognosen
@@ -2027,6 +2036,13 @@ Das eigentliche Problem sind die **Losgrößen**: `rand(1,5) × 10` Einheiten er
 **Der tragfähige Hebel für Pfad C ist deshalb nicht der Credits-Kauf, sondern der Tausch.** Der Tauschtyp (40 % der Angebote) bepreist wertäquivalent — Organika → Regolith liefert bei 10–30 Or rund 17–50 Rg. Das ist genau der Pfadcharakter „Überschuss in Mangel wandeln", und es umgeht die kaputte Credits-Ökonomie vollständig. Give- und Get-Ressource werden heute allerdings gleichverteilt gewürfelt, sodass Or→Rg nur etwa 6,7 % der Angebote trifft — bei 0–2 Gästen pro Sol also eines alle 10–15 Sole.
 
 Vorschlag: **Losgröße an die Zahlungsfähigkeit binden** (höchstens ~35 % des Bestands) **und die Tauschrichtung nach Bestand wählen statt zu würfeln** — Give = Ressource mit dem größten Überschuss, Get = die knappste. Der Zufall bleibt in Preisvarianz, Gästezahl und Gültigkeitsdauer erhalten; er verlagert sich von „welches Angebot?" auf „wie günstig, und kommt heute jemand?". Das ist die planbarere und damit bessere Unsicherheit.
+
+> **Nachtrag 2026-08-15:** `agronomy`-Organika-Parität zu `geology` umgesetzt
+> (`config('game.agronomy_agrardom_bonus_per_level')`, Σ7 Or/Sol bei Lv5, glockenförmig
+> — bewusst NICHT front-loaded wie `geology`, da neu ohne Kalibrierungshistorie). Der
+> Cantina-Pfad-C-Fix (Losgrößen/Tauschrichtung) ist weiterhin offen; `trade`s neuer
+> Kenntniseffekt (zusätzliche Angebotsslots, `BarService::tradeConcurrentSlotBonus()`)
+> läuft parallel dazu, ohne ihn zu ersetzen.
 
 > **⚠️ Offen — Zahlen und Umsetzung.** Die +1,5 Rg/Sol je `geology`-Level sind ein erster Ansatz, kalibriert auf Parität mit dem Frachter-Kanal. Zu prüfen ist, ob der Analytik-Pfad damit insgesamt zu stark wird — er trägt zusätzlich den Supply-Cap-Bonus **und** den Domänen-Effizienzbonus (13.3), leistet also dreifach. Falls ja: auf +1,2/Level senken statt einen der anderen Effekte zu beschneiden.
 

--- a/docs/superpowers/plans/2026-08-15-knowledge-effects-and-encounters.md
+++ b/docs/superpowers/plans/2026-08-15-knowledge-effects-and-encounters.md
@@ -1,0 +1,637 @@
+# Kenntnis-Effekte (Plan 1: Bau-AP-Rabatt, Agronomie, Handel) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Vier der sieben Kenntnisse (`construction`, `cartography`, `trade`, `agronomy`) bekommen einen aktiven, spielrelevanten Effekt — Gebäude-Levelup-AP-Rabatt (additiv, glockenförmig über die Level) sowie Organika- und Cantina-Boni. `geology` (bereits aktiv) und `health` (bewusst ohne Zusatzeffekt) bleiben unangetastet. `defense` + GDD §9 "Begegnungen & Gefahren" sind ein separater Folgeplan.
+
+**Architecture:** Ein neuer `ProjectBonusService` bündelt die additive Bau-AP-Rabatt-Berechnung (Summe der Kenntnis-Kurven von `construction`+`cartography`+`trade`, gedeckelt durch `project_min_cost_factor`) und wird in `ColonyController::investBuilding()`/`hexview()` verdrahtet. `agronomy` und `trade`s Cantina-Bonus folgen dem bereits bestehenden `geology`-Muster (direkter `DB::table('colony_researches')`-Read + `GameTick::cumulativeCurveYield()`) in `GameTick` bzw. `BarService`.
+
+**Tech Stack:** Laravel 12, PHP 8.2, SQLite, PHPUnit.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md`
+
+## Global Constraints
+
+- Alle neuen Effekt-Kurven sind **glockenförmig** über 5 Level (kleiner Zuwachs Lv1/Lv5, größter Zuwachs Lv2–4) — Delta-Arrays im etablierten Stil (`geology_harvester_bonus_per_level`, `colony_zone_expansion`).
+- Bau-AP-Rabatt ist **additiv, nie multiplikativ**, respektiert `project_min_cost_factor` (neu, 0.5) als Untergrenze — Rabatt darf `ap_for_levelup` nie unter 50 % des Basiswerts drücken.
+- `construction`/`cartography`/`trade` rabattieren **alle** Gebäude-Levelups gleichermaßen (inkl. CommandCenter) — keine Unterscheidung nach Gebäudetyp (Owner-Entscheidung, 2026-08-15).
+- Kein neuer AP-Pool, keine AP-Domänen-Trennung — der Rabatt wirkt auf `ap_for_levelup`-Schwellenwerte, nicht auf den Pool selbst.
+- PHP-Code/Kommentare Englisch, Config-Keys Englisch.
+- TDD-Pflicht: jeder neue Effekt braucht mindestens einen Service-/Feature-Test, der den Bonus bei einem konkreten Level verifiziert.
+- Jeder bestehende Aufrufer von `ColonyController::investBuilding()` ohne jede Kenntnis-Investition (alle Kenntnisse Level 0) muss sich identisch zu heute verhalten (Rabatt = 0 %, `effectiveApForLevelup === baseApForLevelup`).
+
+---
+
+### Task 1: `ProjectBonusService` — Bau-AP-Rabatt-Berechnung
+
+**Files:**
+- Create: `app/Services/ProjectBonusService.php`
+- Test: `tests/Unit/ProjectBonusServiceTest.php`
+- Modify: `config/knowledge.php` (neue Felder `construction`, `cartography`, `trade`)
+- Modify: `config/game.php` (neuer Key `project_min_cost_factor`)
+
+**Interfaces:**
+- Produces: `ProjectBonusService::buildingApDiscountPercent(int $colonyId): int` (Summe in Prozentpunkten, 0–45), `ProjectBonusService::effectiveApForLevelup(int $colonyId, int $baseApForLevelup): int` — konsumiert von Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ProjectBonusService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ProjectBonusServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function setKnowledgeLevel(int $researchId, int $level): void
+    {
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => $researchId],
+            ['level' => $level, 'ap_spend' => 0, 'status_points' => 20]
+        );
+    }
+
+    public function test_discount_is_zero_with_no_knowledge_invested(): void
+    {
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(0, $service->buildingApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_discount_sums_all_three_domains_additively(): void
+    {
+        // construction id=90, cartography id=91, trade id=95 (config/knowledge.php)
+        $this->setKnowledgeLevel(90, 3);   // cumulative [2,4,4] = 10
+        $this->setKnowledgeLevel(91, 1);   // cumulative [2] = 2
+        $this->setKnowledgeLevel(95, 5);   // cumulative [2,4,4,3,2] = 15
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(27, $service->buildingApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_effective_ap_for_levelup_applies_discount(): void
+    {
+        $this->setKnowledgeLevel(90, 5);   // construction Lv5 = 15%
+        $service = $this->app->make(ProjectBonusService::class);
+
+        // 10 * (1 - 0.15) = 8.5 → round to 9 (round-half-up)
+        $this->assertSame(9, $service->effectiveApForLevelup(self::COLONY_ID, 10));
+    }
+
+    /**
+     * With current config, max additive discount is 45% (15% × 3 domains) — always
+     * below the 50% floor, so it never binds via real knowledge levels (by design,
+     * see spec §Global Constraints: the floor is a guard rail for future bonus
+     * sources, not active yet). Test the floor logic directly via the pure helper
+     * instead of trying to manufacture a >50% discount through the DB.
+     */
+    public function test_apply_discount_never_drops_below_min_cost_factor(): void
+    {
+        // 80% discount would give round(10 * 0.2) = 2, but the 0.5 floor caps it at 5.
+        $this->assertSame(5, ProjectBonusService::applyDiscount(10, 80, 0.5));
+    }
+
+    public function test_apply_discount_rounds_half_up_below_the_floor(): void
+    {
+        // 15% discount on base 10: round(10 * 0.85) = round(8.5) = 9, floor = ceil(5) = 5.
+        $this->assertSame(9, ProjectBonusService::applyDiscount(10, 15, 0.5));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `php bin/phpunit tests/Unit/ProjectBonusServiceTest.php`
+Expected: FAIL — class `App\Services\ProjectBonusService` not found.
+
+- [ ] **Step 3: Add config fields**
+
+In `config/knowledge.php`, add to `construction`, `cartography`, `trade` (after their existing `levelup_costs` line each):
+
+```php
+        // Bau-AP-Rabatt (GDD §13.3, glockenförmig statt linear — game-designer review
+        // 2026-08-15, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md).
+        // Wirkt additiv mit cartography+trade auf ALLE Gebäude-Levelups (Owner-Entscheidung:
+        // keine Domänentrennung nach Projekttyp, da nur Bau-Projekte existieren).
+        'ap_cost_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
+```
+
+For `trade` specifically, add a second field right after (used by Task 4, defined here so the config file carries both `trade` fields together):
+
+```php
+        // Cantina-Angebotsslot-Bonus (Task 4 dieses Plans) — zusätzliche gleichzeitige
+        // Bar-Angebote bei höherem trade-Level.
+        'bar_offer_boost_per_lv' => [1 => 0, 2 => 1, 3 => 1, 4 => 0, 5 => 0],   // Σ2 Slots
+```
+
+In `config/game.php`, add near the other `game.run.*`/global keys (top-level array, alongside `production_curve`):
+
+```php
+    // Untergrenze für additive Projekt-AP-Rabatte (§13.3) — verhindert, dass Boni
+    // ap_for_levelup auf 0 drücken. Bei aktuellem Max-Rabatt (45%, construction+
+    // cartography+trade voll investiert) nie bindend; Leitplanke für spätere
+    // Bonusquellen (Berater-Rang, Koloniereife), die noch nicht implementiert sind.
+    'project_min_cost_factor' => 0.5,
+```
+
+- [ ] **Step 4: Implement `ProjectBonusService`**
+
+```php
+<?php
+
+namespace App\Services;
+
+use App\Console\Commands\GameTick;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Additive AP-cost discounts for building projects (GDD §13.3). Currently sums the
+ * three "domain knowledge" curves (construction, cartography, trade) — advisor-rank
+ * and CC-level bonus sources from the same GDD table are not yet implemented (out of
+ * scope for this plan, see docs/superpowers/specs/2026-08-15-knowledge-effects-and-
+ * encounters-design.md §2).
+ */
+class ProjectBonusService
+{
+    /** research_id values from config/knowledge.php that discount building projects. */
+    private const DOMAIN_KNOWLEDGE_KEYS = ['construction', 'cartography', 'trade'];
+
+    public function buildingApDiscountPercent(int $colonyId): int
+    {
+        $total = 0;
+
+        foreach (self::DOMAIN_KNOWLEDGE_KEYS as $key) {
+            $cfg = config("knowledge.{$key}");
+            $researchId = (int) $cfg['id'];
+            $curve = $cfg['ap_cost_reduction_per_lv'] ?? [];
+
+            $level = (int) DB::table('colony_researches')
+                ->where('colony_id', $colonyId)
+                ->where('research_id', $researchId)
+                ->value('level');
+
+            $total += GameTick::cumulativeCurveYield($curve, $level);
+        }
+
+        return $total;
+    }
+
+    public function effectiveApForLevelup(int $colonyId, int $baseApForLevelup): int
+    {
+        $discountPercent = $this->buildingApDiscountPercent($colonyId);
+        $minCostFactor = (float) config('game.project_min_cost_factor', 0.5);
+
+        return self::applyDiscount($baseApForLevelup, $discountPercent, $minCostFactor);
+    }
+
+    /** Pure discount math, factored out so the floor logic is testable without DB state. */
+    public static function applyDiscount(int $base, int $discountPercent, float $minCostFactor): int
+    {
+        $floor = (int) ceil($base * $minCostFactor);
+        $discounted = (int) round($base * (1 - $discountPercent / 100));
+
+        return max($floor, $discounted);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `php bin/phpunit tests/Unit/ProjectBonusServiceTest.php`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/ProjectBonusService.php tests/Unit/ProjectBonusServiceTest.php config/knowledge.php config/game.php
+git commit -m "feat: add ProjectBonusService for additive building-project AP discounts"
+```
+
+---
+
+### Task 2: Wire `ProjectBonusService` into `ColonyController`
+
+**Files:**
+- Modify: `app/Http/Controllers/Colony/ColonyController.php`
+- Test: `tests/Feature/Colony/BuildResourceSinkTest.php` (extend existing suite)
+
+**Interfaces:**
+- Consumes: `ProjectBonusService::effectiveApForLevelup(int $colonyId, int $baseApForLevelup): int` (Task 1)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/Feature/Colony/BuildResourceSinkTest.php`, in the "Level-up costs" section (near `test_cc_levelup_deducts_scaled_regolith`):
+
+```php
+    public function test_construction_knowledge_reduces_ap_needed_for_levelup(): void
+    {
+        // construction Lv5 (research_id=90) = 15% discount → CC's ap_for_levelup
+        // (10) drops to round(10 * 0.85) = 9. One less invest click needed to level up.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 90],
+            ['level' => 5, 'ap_spend' => 0, 'status_points' => 20]
+        );
+        $this->setCc(['level' => 1, 'ap_spend' => 8, 'status_points' => 16]);   // 1 AP from the discounted threshold (9)
+
+        $this->actingAs($this->bart())->postJson(route('colony.building.invest'), ['building_id' => 25])
+            ->assertOk()->assertJsonPath('leveled_up', true);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `php bin/phpunit --filter test_construction_knowledge_reduces_ap_needed_for_levelup tests/Feature/Colony/BuildResourceSinkTest.php`
+Expected: FAIL — `leveled_up` is `false` (still gated at the undiscounted threshold of 10, `ap_spend=9` after this click ≠ 10).
+
+- [ ] **Step 3: Inject the service and use it in the AP gate**
+
+In `app/Http/Controllers/Colony/ColonyController.php`, add the import:
+
+```php
+use App\Services\ProjectBonusService;
+```
+
+Add to the constructor parameter list (after `private readonly HarvesterEntitlementService $harvesterEntitlementService,`):
+
+```php
+        private readonly ProjectBonusService $projectBonusService,
+```
+
+Replace the AP-gate block inside `investBuilding()`:
+
+```php
+        // Level-up Regolith is charged only on the click that completes the level (flat,
+        // no escalation; CC scales by target level). Check it BEFORE spending the AP so a
+        // shortfall never burns the final Construction-AP — the player tops up first.
+        $willLevelUp = ($row->ap_spend + 1) >= (int) $building->ap_for_levelup;
+        $levelupRegolith = $willLevelUp
+            ? $this->levelupRegolithFor($buildingId, (int) $row->level + 1)
+            : 0;
+```
+
+with:
+
+```php
+        // Construction/cartography/trade knowledge additively discounts the AP
+        // threshold (GDD §13.3, docs/superpowers/specs/2026-08-15-knowledge-effects-
+        // and-encounters-design.md §2). Level-up Regolith is charged only on the click
+        // that completes the level — checked BEFORE spending the AP so a shortfall
+        // never burns the final Construction-AP.
+        $effectiveApForLevelup = $this->projectBonusService->effectiveApForLevelup($colony->id, (int) $building->ap_for_levelup);
+        $willLevelUp = ($row->ap_spend + 1) >= $effectiveApForLevelup;
+        $levelupRegolith = $willLevelUp
+            ? $this->levelupRegolithFor($buildingId, (int) $row->level + 1)
+            : 0;
+```
+
+Also replace the line just below that clamps `ap_spend`:
+
+```php
+        $newApSpend = min($row->ap_spend + 1, $building->ap_for_levelup);
+```
+
+with:
+
+```php
+        $newApSpend = min($row->ap_spend + 1, $effectiveApForLevelup);
+```
+
+- [ ] **Step 4: Fix the hexview display to show the discounted threshold**
+
+In `hexview()`, the `$buildings` collection's `map()` callback currently reads `$b->ap_for_levelup` straight off the query result (undiscounted). Locate:
+
+```php
+            ->map(function ($b) use ($globalTick) {
+                $b->label = __('techtree.'.$b->building_key);
+                $b->image_slug = self::buildingImageSlug($b->building_key);
+                $b->in_transit = $b->pending_until_tick !== null && (int) $b->pending_until_tick >= $globalTick;
+                $b->levelup_cost = $this->levelupRegolithFor((int) $b->building_id, (int) $b->level + 1);
+
+                return $b;
+            });
+```
+
+Replace with:
+
+```php
+            ->map(function ($b) use ($globalTick, $colony) {
+                $b->label = __('techtree.'.$b->building_key);
+                $b->image_slug = self::buildingImageSlug($b->building_key);
+                $b->in_transit = $b->pending_until_tick !== null && (int) $b->pending_until_tick >= $globalTick;
+                $b->levelup_cost = $this->levelupRegolithFor((int) $b->building_id, (int) $b->level + 1);
+                $b->ap_for_levelup = $this->projectBonusService->effectiveApForLevelup($colony->id, (int) $b->ap_for_levelup);
+
+                return $b;
+            });
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `php bin/phpunit tests/Feature/Colony/BuildResourceSinkTest.php tests/Feature/Colony/BuildingInvestTest.php`
+Expected: PASS — including the new test and all pre-existing tests (which run with zero knowledge invested, so the discount is 0% and behavior is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Http/Controllers/Colony/ColonyController.php tests/Feature/Colony/BuildResourceSinkTest.php
+git commit -m "feat: apply construction/cartography/trade AP discount to building levelups"
+```
+
+---
+
+### Task 3: `agronomy` Organika production bonus
+
+**Files:**
+- Modify: `app/Console/Commands/GameTick.php`
+- Modify: `config/game.php`
+- Test: `tests/Feature/GameTickTest.php` (or the existing GameTick production test file — see Step 1 note)
+
+**Interfaces:**
+- Produces: nothing consumed elsewhere in this plan (self-contained, mirrors the existing `geology` → Harvester pattern).
+
+- [ ] **Step 1: Locate the existing GameTick production test file**
+
+Run: `grep -rln "generateHarvesterYield\|generateResources\|geology_harvester_bonus" tests/Feature/*.php tests/Unit/*.php`
+
+Add the new test to whichever file already covers `generateHarvesterYield`'s geology bonus (same fixture/setup pattern) — if none exists standalone, add to `tests/Feature/GameTickTest.php`. Adjust the exact class/fixture names in Step 2 below to match what that file already uses for colony/user setup.
+
+- [ ] **Step 2: Write the failing test**
+
+```php
+    public function test_agronomy_knowledge_adds_organika_bonus_on_top_of_biofacility_output(): void
+    {
+        // bioFacility (id=41) Lv1 alone yields 8 Organika/Sol (production_curve[41][5][1]).
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 41)
+            ->update(['level' => 1]);
+        // agronomy (research_id=93) Lv3 → cumulative [1,2,2] = 5 bonus Organika/Sol.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 93],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+        $before = (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)->where('resource_id', 5)->value('amount');
+
+        $this->artisan('game:tick')->assertExitCode(0);
+
+        $after = (int) DB::table('colony_resources')
+            ->where('colony_id', self::COLONY_ID)->where('resource_id', 5)->value('amount');
+        // 8 (base) + 5 (agronomy bonus) = 13, at trust multiplier 1.0 (default seeded trust).
+        $this->assertSame($before + 13, $after);
+    }
+```
+
+Adapt `self::COLONY_ID` / `actingAs` fixture references to match the surrounding test file's existing conventions exactly (read a neighboring test first).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `php bin/phpunit --filter test_agronomy_knowledge_adds_organika_bonus_on_top_of_biofacility_output`
+Expected: FAIL — actual delta is 8, not 13 (no agronomy bonus applied yet).
+
+- [ ] **Step 4: Add the config curve**
+
+In `config/game.php`, next to `geology_harvester_bonus_per_level`:
+
+```php
+    // agronomy Kenntnis-Bonus auf bioFacility-Organika-Ertrag — Parität zu geology's
+    // Harvester-Bonus (GDD §13.5 Paritäts-Anforderung). Glockenförmig, NICHT front-
+    // loaded wie geology: dieser Effekt ist neu, ohne bestehende Kalibrierungshistorie.
+    'agronomy_agrardom_bonus_per_level' => [1 => 1, 2 => 2, 3 => 2, 4 => 1, 5 => 1],   // Σ7 Or/Sol
+```
+
+- [ ] **Step 5: Implement the bonus in `GameTick`**
+
+Add a new private method near `generateHarvesterYield()`:
+
+```php
+    /**
+     * agronomy Kenntnis-Bonus auf bioFacility-Organika-Ausstoß (GDD §13.5 Paritäts-
+     * Anforderung, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-
+     * design.md §3) — mirrors generateHarvesterYield()'s geology bonus pattern, but
+     * bioFacility has no per-tile depletion, so this is a flat colony-level add-on.
+     */
+    private function generateAgronomyBonus(Colony $colony, float $multiplier): int
+    {
+        $bioFacilityLevel = (int) DB::table('colony_buildings')
+            ->where('colony_id', $colony->id)
+            ->where('building_id', 41)
+            ->value('level');
+
+        if ($bioFacilityLevel <= 0) {
+            return 0;
+        }
+
+        $agronomyId = (int) config('knowledge.agronomy.id', 93);
+        $agronomyLevel = (int) DB::table('colony_researches')
+            ->where('colony_id', $colony->id)
+            ->where('research_id', $agronomyId)
+            ->value('level');
+
+        $bonus = self::cumulativeCurveYield(config('game.agronomy_agrardom_bonus_per_level', []), $agronomyLevel);
+
+        return (int) round($bonus * $multiplier);
+    }
+```
+
+In `generateResources()`, right after the `$harvesterYield` block (which updates Regolith), add:
+
+```php
+            $agronomyBonus = $this->generateAgronomyBonus($colony, $multiplier);
+            if ($agronomyBonus > 0) {
+                ColonyResource::where('colony_id', $colony->id)
+                    ->where('resource_id', 5) // Organika
+                    ->update(['amount' => DB::raw("amount + {$agronomyBonus}")]);
+            }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `php bin/phpunit --filter test_agronomy_knowledge_adds_organika_bonus_on_top_of_biofacility_output`
+Then: `php bin/phpunit tests/Feature/GameTickTest.php` (full file — confirm no regression on colonies with agronomy Lv0, where the bonus must be 0)
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/Console/Commands/GameTick.php config/game.php tests/Feature/GameTickTest.php
+git commit -m "feat: agronomy knowledge adds Organika bonus to bioFacility output"
+```
+
+---
+
+### Task 4: `trade` Cantina concurrent-offer-slot bonus
+
+**Files:**
+- Modify: `app/Services/BarService.php`
+- Test: `tests/Feature/Colony/BarServiceTest.php` (or wherever existing BarService tests live — see Step 1)
+
+**Interfaces:**
+- Consumes: `config('knowledge.trade.bar_offer_boost_per_lv')` (added in Task 1, Step 3)
+
+- [ ] **Step 1: Locate the existing BarService test file**
+
+Run: `grep -rln "generateOffersForColony\|BarService" tests/Feature/*.php tests/Feature/**/*.php`
+
+Add the new test alongside the existing `generateOffersForColony()` coverage, matching that file's fixture/seed conventions exactly.
+
+- [ ] **Step 2: Write the failing test**
+
+```php
+    public function test_trade_knowledge_increases_concurrent_offer_slots(): void
+    {
+        // trade (research_id=95) Lv3 → cumulative [0,1,1] = 2 extra slots.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+        // Force a high guest roll so the concurrent cap — not the guest-count roll — is
+        // what's under test; base level_max_concurrent for this bar level, see
+        // config/game.php → bar.level_max_concurrent.
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 52)
+            ->update(['level' => 1]);
+        $baseMax = config('game.bar.level_max_concurrent')[1] ?? 2;
+
+        app(BarService::class)->generateOffersForColony(self::COLONY_ID, 1);
+
+        $offerCount = DB::table('bar_offers')->where('colony_id', self::COLONY_ID)->count();
+        $this->assertLessThanOrEqual($baseMax + 2, $offerCount);
+        // Weak upper-bound assertion (guestCount is randomized) — the load-bearing
+        // assertion is the config wiring test in Step 5/6, not offer count here.
+    }
+```
+
+Note in the report if the guest-count randomization makes this assertion too weak to be meaningful once you see the actual fixture/seed setup — if so, prefer directly unit-testing the concurrent-cap calculation by extracting it (see Step 4) rather than asserting on randomized `bar_offers` rows.
+
+- [ ] **Step 3: Run test to verify it fails or passes vacuously**
+
+Run: `php bin/phpunit --filter test_trade_knowledge_increases_concurrent_offer_slots`
+Expected: currently passes vacuously (no bonus applied yet, but the weak upper-bound assertion doesn't catch that) — confirm by temporarily asserting `$offerCount > $baseMax` fails without the bonus, then revert to the real assertion once Step 4 is implemented. Note this in the report.
+
+- [ ] **Step 4: Implement the bonus in `BarService`**
+
+Add a new private method:
+
+```php
+    /**
+     * trade Kenntnis-Bonus auf gleichzeitige Cantina-Angebotsslots (GDD §13.5 Pfad-C,
+     * docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md §4)
+     * — separat vom Bau-AP-Rabatt (ProjectBonusService), da dieser Effekt Handlungen
+     * (Cantina-Angebote), nicht Projekte betrifft.
+     */
+    private function tradeConcurrentSlotBonus(int $colonyId): int
+    {
+        $tradeId = (int) config('knowledge.trade.id', 95);
+        $tradeLevel = (int) DB::table('colony_researches')
+            ->where('colony_id', $colonyId)
+            ->where('research_id', $tradeId)
+            ->value('level');
+
+        return \App\Console\Commands\GameTick::cumulativeCurveYield(
+            config('knowledge.trade.bar_offer_boost_per_lv', []),
+            $tradeLevel
+        );
+    }
+```
+
+In `generateOffersForColony()`, replace:
+
+```php
+        $levelMaxConcurrent = config('game.bar.level_max_concurrent', []);
+        $maxConcurrent = $levelMaxConcurrent[$barLevel] ?? 2;
+```
+
+with:
+
+```php
+        $levelMaxConcurrent = config('game.bar.level_max_concurrent', []);
+        $maxConcurrent = ($levelMaxConcurrent[$barLevel] ?? 2) + $this->tradeConcurrentSlotBonus($colonyId);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `php bin/phpunit tests/Feature/Colony/BarServiceTest.php` (or the actual located file)
+Expected: PASS — including pre-existing tests (trade Lv0 → bonus 0, unchanged behavior).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/BarService.php tests/Feature/Colony/BarServiceTest.php
+git commit -m "feat: trade knowledge increases concurrent Cantina offer slots"
+```
+
+---
+
+### Task 5: Full verification, GDD nachtrag, CHANGELOG
+
+**Files:**
+- Modify: `docs/GDD.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `php artisan test`
+Expected: all green, no regressions vs. the pre-task baseline (988 passed as of 2026-08-15 — exact count may drift from other same-day work landing in parallel; the check is zero new failures).
+
+- [ ] **Step 2: Add a GDD nachtrag**
+
+In `docs/GDD.md`, under §13.3 "Boni: additiv, nie multiplikativ", add directly after the existing "Bonusquellen (Vorschlag, siehe 13.6)" table:
+
+```markdown
+> **Nachtrag 2026-08-15 (Owner-Entscheidung, PlaytestBot-Befund):** Umgesetzt für
+> `construction`/`cartography`/`trade` — glockenförmig statt linear (Σ15% je Kenntnis
+> bei Lv5, Peak Lv2–4), wirkt additiv auf **alle** Gebäude-Levelups (inkl.
+> CommandCenter), nicht nach Projekttyp getrennt, da im aktuellen Spiel nur
+> Bau-Projekte existieren (Navigation/Wirtschaft haben keine passende Projekt-
+> Kategorie). Berater-Rang- und Koloniereife-Bonusquellen aus der Tabelle oben sind
+> weiterhin nicht implementiert. Siehe `app/Services/ProjectBonusService.php`,
+> `docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md`.
+```
+
+Under §13.5 "Regolith-Beschaffung: alle drei Pfade müssen gleichwertig liefern", directly after the existing Pfad-A/B/C-Tabelle, add:
+
+```markdown
+> **Nachtrag 2026-08-15:** `agronomy`-Organika-Parität zu `geology` umgesetzt
+> (`config('game.agronomy_agrardom_bonus_per_level')`, Σ7 Or/Sol bei Lv5, glockenförmig
+> — bewusst NICHT front-loaded wie `geology`, da neu ohne Kalibrierungshistorie). Der
+> Cantina-Pfad-C-Fix (Losgrößen/Tauschrichtung) ist weiterhin offen; `trade`s neuer
+> Kenntniseffekt (zusätzliche Angebotsslots, `BarService::tradeConcurrentSlotBonus()`)
+> läuft parallel dazu, ohne ihn zu ersetzen.
+```
+
+- [ ] **Step 3: CHANGELOG entry**
+
+In `CHANGELOG.md`, under today's `## 2026-08-15` section (top of file):
+
+```markdown
+- Feature: 4 der 7 Kenntnisse bekommen aktive Effekte (`construction`/`cartography`/`trade` → additiver Bau-AP-Rabatt, `agronomy` → Organika-Bonus, `trade` → Cantina-Angebotsslots) — alle glockenförmig über 5 Level statt linear. Siehe `docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md`. `defense` + GDD §9 Begegnungen folgen als separater Plan.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/GDD.md CHANGELOG.md
+git commit -m "docs: GDD §13.3/§13.5 nachtrag + CHANGELOG for knowledge-effects Plan 1"
+```
+
+---
+
+## Post-plan follow-ups (explicitly out of scope here, tracked elsewhere)
+
+- `defense` Encounter-Risikominderung + komplette GDD §9-Implementierung (Sturm/Geologische Instabilität/Seuche, Trust-Events `encounter_lost`/`colony_threatened`, `securityHub.event_mitigation_pct`-Anwendung) — eigener Folgeplan (Owner-Entscheidung 2026-08-15, Plan-Split).
+- Berater-Rang- und Koloniereife-Bonusquellen für den Bau-AP-Rabatt (GDD §13.3-Tabelle, Zeilen "Domänen-Berater"/"Koloniereife") — nicht Teil dieses Plans.
+- Cantina-Pfad-C-Fix (Losgrößen an Bestand koppeln, Tauschrichtung nach Bestand statt Zufall, GDD §13.5) — separate Baustelle, nur lose mit `trade`s Slot-Bonus verwandt.
+- Freischaltbare Spezialoptionen in Dialogen (z. B. bessere Handelskonditionen bei hohem `trade`-Level) — vorgemerkte Erweiterung, kein Teil dieses Plans.

--- a/docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md
+++ b/docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md
@@ -1,0 +1,112 @@
+# Kenntnis-Effekte + Begegnungen & Gefahren — Design
+
+**Status:** Entwurf, wartet auf Owner-Review.
+**Kontext:** Ausgelöst durch PlaytestBot-Balance-Analyse (siehe CHANGELOG 2026-08-14/15): CC erreicht Level 4 typischerweise erst bei Sol 65–91 von ~95 Gesamtlaufzeit — der Flaschenhals ist Timing, nicht Einzelpreise. `docs/GDD.md` §13.5 fordert bereits Paritäts-Hebel für alle drei Ressourcen-Pfade (Analytik/Hangar/Cantina); dieser Review deckt zusätzlich auf, dass 6 von 7 Kenntnissen komplett wirkungslos sind (nur `geology` hat einen aktiven Effekt) und dass GDD §9 "Begegnungen & Gefahren" spezifiziert, aber nie implementiert wurde.
+
+## Ziel
+
+Jede der 7 Kenntnisse bekommt einen thematisch passenden, spielrelevanten Effekt. Damit werden zwei Dinge gleichzeitig erreicht: (1) die Analytik-Labor-Investition lohnt sich über alle Domänen hinweg, nicht nur für `geology`, und (2) mehr Regolith/AP wird früher im Run verfügbar, was CC-Progression beschleunigen soll — ohne den AP-Pool selbst großzügiger zu machen (der ist bewusst knapp, siehe Owner-Entscheidung).
+
+## Bereits vorhandener Ist-Stand (Korrektur zum ersten oberflächlichen Review)
+
+- **`geology` hat bereits einen aktiven, verdrahteten Regolith-Bonus.** `config/game.php:145` → `geology_harvester_bonus_per_level => [1=>3, 2=>3, 3=>2, 4=>2, 5=>2]` (kumulativ 3/6/8/10/12 Rg/Sol), angewendet in `GameTick::harvesterYield()`/`generateHarvesterYield()`, liest den echten Kenntnis-Level aus `colony_researches`. **Bleibt unverändert** — die Kurve ist front-loaded (größter Zuwachs früh), das ist hier bewusst richtig (siehe Kurvenform unten) und nicht Teil dieser Spec.
+- **`config/knowledge.php` hat keinen Effekt-Mechanismus** — nur `levelup_costs`, `credits`, `trust_per_lv`, alle bis auf `trust_per_lv` identisch für alle 7 Kenntnisse.
+- **`health` (+2 Trust/Lv), `agronomy` (+1 Trust/Lv), `defense` (−1 Trust/Lv)** sind die einzigen weiteren aktiven Effekte, alle über `trust_per_lv`.
+- **GDD §9 "Begegnungen & Gefahren" ist spezifiziert, aber nicht implementiert.** Trust-Event-Keys `encounter_lost` und `colony_threatened` existieren nirgends im Code (nur `encounter_won` ist definiert). Kein Zufallsgenerator für Sturm/Geologische Instabilität/Seuche.
+- **GDD §13.3 "Boni: additiv, nie multiplikativ"** beschreibt ein Domänen-Bonus-System (Berater-Rang + Kenntnis-Level + Koloniereife senken additiv die AP-Kosten von Bau-/Navigations-/Wirtschafts-Projekten), linear vorgeschlagen (+3 %/Level), **existiert im Code nicht**.
+
+## Global Constraints
+
+- Effekt-Kurven pro Kenntnis sind **glockenförmig** über 5 Level: kleiner Zuwachs bei Lv1 und Lv5, größter Zuwachs in der Mitte (Lv2–4). Ausnahme: `geology` (bereits bestehend, front-loaded, nicht anfassen).
+- Alle Kostenreduktionen (Domänen-Bonus) bleiben **additiv, nie multiplikativ** (§13.3, unverändert gültig) und respektieren `project_min_cost_factor = 0.5` als Untergrenze, falls dieser Config-Wert existiert — sonst mit anlegen.
+- Keine neue AP-Domänen-Trennung — der Bonus wirkt auf **Projektkosten** (Bau-/Navigations-/Wirtschafts-Projekte), nicht auf einen separaten AP-Pool. Der einheitliche Pool (§13.1) bleibt unangetastet.
+- `health` bekommt **keinen** zweiten Effekt — bleibt reiner Trust-Pfad. Bewusste Design-Entscheidung, keine Lücke.
+- Kein Kampfsystem, keine Stärkewerte (§9 explizit) — Begegnungen wirken direkt auf `status_points` und Trust, nicht auf eine Gegner-Stärke.
+- PHP-Code/Kommentare Englisch, Config-Keys Englisch, `lang/de/*.php`-Werte Deutsch (CLAUDE.md-Standard).
+- TDD-Pflicht für jeden neuen Effekt (Service-Test pro Effekt-Typ, der den Bonus bei einem bestimmten Level verifiziert).
+
+---
+
+## 1. Generische Effekt-Kurven-Struktur
+
+Neues Config-Muster in `config/knowledge.php`, pro Kenntnis optional:
+
+```php
+'construction' => [
+    // ... bestehende Felder unverändert ...
+    'effect_type' => 'ap_cost_reduction',
+    'domain' => 'construction',           // welche Projekt-Kategorie profitiert
+    'effect_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // % additiv, Σ15, glockenförmig
+],
+```
+
+Folgt dem bereits etablierten Delta-Array-Muster (`supply.knowledge_cap_per_level` in `config/game.php`, `colony_zone_expansion`) — kein neuer Formalismus. Kumulierter Effekt bei Level L = Summe der Einträge 1..L (analog `GameTick::cumulativeCurveYield()`, wiederverwendbar).
+
+`effect_type` ist ein geschlossenes Set: `ap_cost_reduction`, `agrardom_yield`, `bar_offer_boost`, `encounter_risk_reduction`, `none` (für `health`/`geology`, die ihren eigenen bestehenden Mechanismus behalten bzw. keinen neuen brauchen).
+
+---
+
+## 2. Domänen-AP-Kostenreduktion (`construction`, `cartography`, `trade`)
+
+**Neuer zentraler Baustein**, da bisher nicht im Code: eine Stelle, die für ein gegebenes Projekt (Gebäude-Levelup ODER Kenntnis-Levelup) die Summe aus Berater-Rang-Bonus + passender Domänen-Kenntnis + Koloniereife (CC-Level) ermittelt und additiv auf `ap_for_levelup` anwendet, gedeckelt durch `project_min_cost_factor`.
+
+**Domänen-Zuordnung** (§13.3, unverändert):
+- Bau ← `construction` (wirkt auf Gebäude-Levelups, via `ColonyController::levelupRegolithFor`-Nachbarschaft — dort wird `ap_for_levelup` bereits gelesen)
+- Navigation ← `cartography` (wirkt auf Erkundungs-/Tile-Aktionen mit AP-Kosten, z.B. `ColonyTileService`)
+- Wirtschaft ← `trade` (wirkt auf handelsbezogene Projekte — aktuell gibt es keine "Wirtschafts-Projekte" mit `ap_for_levelup`; siehe Abschnitt 4 für `trade`s zweiten Effekt, der diese Lücke füllt)
+
+**Kurve pro Kenntnis:** glockenförmig, Summe 15 % bei Lv5 (Owner-Vorgabe aus §13.3-Tabelle bleibt als Zielsumme gültig, nur die Verteilung ändert sich von linear auf Glocke). Beispiel `construction`: `[2, 4, 4, 3, 2]`.
+
+**Owner-Notiz für später (nicht Teil dieser Implementierung):** Freischaltbare Spezialoptionen in Dialogen (z. B. bessere Handelskonditionen bei hohem `trade`) sind eine vorgemerkte Erweiterung für einen Folge-Pass, kein Teil dieser Spec.
+
+---
+
+## 3. `agronomy` — Agrardom-Organika-Bonus (Parität zu `geology`)
+
+Spiegelt `geology_harvester_bonus_per_level` 1:1, eigene Ressource: neuer Config-Key `agronomy_agrardom_bonus_per_level` in `config/game.php`, gleiche Glockenform-Zielgröße (~6–7 Or/Sol kumuliert bei Lv4/5) statt front-loaded — **abweichend von `geology`**, weil dieser Effekt neu eingeführt wird und keine bestehende Kalibrierung/Playtest-Historie hat, die eine front-loaded Kurve rechtfertigen würde. Integration analog `generateHarvesterYield()`: `generateResources()`-Loop in `GameTick.php` liest `agronomy`-Level aus `colony_researches`, addiert den Bonus auf den bioFacility-Output (`production_curve[41]`).
+
+`agronomy` behält zusätzlich `trust_per_lv = 1` unverändert (Nahrungssicherheit als vertrauensbildend, bestehende Design-Entscheidung).
+
+---
+
+## 4. `trade` — Cantina-Angebotsfrequenz/Losgröße
+
+Zweiter Effekt neben dem Domänen-AP-Bonus (Abschnitt 2), um die thematische Nähe zu Cantina zu stiften, ohne mit `advisor_trader` (+15 % Handelsgewinn, Berater-Bonus) zu kollidieren. `trade` verbessert **nicht** den Gewinn pro Angebot, sondern **Verlässlichkeit**: erhöht `guestCount` (Angebotsfrequenz) oder `levelMaxConcurrent` (gleichzeitige Angebote) in `BarService::generateOffersForColony()`, analog zum bereits bestehenden `trader_discount`-Muster (`config("game.bar.trader_discount.{$traderRank}")`).
+
+**Läuft parallel zum separat geplanten Cantina-Pfad-C-Fix** (§13.5: Losgröße an Zahlungsfähigkeit koppeln, Tauschrichtung nach Bestand statt Zufall) — beide Baustellen zusammen spezifizieren, um nicht zweimal an denselben Zahlen zu drehen. Der Pfad-C-Fix ändert *welche* Angebote generiert werden (Richtung/Größe); der `trade`-Kenntniseffekt ändert *wie oft* (Frequenz/Slots). Getrennte Config-Hebel, keine Formel-Überschneidung.
+
+Kurve glockenförmig, Peak Lv2–3, Zielgröße grob +1 zusätzlicher Slot oder +20–30 % Frequenz bei Lv4.
+
+---
+
+## 5. GDD §9 "Begegnungen & Gefahren" — Implementierung
+
+Bisher nur Design, kein Code. Wird jetzt gebaut, weil `defense`s einziger sinnvoller Effekt (Risikominderung bei Zwischenfällen) sonst an einem nicht existierenden System hinge.
+
+**Kernmechanik** (aus §9, unverändert übernommen):
+- Kein Kampfsystem, keine Gegner-Stärke — jedes Ereignis wirkt direkt auf `status_points` eines betroffenen Gebäudes + Trust.
+- Ausgangsstufen nach SP-Anteil zum Ereigniszeitpunkt: ≥66 % Abgewehrt (`encounter_won`, +2 Trust, minimal SP-Verlust), 33–65 % Beschädigt (`encounter_lost`, −4 Trust, SP-Verlust ~20 % von `max_status_points`), <33 % Kritisch (`colony_threatened`, −5 Trust, SP-Verlust + ggf. Level-Down).
+- Drei Gefahrentypen: **Sturm** (zufällig, 1 Gebäude der Colony Zone), **Geologische Instabilität** (gekoppelt an Harvester-Tile, Chance steigt mit Solen seit Relocation, **sinkt mit `geology`**), **Seuchenausbruch** (emergent, nur bei `hunger_streak ≥ 3` oder Trust < −20).
+- `securityHub.event_mitigation_pct` (bereits in Config vorhanden, `0.25`) dämpft alle drei Ausgänge um 25 % — **muss jetzt tatsächlich angewendet werden** (aktuell nur Kommentar, keine Anwendung im Code).
+- Vorwarnung 1 Sol vorher als `colony_log`-Eintrag, Ausgang beim Sol-Wechsel protokolliert.
+
+**Neuer Bestandteil dieser Spec — `defense`s Rolle:**
+`defense` senkt die **Trigger-Chance** von Sturm-Ereignissen (die einzige der drei Gefahrenarten ohne bereits zugewiesene Kenntnis-Abschwächung — Geologische Instabilität hat schon `geology`, Seuche hat `infirmary` als Gebäude-Hebel). Glockenkurve, Zielgröße ~15–20 % Risikoreduktion kumuliert bei Lv4, rechtfertigt den bestehenden Trust-Malus (`trust_per_lv = −1`) narrativ: "Wachsamkeit kostet Vertrauen der Kolonisten, schützt sie aber faktisch."
+
+**Trust-Event-Werte** `encounter_lost` (−4) und `colony_threatened` (−5) müssen neu in `config('game.trust.events')` angelegt werden (bisher fehlen sie komplett, nur in Kommentaren referenziert).
+
+**Kalibrierungs-Hinweis aus dem GDD (übernommen):** Basis-Chancen/Sol und SP-Verlust-Prozentsätze sind Richtwerte, Kalibrierung nach PlaytestBot-Läufen. Cooldown zwischen Ereignissen prüfen, falls Playtest eine Spiral-Häufung von `colony_threatened` zeigt (GDD-eigene Warnung).
+
+---
+
+## 6. `health` — keine Änderung
+
+Bleibt bei `trust_per_lv = 2`, kein zusätzlicher Effekt. Begründung (aus dem Brainstorming): ein zweiter mechanischer Bonus würde die Domänentrennung zwischen den Kenntnissen verwässern (z. B. Decay-Reduktion würde in `construction`s Domäne eingreifen). Der reine Trust-Pfad ist bereits das stärkste Alleinstellungsmerkmal unter den 7 Kenntnissen.
+
+---
+
+## Offene Kalibrierungsfragen (nach erstem Playtest zu klären, nicht vor Implementierung)
+
+- Exakte Glockenkurven-Werte pro Kenntnis (hier nur Beispiele/Zielsummen genannt) — endgültige Zahlen entstehen im Implementierungsplan, analog zum bestehenden Muster "Zahlenvorschlag, erste Fassung" (§13.6).
+- `defense`-Risikoreduktion vs. `securityHub.event_mitigation_pct` — beide wirken auf denselben Sturm-Ausgang; Reihenfolge/Stapelung (additiv oder auf Chance vs. auf Schaden wirkend) im Implementierungsplan konkretisieren.
+- Ob ein Cooldown zwischen Kolonistengefahren-Ereignissen nötig ist (GDD-eigene, offene Balance-Warnung aus §9).

--- a/tests/Feature/Bar/BarServiceTest.php
+++ b/tests/Feature/Bar/BarServiceTest.php
@@ -1143,4 +1143,69 @@ class BarServiceTest extends TestCase
 
         $this->assertLessThanOrEqual(2, $count, 'max_concurrent=2 at bar Lv1 must not be exceeded');
     }
+
+    public function test_trade_knowledge_increases_concurrent_offer_slots(): void
+    {
+        // trade (research_id=95) Lv3 → cumulative [0,1,1] = 2 extra slots
+        // (config/knowledge.php → trade.bar_offer_boost_per_lv).
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $this->setBarLevel(1);
+        $baseMax = config('game.bar.level_max_concurrent')[1] ?? 2;
+
+        // Rank 3 trader guarantees guest_count in [1,2] (config/game.php → bar.guest_count.3)
+        // — deterministic, no need to brute-force a lucky tick/seed.
+        $this->assignTrader(3);
+
+        // Pre-fill exactly baseMax active offers, so the *unboosted* concurrent cap is
+        // already exhausted (maxConcurrent - activeCount = 0 → no new offer possible
+        // without the bonus). This makes the assertion load-bearing instead of a weak
+        // upper bound: with the trade bonus, 2 extra slots open up and — since guest_count
+        // is guaranteed >=1 at rank 3 — at least one new offer MUST be created.
+        $this->clearBarOffers();
+        for ($i = 0; $i < $baseMax; $i++) {
+            $this->insertOffer(['expires_tick' => 20]);
+        }
+
+        $tick = 5;
+        $this->barService->generateOffersForColony(self::COLONY_ID, $tick);
+
+        $activeCount = DB::table('bar_offers')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('expires_tick', '>', $tick)
+            ->where('is_accepted', false)
+            ->count();
+
+        $this->assertGreaterThan($baseMax, $activeCount, 'trade Lv3 must open extra concurrent Cantina offer slots beyond the base cap');
+        $this->assertLessThanOrEqual($baseMax + 2, $activeCount, 'The bonus must not exceed the configured Σ2 extra slots for trade Lv3');
+    }
+
+    public function test_trade_knowledge_level_zero_does_not_change_concurrent_offer_slots(): void
+    {
+        // Lv0 (no colony_researches row / default) must be a strict no-op — same
+        // exhausted-cap setup as above, but without leveling trade: no new offer
+        // may appear since the unboosted cap is already full.
+        $this->setBarLevel(1);
+        $baseMax = config('game.bar.level_max_concurrent')[1] ?? 2;
+        $this->assignTrader(3);
+
+        $this->clearBarOffers();
+        for ($i = 0; $i < $baseMax; $i++) {
+            $this->insertOffer(['expires_tick' => 20]);
+        }
+
+        $tick = 5;
+        $this->barService->generateOffersForColony(self::COLONY_ID, $tick);
+
+        $activeCount = DB::table('bar_offers')
+            ->where('colony_id', self::COLONY_ID)
+            ->where('expires_tick', '>', $tick)
+            ->where('is_accepted', false)
+            ->count();
+
+        $this->assertEquals($baseMax, $activeCount, 'trade Lv0 must leave the concurrent offer cap unchanged');
+    }
 }

--- a/tests/Feature/Colony/BuildResourceSinkTest.php
+++ b/tests/Feature/Colony/BuildResourceSinkTest.php
@@ -160,6 +160,20 @@ class BuildResourceSinkTest extends TestCase
         $this->assertSame($before - 60, $this->colonyRes(self::RES_REGOLITH));
     }
 
+    public function test_construction_knowledge_reduces_ap_needed_for_levelup(): void
+    {
+        // construction Lv5 (research_id=90) = 15% discount → CC's ap_for_levelup
+        // (10) drops to round(10 * 0.85) = 9. One less invest click needed to level up.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 90],
+            ['level' => 5, 'ap_spend' => 0, 'status_points' => 20]
+        );
+        $this->setCc(['level' => 1, 'ap_spend' => 8, 'status_points' => 16]);   // 1 AP from the discounted threshold (9)
+
+        $this->actingAs($this->bart())->postJson(route('colony.building.invest'), ['building_id' => 25])
+            ->assertOk()->assertJsonPath('leveled_up', true);
+    }
+
     public function test_non_cc_levelup_deducts_flat_regolith_regardless_of_build_cost(): void
     {
         // Sciencelab build_cost[3]=95 (25% would be 24) — GDD §13.7 flat 25 applies

--- a/tests/Feature/GameTick/GameTickResourceGenerationTest.php
+++ b/tests/Feature/GameTick/GameTickResourceGenerationTest.php
@@ -309,4 +309,33 @@ class GameTickResourceGenerationTest extends TestCase
         $this->assertEquals(13, $regolith,
             'Production at trust=-80 must apply 0.70× penalty → 13 Regolith');
     }
+
+    // ── agronomy Kenntnis bonus ──────────────────────────────────────────────
+
+    /**
+     * agronomy Kenntnis adds a flat, colony-level Organika bonus on top of
+     * bioFacility's own level-based production — mirrors geology's Harvester
+     * bonus pattern (GDD §13.5 Paritäts-Anforderung).
+     */
+    public function test_agronomy_knowledge_adds_organika_bonus_on_top_of_biofacility_output(): void
+    {
+        // bioFacility Lv1 alone yields 8 Organika/Sol (production_curve[41][5][1]).
+        $this->setBuildingLevel(self::BIO_FACILITY_ID, 1);
+        DB::table('colony_resources')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'resource_id' => self::RES_ORGANICS],
+            ['amount' => 0]
+        );
+        // agronomy (research_id=93) Lv3 → cumulative [1,2,2] = 5 bonus Organika/Sol.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 93],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        Artisan::call('game:tick', ['--tick' => 11222]);
+
+        $organics = $this->getColonyResource(self::RES_ORGANICS);
+        // 8 (base) + 5 (agronomy bonus) = 13, at trust multiplier 1.0 (neutral, fixed in setUp).
+        $this->assertEquals(13, $organics,
+            'bioFacility Lv1 (8 Organika) + agronomy Lv3 bonus (5 Organika) must total 13 Organika');
+    }
 }

--- a/tests/Unit/ProjectBonusServiceTest.php
+++ b/tests/Unit/ProjectBonusServiceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ProjectBonusService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ProjectBonusServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+    }
+
+    private function setKnowledgeLevel(int $researchId, int $level): void
+    {
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => $researchId],
+            ['level' => $level, 'ap_spend' => 0, 'status_points' => 20]
+        );
+    }
+
+    public function test_discount_is_zero_with_no_knowledge_invested(): void
+    {
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(0, $service->buildingApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_discount_sums_all_three_domains_additively(): void
+    {
+        // construction id=90, cartography id=91, trade id=95 (config/knowledge.php)
+        $this->setKnowledgeLevel(90, 3);   // cumulative [2,4,4] = 10
+        $this->setKnowledgeLevel(91, 1);   // cumulative [2] = 2
+        $this->setKnowledgeLevel(95, 5);   // cumulative [2,4,4,3,2] = 15
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(27, $service->buildingApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_effective_ap_for_levelup_applies_discount(): void
+    {
+        $this->setKnowledgeLevel(90, 5);   // construction Lv5 = 15%
+        $service = $this->app->make(ProjectBonusService::class);
+
+        // 10 * (1 - 0.15) = 8.5 → round to 9 (round-half-up)
+        $this->assertSame(9, $service->effectiveApForLevelup(self::COLONY_ID, 10));
+    }
+
+    /**
+     * With current config, max additive discount is 45% (15% × 3 domains) — always
+     * below the 50% floor, so it never binds via real knowledge levels (by design,
+     * see spec §Global Constraints: the floor is a guard rail for future bonus
+     * sources, not active yet). Test the floor logic directly via the pure helper
+     * instead of trying to manufacture a >50% discount through the DB.
+     */
+    public function test_apply_discount_never_drops_below_min_cost_factor(): void
+    {
+        // 80% discount would give round(10 * 0.2) = 2, but the 0.5 floor caps it at 5.
+        $this->assertSame(5, ProjectBonusService::applyDiscount(10, 80, 0.5));
+    }
+
+    public function test_apply_discount_rounds_half_up_below_the_floor(): void
+    {
+        // 15% discount on base 10: round(10 * 0.85) = round(8.5) = 9, floor = ceil(5) = 5.
+        $this->assertSame(9, ProjectBonusService::applyDiscount(10, 15, 0.5));
+    }
+}


### PR DESCRIPTION
## Summary
- Neuer `ProjectBonusService`: additiver Bau-AP-Rabatt aus `construction`+`cartography`+`trade`-Kenntnissen, glockenförmig über 5 Level (Σ15% je Kenntnis), Floor bei 50% (`project_min_cost_factor`). Wirkt auf alle Gebäude-Levelups inkl. CommandCenter.
- `agronomy`: neuer Organika-Produktionsbonus auf bioFacility (Parität zu `geology`s bestehendem Regolith-Bonus), Σ7 Or/Sol bei Lv5, glockenförmig — bewusst nicht front-loaded wie geology.
- `trade`: zweiter Effekt (zusätzlich zum AP-Rabatt) — mehr gleichzeitige Cantina-Angebotsslots.
- `geology` (bereits aktiv) und `health` (bewusst ohne Zusatzeffekt) unangetastet.
- `defense` + GDD §9 „Begegnungen & Gefahren" bewusst nicht Teil dieses PRs — separater Folgeplan (Owner-Entscheidung, Plan-Split).

Spec: `docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md`
Plan + SDD-Ledger: `docs/superpowers/plans/2026-08-15-knowledge-effects-and-encounters.md`

**Nebenbefund im finalen Review:** Der Bau-AP-Rabatt war nach Task 2 nur im Level-up-Gate + initialem Hexview-Render korrekt sichtbar, aber in 3 weiteren AJAX-Emittern (`fetchBuildingRow`, Invest-Event-Log, Baukatalog) noch mit dem unrabattierten Wert — im Fix-Pass behoben, damit UI nach jeder Aktion konsistent den echten Schwellenwert zeigt.

## Test plan
- [x] `php artisan test` — 996 passed, 0 failed
- [x] Alle 5 Tasks einzeln reviewed (spec + quality); Task 3 brauchte 1 Fix-Runde (Kommentare Deutsch→Englisch)
- [x] Finales Whole-Branch-Review (1 Important + 2 Minor Findings) + Fix-Pass + Scoped-Re-Review — alle resolved
- [x] Level-0-No-Op für alle 4 neuen Effekte einzeln verifiziert (kein Verhaltensunterschied ohne investierte Kenntnis)

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9