### PR TITLE
Tool: PlaytestBot-Visualisierungs-Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-16
 
+- Tool: `tools/playtest-dashboard.php` — Browser-Dashboard für PlaytestBot-Läufe (Chart.js-Graphen über Sol, Mehrfachvergleich, Summary-Tabelle), liest bestehende `storage/logs/playtest/*.json`-Reports, teilt sich `dev-panel.css` mit dem Dev Panel.
 - Feature: GDD §9 „Begegnungen & Gefahren" implementiert (Sturm/Geologische Instabilität/Seuchenausbruch) — bisher nur spezifiziert, nie codiert. `defense`-Kenntnis bekommt ihren ersten aktiven Effekt (Sturm-Risikominderung), `geology` einen zweiten (Instabilitäts-Risikominderung, zusätzlich zum Regolith-Bonus). Siehe `docs/superpowers/plans/2026-08-16-encounters-and-defense.md`.
 - Fix (Whole-Branch-Review-Nachzügler zu §9 Begegnungen): Komm-Log zeigte rohe Event-Keys statt Beschreibungen; Onboarding-Hint für Begegnungen erreichte den Spieler nie; Geologische Instabilität blockierte fälschlich die Harvester-Verlegung (eigenes Feld `instability_outage_until_tick` statt Wiederverwendung von `pending_until_tick`, neue Migration); AP-Popup rechnete sich während Seuchenausbruch nicht zusammen (`plague_multiplier` ergänzt); alle drei Gefahrentypen konnten trotz Cooldown am selben Sol gleichzeitig triggern (Mutual-Exclusion pro Kolonie/Tick ergänzt). Details siehe `.superpowers/sdd/2026-08-16-encounters-and-defense/final-fix-report.md`.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -553,6 +553,7 @@ Lokale Admin-Tools für den Entwickler — kein Spieler-Feature, kein Laravel-St
 - [x] **Debug-Statusleiste** — Fixed Bottom-Bar, nur für `role=admin` sichtbar. Kompakte Zeile: Run-ID, Sol/Tick-Limit, Bypass-Flags (farbkodiert), App-Env. „Config ▾"-Toggle öffnet Detailpanel mit Run-, Tick-, Supply-, Credits-, Fleet-AP- und Moral-Event-Werten aus `config/game.php`. Alpine.js x-show, kein Bootstrap.
 - [ ] **Berechnungs-Toggle** — Artisan-Kommando oder .env-Flag zum An-/Abschalten einzelner Berechnungen für Testzwecke: Ressourcenberechnung, AP-Berechnung, Decay, Moral-Multiplikator. Erlaubt isoliertes Testen einzelner Systeme ohne Interferenz.
 - [x] **Tick-Simulator** (`game:tick-dry-run`) — Simuliert einen Tick und zeigt Credits-, Ressourcen- und Decay-Diff ohne DB-Schreibzugriff. `--colony=ID` filtert auf eine Kolonie. Ideal für Balancing-Checks.
+- [x] **Playtest Dashboard** (`tools/playtest-dashboard.php`, 2026-08-16) — Browser-Viewer für `storage/logs/playtest/*.json`-Reports (von `game:playtest`/`PlaytestBotTest` erzeugt, keine neue Datenerhebung). Sidebar mit allen Läufen, Mehrfachauswahl, Chart.js-Liniendiagramme (Regolith/Credits/AP/Vertrauen/CC-Level über Sol) + Summary-Tabelle (Outcome, Objectives, Rejections). Teilt sich `tools/assets/dev-panel.css` mit Dev Panel (eigene `PLAYTEST DASHBOARD`-Sektion). Start: `php -S localhost:8082 tools/playtest-dashboard.php`
 
 ---
 

--- a/tools/assets/dev-panel.css
+++ b/tools/assets/dev-panel.css
@@ -1,73 +1,208 @@
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: system-ui, monospace, sans-serif; font-size: 13px; background: #111827; color: #e0e0e0; min-height: 100vh; }
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+body {
+    font-family: system-ui, monospace, sans-serif;
+    font-size: 13px;
+    background: #111827;
+    color: #e0e0e0;
+    min-height: 100vh;
+}
 
 /* ── Header ───────────────────────────────────────────────────────────────── */
 .panel-header {
-    background: #0d1117; border-bottom: 1px solid #2a2a3e;
-    padding: .6rem 1.2rem; display: flex; align-items: center; gap: 1.5rem;
+    background: #0d1117;
+    border-bottom: 1px solid #2a2a3e;
+    padding: 0.6rem 1.2rem;
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
 }
-.panel-header h1 { font-size: 1rem; font-weight: 700; color: #7fbbff; letter-spacing: .02em; }
-.panel-header .hint { font-size: .78rem; color: #555; }
+.panel-header h1 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #7fbbff;
+    letter-spacing: 0.02em;
+}
+.panel-header .hint {
+    font-size: 0.78rem;
+    color: #555;
+}
 
 /* ── Tool tabs ────────────────────────────────────────────────────────────── */
-.tool-tabs { display: flex; gap: 2px; padding: .5rem 1.2rem; background: #0d1117; border-bottom: 1px solid #1e2030; }
-.tool-tab {
-    padding: .35rem 1.1rem; border-radius: 4px 4px 0 0; cursor: pointer;
-    border: 1px solid transparent; font-size: .82rem; font-weight: 500;
-    color: #888; background: transparent; text-decoration: none; display: inline-block;
-    transition: color .15s, background .15s;
+.tool-tabs {
+    display: flex;
+    gap: 2px;
+    padding: 0.5rem 1.2rem;
+    background: #0d1117;
+    border-bottom: 1px solid #1e2030;
 }
-.tool-tab:hover { color: #bbb; background: #1a1a2e; }
-.tool-tab.active { background: #1a1a2e; color: #7fbbff; border-color: #2a2a4e; border-bottom-color: #1a1a2e; }
+.tool-tab {
+    padding: 0.35rem 1.1rem;
+    border-radius: 4px 4px 0 0;
+    cursor: pointer;
+    border: 1px solid transparent;
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: #888;
+    background: transparent;
+    text-decoration: none;
+    display: inline-block;
+    transition:
+        color 0.15s,
+        background 0.15s;
+}
+.tool-tab:hover {
+    color: #bbb;
+    background: #1a1a2e;
+}
+.tool-tab.active {
+    background: #1a1a2e;
+    color: #7fbbff;
+    border-color: #2a2a4e;
+    border-bottom-color: #1a1a2e;
+}
 
 /* ── Content wrapper ──────────────────────────────────────────────────────── */
-.tab-content { display: none; }
-.tab-content.active { display: block; }
+.tab-content {
+    display: none;
+}
+.tab-content.active {
+    display: block;
+}
 
 /* ═══════════════════════════════════════════════════════════════════════════
    RESOURCES TAB
    ═══════════════════════════════════════════════════════════════════════════ */
-.res-section { padding: 1.2rem; }
-.res-section h2 { color: #aaa; font-size: .9rem; margin: 1.2rem 0 .6rem; border-bottom: 1px solid #252535; padding-bottom: .3rem; }
-.res-section h2:first-child { margin-top: 0; }
-
-.msg { background: #1e4a1e; border: 1px solid #2e6b2e; color: #7fff7f; padding: 8px 12px; border-radius: 4px; margin-bottom: 12px; }
-
-table.res-table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; }
-table.res-table th { background: #1a1a2e; color: #7fbbff; text-align: left; padding: 5px 10px; font-size: .78rem; }
-table.res-table td { padding: 5px 10px; border-top: 1px solid #1e1e30; vertical-align: middle; }
-table.res-table tr:hover td { background: #161625; }
-
-.user-label { font-weight: 600; color: #e0e0e0; }
-.id-label    { font-size: .72rem; color: #555; }
-
-input[type=number] {
-    background: #0d0d1a; color: #fff; border: 1px solid #333; padding: 3px 6px;
-    width: 100px; border-radius: 3px; font-family: monospace; font-size: .82rem;
+.res-section {
+    padding: 1.2rem;
 }
-input[type=number]:focus { border-color: #7fbbff; outline: none; }
+.res-section h2 {
+    color: #aaa;
+    font-size: 0.9rem;
+    margin: 1.2rem 0 0.6rem;
+    border-bottom: 1px solid #252535;
+    padding-bottom: 0.3rem;
+}
+.res-section h2:first-child {
+    margin-top: 0;
+}
+
+.msg {
+    background: #1e4a1e;
+    border: 1px solid #2e6b2e;
+    color: #7fff7f;
+    padding: 8px 12px;
+    border-radius: 4px;
+    margin-bottom: 12px;
+}
+
+table.res-table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-bottom: 1rem;
+}
+table.res-table th {
+    background: #1a1a2e;
+    color: #7fbbff;
+    text-align: left;
+    padding: 5px 10px;
+    font-size: 0.78rem;
+}
+table.res-table td {
+    padding: 5px 10px;
+    border-top: 1px solid #1e1e30;
+    vertical-align: middle;
+}
+table.res-table tr:hover td {
+    background: #161625;
+}
+
+.user-label {
+    font-weight: 600;
+    color: #e0e0e0;
+}
+.id-label {
+    font-size: 0.72rem;
+    color: #555;
+}
+
+input[type="number"] {
+    background: #0d0d1a;
+    color: #fff;
+    border: 1px solid #333;
+    padding: 3px 6px;
+    width: 100px;
+    border-radius: 3px;
+    font-family: monospace;
+    font-size: 0.82rem;
+}
+input[type="number"]:focus {
+    border-color: #7fbbff;
+    outline: none;
+}
 button.set-btn {
-    background: #1e3a6e; color: #aac8ff; border: 1px solid #2a4a8e;
-    padding: 3px 10px; border-radius: 3px; cursor: pointer; font-size: .78rem;
-    transition: background .1s;
+    background: #1e3a6e;
+    color: #aac8ff;
+    border: 1px solid #2a4a8e;
+    padding: 3px 10px;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.78rem;
+    transition: background 0.1s;
 }
-button.set-btn:hover { background: #2a4a9e; }
-.field-row { display: flex; gap: 6px; align-items: center; }
+button.set-btn:hover {
+    background: #2a4a9e;
+}
+.field-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
 
 /* ═══════════════════════════════════════════════════════════════════════════
    TECHTREE TAB
    ═══════════════════════════════════════════════════════════════════════════ */
-.techtree-wrap { background: #f0f2f5; color: #1a1a2e; padding-bottom: 2.5rem; }
-
-.phase-tabs { display: flex; gap: .25rem; padding: .5rem 1rem; background: #fff; border-bottom: 1px solid #dde; }
-.phase-tab {
-    padding: .3rem .9rem; border-radius: 4px; cursor: pointer;
-    border: 1px solid #ccd; background: #f5f5f8; font-size: .8rem; font-weight: 500; color: #1a1a2e;
+.techtree-wrap {
+    background: #f0f2f5;
+    color: #1a1a2e;
+    padding-bottom: 2.5rem;
 }
-.phase-tab.tt-active { background: #1a1a2e; color: #fff; border-color: #1a1a2e; }
 
-.phase-panel { display: none; padding: 1rem; }
-.phase-panel.tt-active { display: block; }
+.phase-tabs {
+    display: flex;
+    gap: 0.25rem;
+    padding: 0.5rem 1rem;
+    background: #fff;
+    border-bottom: 1px solid #dde;
+}
+.phase-tab {
+    padding: 0.3rem 0.9rem;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid #ccd;
+    background: #f5f5f8;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #1a1a2e;
+}
+.phase-tab.tt-active {
+    background: #1a1a2e;
+    color: #fff;
+    border-color: #1a1a2e;
+}
+
+.phase-panel {
+    display: none;
+    padding: 1rem;
+}
+.phase-panel.tt-active {
+    display: block;
+}
 
 .grid {
     display: grid;
@@ -77,141 +212,480 @@ button.set-btn:hover { background: #2a4a9e; }
     max-width: 900px;
 }
 
-.col-header { display: flex; align-items: center; justify-content: center; font-size: .7rem; font-weight: 600; color: #666; text-transform: uppercase; letter-spacing: .05em; }
-.row-header { display: flex; align-items: center; justify-content: center; font-size: .7rem; color: #999; }
+.col-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.row-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    color: #999;
+}
 
-.cell { border: 2px dashed #cdd; border-radius: 6px; background: #f9fafb; min-height: 80px; position: relative; transition: background .15s, border-color .15s; }
-.cell.drag-over { background: #e8f0ff; border-color: #4a90d9; }
+.cell {
+    border: 2px dashed #cdd;
+    border-radius: 6px;
+    background: #f9fafb;
+    min-height: 80px;
+    position: relative;
+    transition:
+        background 0.15s,
+        border-color 0.15s;
+}
+.cell.drag-over {
+    background: #e8f0ff;
+    border-color: #4a90d9;
+}
 
 .entity-card {
-    position: absolute; inset: 3px; border-radius: 4px; padding: 5px 7px;
-    cursor: grab; user-select: none;
-    display: flex; flex-direction: column; gap: 2px;
-    border: 1px solid rgba(0,0,0,.1);
-    font-size: .75rem; line-height: 1.3;
+    position: absolute;
+    inset: 3px;
+    border-radius: 4px;
+    padding: 5px 7px;
+    cursor: grab;
+    user-select: none;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    font-size: 0.75rem;
+    line-height: 1.3;
 }
-.entity-card:active { cursor: grabbing; }
-.entity-card.type-building  { background: #dbeafe; border-color: #93c5fd; }
-.entity-card.type-research  { background: #dcfce7; border-color: #86efac; }
-.entity-card.type-ship      { background: #fef3c7; border-color: #fcd34d; }
-.entity-card.type-personell { background: #f3e8ff; border-color: #d8b4fe; }
+.entity-card:active {
+    cursor: grabbing;
+}
+.entity-card.type-building {
+    background: #dbeafe;
+    border-color: #93c5fd;
+}
+.entity-card.type-research {
+    background: #dcfce7;
+    border-color: #86efac;
+}
+.entity-card.type-ship {
+    background: #fef3c7;
+    border-color: #fcd34d;
+}
+.entity-card.type-personell {
+    background: #f3e8ff;
+    border-color: #d8b4fe;
+}
 
-.entity-card .type-badge   { font-size: .6rem; font-weight: 700; text-transform: uppercase; opacity: .6; letter-spacing: .05em; }
-.entity-card .entity-name  { font-weight: 600; color: #111; }
-.entity-card .entity-prereq { font-size: .65rem; color: #555; margin-top: auto; }
+.entity-card .type-badge {
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    opacity: 0.6;
+    letter-spacing: 0.05em;
+}
+.entity-card .entity-name {
+    font-weight: 600;
+    color: #111;
+}
+.entity-card .entity-prereq {
+    font-size: 0.65rem;
+    color: #555;
+    margin-top: auto;
+}
 
 .tt-legend {
-    display: flex; gap: 1rem; padding: .5rem 1rem;
-    background: #fff; border-top: 1px solid #dde; font-size: .75rem; color: #1a1a2e;
+    display: flex;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    background: #fff;
+    border-top: 1px solid #dde;
+    font-size: 0.75rem;
+    color: #1a1a2e;
 }
-.legend-item { display: flex; align-items: center; gap: .3rem; }
-.legend-swatch { width: 10px; height: 10px; border-radius: 2px; }
-.swatch-building  { background: #dbeafe; border: 1px solid #93c5fd; }
-.swatch-research  { background: #dcfce7; border: 1px solid #86efac; }
-.swatch-ship      { background: #fef3c7; border: 1px solid #fcd34d; }
-.swatch-personell { background: #f3e8ff; border: 1px solid #d8b4fe; }
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+.legend-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+}
+.swatch-building {
+    background: #dbeafe;
+    border: 1px solid #93c5fd;
+}
+.swatch-research {
+    background: #dcfce7;
+    border: 1px solid #86efac;
+}
+.swatch-ship {
+    background: #fef3c7;
+    border: 1px solid #fcd34d;
+}
+.swatch-personell {
+    background: #f3e8ff;
+    border: 1px solid #d8b4fe;
+}
 
 #status-bar {
-    position: fixed; bottom: 0; left: 0; right: 0;
-    background: #1a1a2e; color: #aad; padding: .35rem 1rem;
-    font-size: .75rem; font-family: monospace; z-index: 100;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #1a1a2e;
+    color: #aad;
+    padding: 0.35rem 1rem;
+    font-size: 0.75rem;
+    font-family: monospace;
+    z-index: 100;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
    CANTINA HOTSPOTS TAB
    ═══════════════════════════════════════════════════════════════════════════ */
-.cantina-editor { padding: 1rem 1.2rem; }
+.cantina-editor {
+    padding: 1rem 1.2rem;
+}
 
 .hs-toolbar {
-    display: flex; flex-wrap: wrap; gap: .75rem; align-items: center;
-    margin-bottom: .75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    margin-bottom: 0.75rem;
 }
-.hs-toolbar-group { display: flex; gap: 4px; }
-.hs-toolbar-label { font-size: .75rem; color: #666; align-self: center; margin-right: 2px; }
+.hs-toolbar-group {
+    display: flex;
+    gap: 4px;
+}
+.hs-toolbar-label {
+    font-size: 0.75rem;
+    color: #666;
+    align-self: center;
+    margin-right: 2px;
+}
 
 .hs-btn {
-    padding: .28rem .85rem; border-radius: 4px; cursor: pointer;
-    border: 1px solid #333; background: #1a1a2e; color: #888;
-    font-size: .8rem; font-weight: 500; transition: background .12s, color .12s;
+    padding: 0.28rem 0.85rem;
+    border-radius: 4px;
+    cursor: pointer;
+    border: 1px solid #333;
+    background: #1a1a2e;
+    color: #888;
+    font-size: 0.8rem;
+    font-weight: 500;
+    transition:
+        background 0.12s,
+        color 0.12s;
 }
-.hs-btn:hover { background: #252540; color: #bbb; }
-.hs-btn.active { background: #1e3a6e; color: #7fbbff; border-color: #2a4a8e; }
-.hs-btn.slot-active { background: #3a1e1e; color: #ff9f7f; border-color: #8e3a2a; }
+.hs-btn:hover {
+    background: #252540;
+    color: #bbb;
+}
+.hs-btn.active {
+    background: #1e3a6e;
+    color: #7fbbff;
+    border-color: #2a4a8e;
+}
+.hs-btn.slot-active {
+    background: #3a1e1e;
+    color: #ff9f7f;
+    border-color: #8e3a2a;
+}
 
 .hs-canvas-wrap {
-    position: relative; display: inline-block;
-    cursor: crosshair; user-select: none;
-    border: 1px solid #333; border-radius: 4px; overflow: hidden;
+    position: relative;
+    display: inline-block;
+    cursor: crosshair;
+    user-select: none;
+    border: 1px solid #333;
+    border-radius: 4px;
+    overflow: hidden;
     max-width: 100%;
 }
-.hs-canvas-wrap img { display: block; max-width: 100%; height: auto; max-height: 65vh; }
+.hs-canvas-wrap img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    max-height: 65vh;
+}
 
 .hs-dot {
-    position: absolute; width: 20px; height: 20px;
+    position: absolute;
+    width: 20px;
+    height: 20px;
     transform: translate(-50%, -50%);
-    border-radius: 50%; border: 2px solid #fff;
-    display: flex; align-items: center; justify-content: center;
-    font-size: .6rem; font-weight: 700; color: #fff;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.6rem;
+    font-weight: 700;
+    color: #fff;
     pointer-events: none;
-    box-shadow: 0 1px 4px rgba(0,0,0,.5);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
 }
 .hs-dot-label {
-    position: absolute; top: 22px; left: 50%; transform: translateX(-50%);
-    font-size: .65rem; color: #fff; white-space: nowrap; text-shadow: 0 1px 3px #000;
+    position: absolute;
+    top: 22px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.65rem;
+    color: #fff;
+    white-space: nowrap;
+    text-shadow: 0 1px 3px #000;
     pointer-events: none;
 }
-.hs-dot[data-slot="spot_0"] { background: #1d6ef5; }
-.hs-dot[data-slot="spot_1"] { background: #c0392b; }
-.hs-dot[data-slot="spot_2"] { background: #27ae60; }
-.hs-dot[data-slot="spot_3"] { background: #e67e22; }
-.hs-dot[data-slot="spot_4"] { background: #8e44ad; }
-.hs-dot[data-slot="spot_5"] { background: #16a085; }
-.hs-dot.hs-dot--active { width: 26px; height: 26px; border-width: 3px; }
+.hs-dot[data-slot="spot_0"] {
+    background: #1d6ef5;
+}
+.hs-dot[data-slot="spot_1"] {
+    background: #c0392b;
+}
+.hs-dot[data-slot="spot_2"] {
+    background: #27ae60;
+}
+.hs-dot[data-slot="spot_3"] {
+    background: #e67e22;
+}
+.hs-dot[data-slot="spot_4"] {
+    background: #8e44ad;
+}
+.hs-dot[data-slot="spot_5"] {
+    background: #16a085;
+}
+.hs-dot.hs-dot--active {
+    width: 26px;
+    height: 26px;
+    border-width: 3px;
+}
 
 .hs-coords-bar {
-    display: flex; align-items: center; gap: 1rem; margin-top: .6rem;
-    font-family: monospace; font-size: .8rem; color: #888;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 0.6rem;
+    font-family: monospace;
+    font-size: 0.8rem;
+    color: #888;
 }
-.hs-coords-bar strong { color: #7fbbff; }
+.hs-coords-bar strong {
+    color: #7fbbff;
+}
 .hs-save-btn {
-    margin-left: auto; padding: .3rem 1.1rem; background: #1e4a1e;
-    color: #7fff7f; border: 1px solid #2e6b2e; border-radius: 4px;
-    cursor: pointer; font-size: .82rem; font-weight: 600;
-    transition: background .12s;
+    margin-left: auto;
+    padding: 0.3rem 1.1rem;
+    background: #1e4a1e;
+    color: #7fff7f;
+    border: 1px solid #2e6b2e;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.82rem;
+    font-weight: 600;
+    transition: background 0.12s;
 }
-.hs-save-btn:hover { background: #275827; }
-#hs-save-status { font-size: .78rem; }
-#hs-save-status.ok  { color: #7fff7f; }
-#hs-save-status.err { color: #ff7f7f; }
+.hs-save-btn:hover {
+    background: #275827;
+}
+#hs-save-status {
+    font-size: 0.78rem;
+}
+#hs-save-status.ok {
+    color: #7fff7f;
+}
+#hs-save-status.err {
+    color: #ff7f7f;
+}
 
 .hs-char-section {
-    margin-top: 1.25rem; padding-top: 1rem;
+    margin-top: 1.25rem;
+    padding-top: 1rem;
     border-top: 1px solid #252535;
 }
 .hs-char-title {
-    font-size: .85rem; font-weight: 700; color: #aaa;
-    margin: 0 0 .75rem;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #aaa;
+    margin: 0 0 0.75rem;
 }
 table.hs-matrix {
-    border-collapse: collapse; font-size: .78rem;
+    border-collapse: collapse;
+    font-size: 0.78rem;
 }
 table.hs-matrix th {
-    background: #1a1a2e; color: #7fbbff; padding: 5px 14px;
-    text-align: center; font-weight: 600; border: 1px solid #252545;
+    background: #1a1a2e;
+    color: #7fbbff;
+    padding: 5px 14px;
+    text-align: center;
+    font-weight: 600;
+    border: 1px solid #252545;
 }
 table.hs-matrix th.col-char {
-    text-align: left; padding-left: 10px; min-width: 160px;
+    text-align: left;
+    padding-left: 10px;
+    min-width: 160px;
 }
 table.hs-matrix td {
-    padding: 4px 14px; border: 1px solid #1e1e30;
-    text-align: center; vertical-align: middle;
+    padding: 4px 14px;
+    border: 1px solid #1e1e30;
+    text-align: center;
+    vertical-align: middle;
 }
 table.hs-matrix td.col-char {
-    text-align: left; padding-left: 10px; color: #ccc;
+    text-align: left;
+    padding-left: 10px;
+    color: #ccc;
     font-family: monospace;
 }
-table.hs-matrix tr.row-unassigned td { background: rgba(180,40,40,.12); }
-table.hs-matrix tr.row-unassigned td.col-char { color: #f87171; }
-table.hs-matrix tr:not(.row-unassigned):hover td { background: #161625; }
-table.hs-matrix input[type=checkbox] { cursor: pointer; accent-color: #7fbbff; width: 14px; height: 14px; }
-table.hs-matrix .col-active { background: rgba(127,187,255,.07); }
+table.hs-matrix tr.row-unassigned td {
+    background: rgba(180, 40, 40, 0.12);
+}
+table.hs-matrix tr.row-unassigned td.col-char {
+    color: #f87171;
+}
+table.hs-matrix tr:not(.row-unassigned):hover td {
+    background: #161625;
+}
+table.hs-matrix input[type="checkbox"] {
+    cursor: pointer;
+    accent-color: #7fbbff;
+    width: 14px;
+    height: 14px;
+}
+table.hs-matrix .col-active {
+    background: rgba(127, 187, 255, 0.07);
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   PLAYTEST DASHBOARD (tools/playtest-dashboard.php)
+   ═══════════════════════════════════════════════════════════════════════════ */
+.pd-layout {
+    display: flex;
+    min-height: calc(100vh - 52px);
+}
+.pd-sidebar {
+    width: 280px;
+    flex-shrink: 0;
+    background: #0d1117;
+    border-right: 1px solid #1e2030;
+    padding: 1rem;
+    overflow-y: auto;
+    max-height: calc(100vh - 52px);
+}
+.pd-sidebar h2 {
+    color: #aaa;
+    font-size: 0.82rem;
+    margin: 0 0 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.pd-run-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 6px;
+    border-radius: 3px;
+    font-size: 0.78rem;
+    cursor: pointer;
+    margin-bottom: 2px;
+}
+.pd-run-item:hover {
+    background: #161625;
+}
+.pd-run-item input[type="checkbox"] {
+    cursor: pointer;
+    accent-color: #7fbbff;
+    flex-shrink: 0;
+}
+.pd-run-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+}
+.pd-run-label {
+    color: #ccc;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.pd-run-label .pd-run-profile {
+    color: #7fbbff;
+    font-weight: 600;
+}
+.pd-run-label .pd-run-outcome-completed {
+    color: #7fff7f;
+}
+.pd-run-label .pd-run-outcome-failed {
+    color: #f87171;
+}
+.pd-empty {
+    color: #555;
+    font-size: 0.82rem;
+    padding: 1rem;
+}
+
+.pd-main {
+    flex: 1;
+    padding: 1.2rem;
+    overflow-y: auto;
+}
+.pd-chart-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+.pd-chart-card {
+    background: #161625;
+    border: 1px solid #252535;
+    border-radius: 6px;
+    padding: 0.8rem;
+}
+.pd-chart-card h3 {
+    color: #aaa;
+    font-size: 0.8rem;
+    margin: 0 0 0.5rem;
+    font-weight: 600;
+}
+.pd-chart-card canvas {
+    max-height: 240px;
+}
+
+table.pd-summary {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.78rem;
+}
+table.pd-summary th {
+    background: #1a1a2e;
+    color: #7fbbff;
+    text-align: left;
+    padding: 5px 10px;
+}
+table.pd-summary td {
+    padding: 5px 10px;
+    border-top: 1px solid #1e1e30;
+    vertical-align: top;
+}
+table.pd-summary tr:hover td {
+    background: #161625;
+}
+.pd-outcome-completed {
+    color: #7fff7f;
+    font-weight: 600;
+}
+.pd-outcome-failed {
+    color: #f87171;
+    font-weight: 600;
+}
+.pd-rejections {
+    color: #888;
+    font-size: 0.74rem;
+}

--- a/tools/playtest-dashboard.php
+++ b/tools/playtest-dashboard.php
@@ -1,0 +1,214 @@
+<?php
+// Nouron Playtest Dashboard — visual comparison of PlaytestBot runs.
+// Usage: php -S localhost:8082 tools/playtest-dashboard.php
+// Then open: http://localhost:8082
+//
+// Reads the JSON reports game:playtest / PlaytestBotTest already write to
+// storage/logs/playtest/ — no new data pipeline, this is a viewer only.
+
+if (php_sapi_name() === 'cli-server') {
+    $requestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    $file = dirname(__DIR__).$requestPath;
+    if (is_file($file)) {
+        return false;
+    }
+}
+
+$reportDir = __DIR__.'/../storage/logs/playtest';
+$runs = [];
+
+if (is_dir($reportDir)) {
+    $files = glob($reportDir.'/*.json');
+    // Newest first — matches the sidebar's intended reading order.
+    usort($files, fn ($a, $b) => filemtime($b) <=> filemtime($a));
+
+    foreach ($files as $path) {
+        $data = json_decode(file_get_contents($path), true);
+        if (! is_array($data) || ! isset($data['seed'], $data['sols'])) {
+            continue; // skip malformed/foreign files rather than fail the whole page
+        }
+
+        $runs[] = [
+            'file' => basename($path),
+            'mtime' => filemtime($path),
+            'profile' => $data['profile'] ?? 'default',
+            'seed' => $data['seed'],
+            'outcome' => $data['outcome'] ?? ['status' => 'unknown'],
+            'phase2_start_sol' => $data['phase2_start_sol'] ?? null,
+            'objectives' => $data['objectives'] ?? [],
+            'actions' => $data['actions'] ?? [],
+            'rejections' => $data['rejections'] ?? [],
+            'sols' => $data['sols'] ?? [],
+        ];
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<title>Nouron Playtest Dashboard</title>
+<link rel="stylesheet" href="/tools/assets/dev-panel.css">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+</head>
+<body>
+
+<div class="panel-header">
+    <h1>Nouron Playtest Dashboard</h1>
+    <span class="hint">php -S localhost:8082 tools/playtest-dashboard.php</span>
+</div>
+
+<div class="pd-layout">
+    <div class="pd-sidebar">
+        <h2>Läufe (<?= count($runs) ?>)</h2>
+        <?php if (empty($runs)) { ?>
+            <p class="pd-empty">Keine Reports in <code>storage/logs/playtest/</code>. Erst <code>php artisan game:playtest</code> laufen lassen.</p>
+        <?php } else { ?>
+            <div id="pd-run-list"></div>
+        <?php } ?>
+    </div>
+
+    <div class="pd-main">
+        <div class="pd-chart-grid">
+            <div class="pd-chart-card"><h3>Regolith</h3><canvas id="chart-regolith"></canvas></div>
+            <div class="pd-chart-card"><h3>Credits</h3><canvas id="chart-credits"></canvas></div>
+            <div class="pd-chart-card"><h3>AP (verfügbar)</h3><canvas id="chart-ap"></canvas></div>
+            <div class="pd-chart-card"><h3>Vertrauen</h3><canvas id="chart-trust"></canvas></div>
+            <div class="pd-chart-card"><h3>CC-Level</h3><canvas id="chart-cc"></canvas></div>
+        </div>
+
+        <table class="pd-summary">
+            <thead>
+                <tr><th>Profil</th><th>Seed</th><th>Outcome</th><th>Phase 2 ab Sol</th><th>Objectives</th><th>Score</th><th>Aktionen</th><th>Top-Rejections</th></tr>
+            </thead>
+            <tbody id="pd-summary-body"></tbody>
+        </table>
+    </div>
+</div>
+
+<script id="playtest-data" type="application/json"><?= json_encode($runs, JSON_UNESCAPED_SLASHES) ?></script>
+<script>
+const RUNS = JSON.parse(document.getElementById('playtest-data').textContent);
+
+// Stable color per profile name — cycles through a fixed palette so the same
+// profile always reads as the same color across page reloads.
+const PALETTE = ['#7fbbff', '#ff9f7f', '#7fff9f', '#e0a0ff', '#ffe07f', '#7fe0e0', '#ff7fa0'];
+const profileColors = {};
+function colorFor(profile) {
+    if (!(profile in profileColors)) {
+        profileColors[profile] = PALETTE[Object.keys(profileColors).length % PALETTE.length];
+    }
+    return profileColors[profile];
+}
+
+function runLabel(run) {
+    return `${run.profile} · seed ${run.seed}`;
+}
+
+// ── Sidebar ──────────────────────────────────────────────────────────────
+const listEl = document.getElementById('pd-run-list');
+const selected = new Set();
+
+if (listEl) {
+    RUNS.forEach((run, idx) => {
+        const item = document.createElement('label');
+        item.className = 'pd-run-item';
+        const swatch = document.createElement('span');
+        swatch.className = 'pd-run-swatch';
+        swatch.style.background = colorFor(run.profile);
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.dataset.idx = idx;
+        checkbox.addEventListener('change', () => {
+            checkbox.checked ? selected.add(idx) : selected.delete(idx);
+            render();
+        });
+        const text = document.createElement('span');
+        text.className = 'pd-run-label';
+        const outcomeClass = run.outcome.status === 'completed' ? 'pd-run-outcome-completed' : 'pd-run-outcome-failed';
+        text.innerHTML = `<span class="pd-run-profile">${run.profile}</span> #${run.seed} <span class="${outcomeClass}">${run.outcome.status}</span>`;
+        item.append(checkbox, swatch, text);
+        listEl.appendChild(item);
+
+        // Auto-select the 3 most recent runs on first load — sidebar is
+        // newest-first, so this is just "check the first 3 rows".
+        if (idx < 3) {
+            checkbox.checked = true;
+            selected.add(idx);
+        }
+    });
+}
+
+// ── Charts ───────────────────────────────────────────────────────────────
+const chartDefs = [
+    { id: 'chart-regolith', field: 'regolith' },
+    { id: 'chart-credits', field: 'credits' },
+    { id: 'chart-ap', field: 'ap_unspent' },
+    { id: 'chart-trust', field: 'trust' },
+    { id: 'chart-cc', field: 'cc_level' },
+];
+const charts = {};
+chartDefs.forEach(def => {
+    const canvas = document.getElementById(def.id);
+    if (!canvas) return;
+    charts[def.field] = new Chart(canvas, {
+        type: 'line',
+        data: { datasets: [] },
+        options: {
+            responsive: true,
+            animation: false,
+            interaction: { mode: 'nearest', intersect: false },
+            scales: {
+                x: { type: 'linear', title: { display: true, text: 'Sol', color: '#888' }, ticks: { color: '#888' }, grid: { color: '#1e1e30' } },
+                y: { ticks: { color: '#888' }, grid: { color: '#1e1e30' } },
+            },
+            plugins: { legend: { labels: { color: '#ccc', boxWidth: 12, font: { size: 10 } } } },
+        },
+    });
+});
+
+function render() {
+    const activeRuns = [...selected].map(idx => RUNS[idx]).filter(Boolean);
+
+    chartDefs.forEach(def => {
+        const chart = charts[def.field];
+        if (!chart) return;
+        chart.data.datasets = activeRuns.map(run => ({
+            label: runLabel(run),
+            data: run.sols.map(s => ({ x: s.sol, y: s[def.field] })),
+            borderColor: colorFor(run.profile),
+            backgroundColor: colorFor(run.profile),
+            borderWidth: 2,
+            pointRadius: 0,
+            tension: 0.15,
+        }));
+        chart.update();
+    });
+
+    const body = document.getElementById('pd-summary-body');
+    if (!body) return;
+    body.innerHTML = activeRuns.map(run => {
+        const objectivesDone = run.objectives.filter(o => o.completed_at).length;
+        const rejections = Object.entries(run.rejections || {})
+            .sort((a, b) => b[1] - a[1]).slice(0, 3)
+            .map(([k, v]) => `${k}:${v}`).join(', ');
+        const outcomeClass = run.outcome.status === 'completed' ? 'pd-outcome-completed' : 'pd-outcome-failed';
+        const outcomeText = run.outcome.status === 'completed' ? 'completed' : `failed (${run.outcome.fail_reason || '?'})`;
+        return `<tr>
+            <td>${run.profile}</td>
+            <td>${run.seed}</td>
+            <td class="${outcomeClass}">${outcomeText}</td>
+            <td>${run.phase2_start_sol ?? '—'}</td>
+            <td>${objectivesDone}/${run.objectives.length}</td>
+            <td>${run.outcome.score ?? 0}</td>
+            <td>${run.actions.ok ?? '—'}/${run.actions.attempted ?? '—'}</td>
+            <td class="pd-rejections">${rejections || '—'}</td>
+        </tr>`;
+    }).join('');
+}
+
+render();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Neues `tools/playtest-dashboard.php` — Browser-Dashboard zum visuellen Vergleich mehrerer PlaytestBot-Läufe. Liest bestehende `storage/logs/playtest/*.json`-Reports (keine neue Datenerhebung).
- Sidebar mit allen gefundenen Läufen (Profil, Seed, Outcome), Mehrfachauswahl per Checkbox, automatisch die 3 neuesten vorausgewählt.
- Chart.js-Liniendiagramme über Sol: Regolith, Credits, AP (verfügbar), Vertrauen, CC-Level — je eine Farbe pro Profil.
- Summary-Tabelle: Outcome, Phase-2-Start-Sol, Objectives-Fortschritt, Score, Top-3-Rejections.
- Teilt sich `tools/assets/dev-panel.css` mit dem bestehenden Dev Panel (neue `PLAYTEST DASHBOARD`-Sektion statt eigenes Stylesheet) — auf Owner-Wunsch Ressourcen zwischen Dev Tools vereinheitlicht.

Start: `php -S localhost:8082 tools/playtest-dashboard.php`

## Test plan
- [x] `php -l tools/playtest-dashboard.php` — keine Syntaxfehler
- [x] Server lokal gestartet, 234 vorhandene Reports korrekt erkannt (HTTP 200)
- [x] Eingebettetes JSON validiert (Struktur/Feldnamen stimmen mit den `game:playtest`-Report-Keys überein)
- [x] **Visuell im Headless-Browser geprüft** (Playwright/Chromium): alle 5 Graphen rendern korrekt mit echten Daten, Farbkodierung pro Profil korrekt, Summary-Tabelle zeigt Outcome/Objectives/Score/Rejections korrekt
- [x] Interaktivität geprüft: Checkbox-Toggle aktualisiert Charts + Legende + Tabelle live, keine Browser-Konsolenfehler beim Reload

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9