### PR TITLE
Fix: expedition_coverage bei CC Lv4 erreichbar, self_sufficiency gelockert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-16
 
+- Fix: `task_expedition_coverage` (Ziel 16) praktisch nie erreichbar, weil die letzte Kachel exklusiv an CC Lv5 hing — `colony_zone_expansion` umverteilt, jetzt bei CC Lv4 erreichbar. `task_self_sufficiency`-Streak 15→8 Sole + Regolith-Schwelle 50→25 gelockert (PlaytestBot: Regolith nur 18/95 Sole über der alten Schwelle). Dabei auch Text/Code-Mismatch in lang-Strings korrigiert (nannte "Werkstoffe" statt Regolith).
 - Fix: Encounter-Trigger-Chance rampt jetzt 0→volle Stärke über die ersten 15 Sole der Phase 1 (`game.encounter.phase1_ramp_sols`) — frisch gelandete Kolonie hat noch keine Mitigation-Infrastruktur, PlaytestBot-Batch zeigte einen `phase1_deadline`-Ausreißer als Symptom.
 - Tool: `tools/playtest-dashboard.php` — Browser-Dashboard für PlaytestBot-Läufe (Chart.js-Graphen über Sol, Mehrfachvergleich, Summary-Tabelle), liest bestehende `storage/logs/playtest/*.json`-Reports, teilt sich `dev-panel.css` mit dem Dev Panel.
 - Feature: GDD §9 „Begegnungen & Gefahren" implementiert (Sturm/Geologische Instabilität/Seuchenausbruch) — bisher nur spezifiziert, nie codiert. `defense`-Kenntnis bekommt ihren ersten aktiven Effekt (Sturm-Risikominderung), `geology` einen zweiten (Instabilitäts-Risikominderung, zusätzlich zum Regolith-Bonus). Siehe `docs/superpowers/plans/2026-08-16-encounters-and-defense.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-16
 
+- Fix: Regolith-Startbestand 340→370 — GDD-§9-Begegnungen können jetzt auch in Phase 1 landen (trotz Ramp-Dämpfung), ein Kritisch-Tier-Sturmtreffer (Ø ~77,5 Rg) reichte, um die Sol-30-Deadline zu reißen (PlaytestBot-Standardseed 4242 verifiziert betroffen und mit dem Fix wieder behoben).
 - Fix: `task_expedition_coverage` (Ziel 16) praktisch nie erreichbar, weil die letzte Kachel exklusiv an CC Lv5 hing — `colony_zone_expansion` umverteilt, jetzt bei CC Lv4 erreichbar. `task_self_sufficiency`-Streak 15→8 Sole + Regolith-Schwelle 50→25 gelockert (PlaytestBot: Regolith nur 18/95 Sole über der alten Schwelle). Dabei auch Text/Code-Mismatch in lang-Strings korrigiert (nannte "Werkstoffe" statt Regolith).
 - Fix: Encounter-Trigger-Chance rampt jetzt 0→volle Stärke über die ersten 15 Sole der Phase 1 (`game.encounter.phase1_ramp_sols`) — frisch gelandete Kolonie hat noch keine Mitigation-Infrastruktur, PlaytestBot-Batch zeigte einen `phase1_deadline`-Ausreißer als Symptom.
 - Tool: `tools/playtest-dashboard.php` — Browser-Dashboard für PlaytestBot-Läufe (Chart.js-Graphen über Sol, Mehrfachvergleich, Summary-Tabelle), liest bestehende `storage/logs/playtest/*.json`-Reports, teilt sich `dev-panel.css` mit dem Dev Panel.

--- a/app/Services/OnboardingService.php
+++ b/app/Services/OnboardingService.php
@@ -133,7 +133,12 @@ class OnboardingService
             // ColonyController::LEVELUP_REGOLITH_FLAT) für die Pfadgebäude komplett
             // und für bioFacility teilweise unterschlagen — korrigierte Bedarfssumme
             // 535 Rg statt 500. Verschiebt den Floor auf ≈Sol 15,1.
-            ['resource_id' => 3,  'colony_id' => $colonyId, 'amount' => 340],  // regolith
+            // 340 → 370 (Nachtrag 2026-08-16, game-designer review): GDD §9-Begegnungen
+            // können jetzt auch in Phase 1 einen Kritisch-Tier-Sturm-Treffer landen
+            // (Ø ~77,5 Rg Verlust, Band 60-95). +30 Puffer deckt ~40% eines typischen
+            // Treffers ab, verschiebt den No-Storm-Floor auf ≈Sol 12,9 — bewusst kein
+            // Vollschutz (das wäre eine Überkorrektur, siehe §13.7-Warnung bei 400).
+            ['resource_id' => 3,  'colony_id' => $colonyId, 'amount' => 370],  // regolith
             ['resource_id' => 4,  'colony_id' => $colonyId, 'amount' => 0],    // werkstoffe — produced by harvester
             ['resource_id' => 5,  'colony_id' => $colonyId, 'amount' => 0],    // organika  — produced by bioFacility
             ['resource_id' => 12, 'colony_id' => $colonyId, 'amount' => 0],    // trust

--- a/app/Services/RunProgressService.php
+++ b/app/Services/RunProgressService.php
@@ -38,7 +38,11 @@ class RunProgressService
         'task_credit_reserve' => 10,
         'task_colony_prosperity' => 10,
         'task_research_lead' => 3,
-        'task_self_sufficiency' => 15,
+        // 15 → 8 (2026-08-16, game-designer review): PlaytestBot data showed
+        // Regolith above the old >50 threshold only 18/95 Sols (Ø 31.4) — a
+        // 15-Sol streak was practically unreachable. Halved streak length +
+        // lowered Regolith threshold (see updateSelfSufficiency()) together.
+        'task_self_sufficiency' => 8,
         // Max reachable is 1 (CC ring-0, always colony zone + pre-explored) + Σ
         // config('game.colony_zone_expansion') over all 5 CC levels (15) = 16.
         // Was 19 — mathematically unwinnable regardless of play skill (found
@@ -326,7 +330,11 @@ class RunProgressService
             ->where('user_id', $run->user_id)
             ->value('supply') ?? 0);
 
-        $allMet = $regolith > 50 && $organics > 50 && $supply > 0;
+        // Regolith threshold 50 → 25 (2026-08-16, game-designer review): Regolith
+        // is a running-consumption resource (build/level-up), not a stable
+        // reserve — 50 was above the observed Sol-average (Ø 31.4), see
+        // TASK_TARGETS['task_self_sufficiency'] comment above.
+        $allMet = $regolith > 25 && $organics > 50 && $supply > 0;
 
         if ($allMet) {
             $objective->streak_value++;

--- a/app/Services/RunProgressService.php
+++ b/app/Services/RunProgressService.php
@@ -311,7 +311,7 @@ class RunProgressService
 
     /**
      * Streak task: all three conditions must hold simultaneously each sol.
-     * Regolith (colony_resources, resource_id=3) > 50, Organika (resource_id=5) > 50,
+     * Regolith (colony_resources, resource_id=3) > 25, Organika (resource_id=5) > 50,
      * Supply (user_resources.supply) > 0. Any single failure resets the streak to 0.
      */
     private function updateSelfSufficiency(RunObjective $objective, Run $run): void

--- a/config/game.php
+++ b/config/game.php
@@ -29,7 +29,13 @@ return [
     // Walk order: ring 1 → ring 2 → ring 3; skip regolith_* and terrain_impassable.
     // Ring 1 (6 tiles) fully unlocked at Lv1 = your immediate base area.
     // Ring 2 expands step by step at Lv2–Lv5. Max = 15 terrain tiles + CC = 16 total.
-    'colony_zone_expansion' => [6, 3, 3, 2, 1],
+    // Redistributed 2026-08-16 (game-designer review): the last slot used to be
+    // CC Lv5-only (1 tile), which made the last colony-zone tile unreachable in
+    // practice — CC rarely hits Lv5 before the run's time limit (PlaytestBot,
+    // 2026-08-14/16). Sum unchanged (15, +1 CC ring-0 tile = 16); the 15th tile
+    // now unlocks at Lv4 instead of Lv5, so task_expedition_coverage (target 16)
+    // stays reachable within the typical Lv4 timing window.
+    'colony_zone_expansion' => [6, 3, 3, 3, 0],
 
     // Navigation-AP cost to explore a fogged tile, keyed by ring distance from the
     // CC (ring 0). Staggers the fog-of-war reveal pace: ring 2 costs more than ring 1,

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -3066,6 +3066,18 @@ Verfügbar(N) = Startbestand + 17×(N−1) − 2,94×N = Startbestand − 17 + 1
 
 **Empfehlung: Startbestand 300 → 340** (nicht 400 — dieser Wert stand in einer Zwischenfassung dieses Nachtrags, siehe Kasten oben, und beruhte auf der inzwischen korrigierten Wohnhabitat-Zeile). Bei 340 landet der Floor bei ≈Sol 15,1 (volle Kette, beide Pfadgebäude) — nahezu exakt der Wert, den der 08-12-Nachtrag als Zielposition beabsichtigt hatte (≈15,4), jetzt aber gegen die korrekt gerechnete 535er-Kette statt der fehlerhaften 500er. **400 wäre eine Überkorrektur:** Floor ≈10,8 würde die Kolonie strukturell zu schnell durch Phase 1 tragen und mit G5 („2–4 Mal pro Run an Regolith scheitern") sowie der G4-5–8-Sole-pro-Gebäude-Kalibrierung kollidieren — der gleiche Fehler in die andere Richtung, den die verschärfte Owner-Vorgabe vermeiden soll (Tempo-Ziel gegen Varianz-Ziel eingetauscht). 340 hält den Floor nah an der ursprünglich beabsichtigten Position, ohne den Korridor nach unten zu sprengen.
 
+> **Nachtrag 2026-08-16:** 340 → 370. GDD §9-Begegnungen (Sturm) können seit
+> ihrer Implementierung auch in Phase 1 landen (trotz der Phase-1-Ramp-
+> Dämpfung, die die Chance nur senkt, nie auf 0 setzt) — ein Kritisch-Tier-
+> Treffer kostet Ø ~77,5 Rg (Band 60-95), genug um die knappe Sol-30-Deadline
+> zu reißen (empirisch beobachtet: PlaytestBot-Standardseed 4242 kippte von
+> zuverlässigem Phase-1-Erfolg zu `phase1_deadline`-Fail, sobald Encounters
+> aktiv waren). +30 Rg deckt ~40 % eines typischen Treffers, verschiebt den
+> No-Storm-Floor auf ≈Sol 12,9 — bewusst kein Vollschutz, um nicht erneut in
+> die oben verworfene 400er-Überkorrektur zu laufen. Verifiziert: Seed 4242
+> schließt mit 370 wieder zuverlässig ab (in einem Testlauf sogar komplett,
+> Score 2966, statt nur Phase 1 zu erreichen).
+
 `resource_max['regolith_normal'] = 300` bleibt unverändert ausreichend: kumulierte Extraktion bei Floor-Sol 15,1 ≈ `17×14,1 ≈ 240 Rg`, weiterhin unter der Mengengrenze.
 
 **Poor-Tile-Worst-Case, neu gerechnet gegen 340/535:** `Verfügbar(14, poor) = 340 + 12×13 − 2,0×14 = 340 + 156 − 28 = 468`. Rest-Bedarf `535 − 468 = 67` Rg, bei ≈15 Rg/Sol netto auf dem neuen Tile ≈5 weitere Sole → Abschluss ≈ Sol 14 + 1 (Transit) + 5 = **Sol 20** — deckt sich mit dem 08-12-Zielwert. Bei unverändertem Startbestand 300 läge der Worst-Case bei ≈Sol 23 (immer noch unter der harten Sol-25-Grenze, aber ohne Sicherheitsmarge) — ein weiteres Argument für den moderaten Sprung auf 340 statt „300 unverändert lassen".

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -3811,6 +3811,19 @@ Bei Phase-1-Ende Sol 20 fällt Phase-2-Sol 80 exakt auf Gesamt-Sol 100 — das i
 | Typischer Sieg < Sol 55 | `TASK_TARGETS`-Werte erhöhen oder tick_limit auf 80 senken |
 
 > ✅ BEHOBEN (2026-08-14): `task_expedition_coverage: 19` war **mathematisch unerreichbar**, nicht nur schwierig — die Colony-Zone wächst über `config('game.colony_zone_expansion')` (Summe 15 Terrain-Tiles über alle 5 CC-Level) plus das immer-Zone-und-vorerkundete CC-Ring-0-Tile, macht maximal **16** je erreichbare `is_colony_zone=1`-Tiles. PlaytestBot bestätigte den Deadlock empirisch: alle 3 Testseeds blieben identisch bei 13/19 stehen (Phase-2-Pacing-Untersuchung, 2026-08-14). `RunProgressService::TASK_TARGETS['task_expedition_coverage']` auf **16** korrigiert, Regressionstest ergänzt (`RunProgressServiceTest::test_task_expedition_coverage_target_does_not_exceed_max_reachable_colony_zone_tiles`), der jede künftige `colony_zone_expansion`-Änderung gegen diesen Zielwert prüft.
+>
+> **Nachtrag 2026-08-16:** Ziel 16 war zwar rechnerisch erreichbar, praktisch aber
+> fast nie — die 16. Kachel hing exklusiv an CC Lv5, das typischerweise erst
+> weit nach Sol 65 erreicht wird (CC-Lv4-Timing-Befund, siehe §13.5-Diskussion).
+> `colony_zone_expansion` von `[6,3,3,2,1]` auf `[6,3,3,3,0]` umverteilt (Summe
+> weiterhin 15) — die 15. Kachel (Ziel-Gesamt 16 mit CC-Ring-0-Tile) schaltet
+> jetzt bereits bei CC Lv4 frei. `task_expedition_coverage`-Ziel bleibt bei 16.
+> Gleicher Nachtrag korrigiert `task_self_sufficiency`: Streak-Ziel 15→8 Sole,
+> Regolith-Schwelle `>50`→`>25` (PlaytestBot zeigte Regolith nur in 18/95 Solen
+> über der alten Schwelle, Ø 31,4 — Regolith ist laufender Verbrauch, keine
+> stabile Reserve). `lang/de+en/run.php` korrigiert dabei auch einen
+> Text/Code-Mismatch: der Text nannte "Werkstoffe", der Code prüft schon immer
+> Regolith (resource_id=3).
 
 > **Entschieden (2026-07-19):** `task_credit_reserve: 10` (10 aufeinanderfolgende Sole mit Credits > 5.000) war mit der alten Ökonomie strukturell unerreichbar — Playtest-Bot-Befund PR #218 bestätigt: Credits fielen auf 0 und blieben dort geklemmt, der dritte Berater wurde nie leistbar, Phase 1 nie abgeschlossen. Fix über drei Hebel (Details siehe §13 "Rang-System" und §12 "Kanal 1: Bar/Cantina"):
 >

--- a/lang/de/run.php
+++ b/lang/de/run.php
@@ -10,7 +10,7 @@ return [
     'task_credit_reserve' => 'Kreditimperium: Credits-Bestand ≥ 5.000 für 10 aufeinanderfolgende Sole',
     'task_colony_prosperity' => 'Kolonieblüte: Vertrauen > 70 für 10 aufeinanderfolgende Sole',
     'task_research_lead' => 'Forschungsvorsprung: Mindestens 3 Forschungen auf Level 5+',
-    'task_self_sufficiency' => 'Selbstversorgung: Werkstoffe + Organika produzieren + Supply > 0 für 15 Sole',
+    'task_self_sufficiency' => 'Selbstversorgung: Regolith + Organika produzieren + Supply > 0 für 8 Sole',
     'task_expedition_coverage' => 'Expeditionsstatus: Alle Colony-Zone-Tiles erkundet',
     'task_engineering_output' => 'Ingenieursleistung: Gesamt-Zustand aller Gebäude ≥ 200 SP',
     'task_trade_volume' => 'Handelspartner: 5 Käufe beim Reisenden Händler',

--- a/lang/en/run.php
+++ b/lang/en/run.php
@@ -10,7 +10,7 @@ return [
     'task_credit_reserve' => 'Credit Empire: Credits balance ≥ 5,000 for 10 consecutive Sols',
     'task_colony_prosperity' => 'Colony Prosperity: Trust > 70 for 10 consecutive Sols',
     'task_research_lead' => 'Research Lead: at least 3 knowledge fields at Level 5+',
-    'task_self_sufficiency' => 'Self-Sufficiency: producing Compounds + Organics + Supply > 0 for 15 Sols',
+    'task_self_sufficiency' => 'Self-Sufficiency: producing Regolith + Organics + Supply > 0 for 8 Sols',
     'task_expedition_coverage' => 'Expedition Status: all colony zone tiles explored',
     'task_engineering_output' => 'Engineering Output: total condition of all buildings ≥ 200 SP',
     'task_trade_volume' => 'Trade Partner: 5 purchases from the Travelling Merchant',

--- a/tests/Feature/Auth/OnboardingTest.php
+++ b/tests/Feature/Auth/OnboardingTest.php
@@ -44,7 +44,7 @@ class OnboardingTest extends TestCase
         $res = DB::table('colony_resources')
             ->where('colony_id', $colony->id)
             ->pluck('amount', 'resource_id');
-        $this->assertEquals(340, $res[3]);   // regolith
+        $this->assertEquals(370, $res[3]);   // regolith
         $this->assertEquals(0, $res[4]);   // werkstoffe — produced by harvester, no starting stock
         $this->assertEquals(0, $res[5]);   // organika   — produced by bioFacility, no starting stock
 

--- a/tests/Feature/RunProgressServiceTest.php
+++ b/tests/Feature/RunProgressServiceTest.php
@@ -36,9 +36,9 @@ namespace Tests\Feature;
  *   - calculateScore returns positive score for completed run with objectives
  *
  * TASK_SELBSTVERSORGUNG (streak)
- *   - streak increments when regolith>50 AND organics>50 AND supply>0
- *   - streak resets to 0 when regolith fails (<= 50)
- *   - completes (completed_at set) when streak reaches target_value (15)
+ *   - streak increments when regolith>25 AND organics>50 AND supply>0
+ *   - streak resets to 0 when regolith fails (<= 25)
+ *   - completes (completed_at set) when streak reaches target_value (8)
  *
  * TASK_EXPEDITIONSSTATUS (counter)
  *   - completes when 19+ explored colony-zone tiles exist

--- a/tests/Feature/RunProgressServiceTest.php
+++ b/tests/Feature/RunProgressServiceTest.php
@@ -810,10 +810,11 @@ class RunProgressServiceTest extends TestCase
     public function test_task_self_sufficiency_increments_streak_when_all_conditions_met(): void
     {
         $run = $this->makeRun(['current_tick' => 10, 'phase' => 2]);
-        $objective = $this->makeObjective($run, 'task_self_sufficiency', 15, 0);
+        $objective = $this->makeObjective($run, 'task_self_sufficiency', 8, 0);
 
-        // regolith (resource_id=3) > 50, organics (resource_id=5) > 50, supply (user_resources) > 0
-        $this->setColonyResource(3, 60);
+        // regolith (resource_id=3) > 25 (30 passes new threshold, fails old >50 —
+        // a discriminating value, not just any passing value), organics > 50, supply > 0
+        $this->setColonyResource(3, 30);
         $this->setColonyResource(5, 55);
         $this->setSupply(1);
 
@@ -829,17 +830,17 @@ class RunProgressServiceTest extends TestCase
     {
         $run = $this->makeRun(['current_tick' => 10, 'phase' => 2]);
         // Pre-load a streak of 7
-        $objective = $this->makeObjective($run, 'task_self_sufficiency', 15, 7);
+        $objective = $this->makeObjective($run, 'task_self_sufficiency', 8, 7);
 
-        // Regolith at exactly 50 — condition requires > 50, so this fails
-        $this->setColonyResource(3, 50);
+        // Regolith at exactly 25 — condition requires > 25, so this fails
+        $this->setColonyResource(3, 25);
         $this->setColonyResource(5, 55);
         $this->setSupply(1);
 
         $this->service->updateObjectiveProgress($run);
 
         $objective->refresh();
-        $this->assertEquals(0, $objective->streak_value, 'streak_value must reset to 0 when regolith <= 50');
+        $this->assertEquals(0, $objective->streak_value, 'streak_value must reset to 0 when regolith <= 25');
         $this->assertEquals(0, $objective->current_value);
         $this->assertNull($objective->completed_at);
     }
@@ -847,8 +848,8 @@ class RunProgressServiceTest extends TestCase
     public function test_task_self_sufficiency_completes_when_streak_reaches_target(): void
     {
         $run = $this->makeRun(['current_tick' => 20, 'phase' => 2]);
-        // Pre-load streak at 14 — one passing tick should complete it (target=15)
-        $objective = $this->makeObjective($run, 'task_self_sufficiency', 15, 14);
+        // Pre-load streak at 7 — one passing tick should complete it (target=8)
+        $objective = $this->makeObjective($run, 'task_self_sufficiency', 8, 7);
 
         $this->setColonyResource(3, 100);
         $this->setColonyResource(5, 100);
@@ -857,7 +858,7 @@ class RunProgressServiceTest extends TestCase
         $this->service->updateObjectiveProgress($run);
 
         $objective->refresh();
-        $this->assertEquals(15, $objective->streak_value, 'streak_value must reach 15');
+        $this->assertEquals(8, $objective->streak_value, 'streak_value must reach 8');
         $this->assertNotNull($objective->completed_at, 'task_self_sufficiency must be marked complete when streak reaches target_value');
     }
 
@@ -1242,7 +1243,7 @@ class RunProgressServiceTest extends TestCase
     public function test_task_self_sufficiency_resets_streak_when_supply_is_zero(): void
     {
         $run = $this->makeRun(['current_tick' => 10, 'phase' => 2]);
-        $objective = $this->makeObjective($run, 'task_self_sufficiency', 15, 5);
+        $objective = $this->makeObjective($run, 'task_self_sufficiency', 8, 5);
 
         $this->setColonyResource(3, 60);
         $this->setColonyResource(5, 55);
@@ -1257,7 +1258,7 @@ class RunProgressServiceTest extends TestCase
     public function test_task_self_sufficiency_resets_streak_when_organics_fails(): void
     {
         $run = $this->makeRun(['current_tick' => 10, 'phase' => 2]);
-        $objective = $this->makeObjective($run, 'task_self_sufficiency', 15, 5);
+        $objective = $this->makeObjective($run, 'task_self_sufficiency', 8, 5);
 
         $this->setColonyResource(3, 60);
         $this->setColonyResource(5, 50); // exactly 50 — requires > 50, so fails


### PR DESCRIPTION
## Summary
- `colony_zone_expansion` umverteilt `[6,3,3,2,1]`→`[6,3,3,3,0]` (Summe unverändert 15): die 16. Colony-Zone-Kachel hing exklusiv an CC Lv5 (typischerweise erst weit nach Sol 65 erreicht), jetzt bereits bei CC Lv4 erreichbar. `task_expedition_coverage`-Ziel bleibt bei 16.
- `task_self_sufficiency`: Streak-Ziel 15→8 Sole, Regolith-Schwelle `>50`→`>25`. PlaytestBot-Daten: Regolith nur in 18 von 95 Solen über der alten Schwelle (Ø 31,4) — 15-Sol-Streak praktisch unerreichbar.
- Nebenbei behoben: `lang/de+en/run.php` nannte "Werkstoffe" statt Regolith — reiner Text-Fehler.
- **Regolith-Startbestand 340→370.** Untersuchung eines neuen Befunds (PlaytestBot-Standardseed 4242 kippte reproduzierbar von Phase-1-Erfolg zu `phase1_deadline`-Fail, sobald GDD-§9-Encounters aktiv sind): Ursache ist kein Bug — mit Encounters deaktiviert läuft derselbe Seed wieder sauber (verifiziert per A/B-Test). Ein Kritisch-Tier-Sturmtreffer in Phase 1 (Ø ~77,5 Rg Verlust) reicht aus, um die knappe Sol-30-Deadline zu reißen, selbst mit der Phase-1-Ramp-Dämpfung aus PR #256 (die Chance senkt, nie auf 0 setzt). +30 Rg Startpuffer deckt ~40% eines typischen Treffers, ohne die 400er-Überkorrektur aus §13.7 zu wiederholen. Verifiziert: Seed 4242 schließt jetzt wieder zuverlässig ab (in einem Lauf sogar komplett, Score 2966).
- Alle Werte nach game-designer-Review.

## Test plan
- [x] TDD: alle Threshold-Änderungen mit diskriminierenden Testwerten rot bestätigt vor Fix
- [x] `php bin/phpunit tests/Feature/RunProgressServiceTest.php` — 62/62 grün
- [x] `php bin/phpunit tests/Feature/Auth/OnboardingTest.php` — 3/3 grün
- [x] `php artisan test` — 1019 passed, 0 failed
- [x] `/code-review high` gegen PR #257 — 2 Findings (veraltete Docblock-Zahlen), beide gefixt

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9