### PR TITLE
chore: Playtest-Dashboard Farben + Concurrency-Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-08-17
+
+- Fix: `tools/playtest-dashboard.php` — Chart-Linien/Sidebar-Swatches färbten alle Läufe eines Profils identisch (`colorFor()` keyte auf Profilname statt Lauf), Mehrfachvergleich damit unlesbar. Färbt jetzt pro Lauf (Profil+Seed+Datei).
+- Perf: `game:playtest`s gespawnte `bin/phpunit`-Kindprozesse laufen jetzt mit `-d opcache.enable_cli=1` — `--concurrency=5` überschritt vorher zuverlässig das 120s-Pool-Timeout, läuft jetzt in ~88s durch.
+
 ## 2026-08-16
 
 - Feature: `game:playtest` läuft jetzt parallel (`--concurrency=N`, Default 10) statt sequentiell — für spätere große Seed-Sweeps (100+). Dabei entdeckt und gefixt: `phpunit.xml`s `DB_DATABASE=:memory:`-Force griff nicht zuverlässig, wenn `bin/phpunit` aus einem laufenden `artisan`-Prozess heraus gestartet wurde — DB-Env wird jetzt explizit pro Kindprozess erzwungen.

--- a/app/Console/Commands/Playtest.php
+++ b/app/Console/Commands/Playtest.php
@@ -72,7 +72,14 @@ class Playtest extends Command
                         ])
                         ->timeout(120)
                         ->command([
-                            'php', 'bin/phpunit',
+                            // opcache.enable_cli defaults to Off system-wide, so every
+                            // spawned child cold-compiles the whole vendor tree from
+                            // scratch — measured ~47s for a single run just from that.
+                            // Forcing it on here (scoped to this process only, no global
+                            // php.ini change) lets concurrency scale past ~2 without
+                            // hitting the timeout below (found 2026-08-17).
+                            'php', '-d', 'opcache.enable_cli=1',
+                            'bin/phpunit',
                             '--filter', 'test_bot_plays_a_full_run_and_produces_a_report',
                             'tests/Feature/Playtest/PlaytestBotTest.php',
                         ]);

--- a/tools/playtest-dashboard.php
+++ b/tools/playtest-dashboard.php
@@ -90,15 +90,17 @@ if (is_dir($reportDir)) {
 <script>
 const RUNS = JSON.parse(document.getElementById('playtest-data').textContent);
 
-// Stable color per profile name — cycles through a fixed palette so the same
-// profile always reads as the same color across page reloads.
-const PALETTE = ['#7fbbff', '#ff9f7f', '#7fff9f', '#e0a0ff', '#ffe07f', '#7fe0e0', '#ff7fa0'];
-const profileColors = {};
-function colorFor(profile) {
-    if (!(profile in profileColors)) {
-        profileColors[profile] = PALETTE[Object.keys(profileColors).length % PALETTE.length];
+// Stable color per individual run (profile+seed) — cycles through a fixed
+// palette so every run line is distinguishable, even when several runs
+// share the same profile name.
+const PALETTE = ['#7fbbff', '#ff9f7f', '#7fff9f', '#e0a0ff', '#ffe07f', '#7fe0e0', '#ff7fa0', '#b0ff7f', '#ff7fd0', '#7fa0ff', '#ffd07f', '#a0ff7f'];
+const runColors = {};
+function colorFor(run) {
+    const key = `${run.profile}-${run.seed}-${run.file}`;
+    if (!(key in runColors)) {
+        runColors[key] = PALETTE[Object.keys(runColors).length % PALETTE.length];
     }
-    return profileColors[profile];
+    return runColors[key];
 }
 
 function runLabel(run) {
@@ -115,7 +117,7 @@ if (listEl) {
         item.className = 'pd-run-item';
         const swatch = document.createElement('span');
         swatch.className = 'pd-run-swatch';
-        swatch.style.background = colorFor(run.profile);
+        swatch.style.background = colorFor(run);
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.dataset.idx = idx;
@@ -176,8 +178,8 @@ function render() {
         chart.data.datasets = activeRuns.map(run => ({
             label: runLabel(run),
             data: run.sols.map(s => ({ x: s.sol, y: s[def.field] })),
-            borderColor: colorFor(run.profile),
-            backgroundColor: colorFor(run.profile),
+            borderColor: colorFor(run),
+            backgroundColor: colorFor(run),
             borderWidth: 2,
             pointRadius: 0,
             tension: 0.15,


### PR DESCRIPTION
## Summary
- Dashboard-Chart-Linien/Sidebar-Swatches färbten alle Läufe eines Profils identisch — jetzt pro Lauf eindeutig (`colorFor()` keyt auf profile+seed+file).
- `game:playtest`s gespawnte `bin/phpunit`-Kindprozesse laufen jetzt mit `-d opcache.enable_cli=1` — `--concurrency=5` überschritt vorher das 120s-Pool-Timeout, läuft jetzt in ~88s durch (nicht Hardware-limitiert, 24 Kerne/23GB frei).

## Test plan
- [x] `php bin/phpunit` — 1020/1020 grün
- [x] `--concurrency=5` manuell verifiziert (88s, unter Timeout)

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9