### PR TITLE
feat: Playtest-Dashboard Aktions-Log + Ereignis-Marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: `tools/playtest-dashboard.php` — Chart-Linien/Sidebar-Swatches färbten alle Läufe eines Profils identisch (`colorFor()` keyte auf Profilname statt Lauf), Mehrfachvergleich damit unlesbar. Färbt jetzt pro Lauf (Profil+Seed+Datei).
 - Perf: `game:playtest`s gespawnte `bin/phpunit`-Kindprozesse laufen jetzt mit `-d opcache.enable_cli=1` — `--concurrency=5` überschritt vorher zuverlässig das 120s-Pool-Timeout, läuft jetzt in ~88s durch.
+- Feature: PlaytestBot-Reports tragen jetzt den vollen Aktions-Log (Sol/Regel/OK/Error), nicht mehr nur aggregierte Rejection-Zähler. Dashboard zeigt ihn pro Lauf an + zwei zuschaltbare Ereignis-Marker (CC-Level-Aufstieg, Berater angestellt) als Linien in allen Charts.
 
 ## 2026-08-16
 

--- a/tests/Feature/Playtest/PlaytestBotTest.php
+++ b/tests/Feature/Playtest/PlaytestBotTest.php
@@ -44,6 +44,11 @@ class PlaytestBotTest extends TestCase
         $this->assertGreaterThan(0, $data['actions']['ok'], 'Bot must have taken at least one successful action');
         $this->assertFileExists($path);
         $this->assertIsArray(json_decode(file_get_contents($path), true), 'Report artifact must be valid JSON');
+
+        // Dashboard event markers (2026-08-17) need the raw per-action log —
+        // sol/rule/ok/error per action — not just the aggregated rejection
+        // counts, so the report must carry it through unchanged.
+        $this->assertSame($bot->log, $data['log'], 'Report must include the full raw action log for dashboard event markers');
     }
 
     /**

--- a/tests/Feature/Playtest/RunReport.php
+++ b/tests/Feature/Playtest/RunReport.php
@@ -52,7 +52,7 @@ class RunReport
 
     /**
      * @return array{seed:int, profile:string, outcome:array, phase2_start_sol:?int, objectives:array,
-     *               actions:array, rejections:array, burnout:array, sols:array}
+     *               actions:array, rejections:array, burnout:array, sols:array, log:array}
      */
     public function build(BotSession $bot): array
     {
@@ -113,6 +113,9 @@ class RunReport
                 'advisor_active_ticks' => $advisorActiveTicks,
             ],
             'sols' => $this->sols,
+            // Raw per-action log (sol/rule/ok/error) — dashboard event markers
+            // read this directly, kept unaggregated unlike 'rejections' above.
+            'log' => $bot->log,
         ];
     }
 

--- a/tools/assets/dev-panel.css
+++ b/tools/assets/dev-panel.css
@@ -689,3 +689,76 @@ table.pd-summary tr:hover td {
     color: #888;
     font-size: 0.74rem;
 }
+
+.pd-event-toggles {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    font-size: 0.78rem;
+    color: #aaa;
+    margin-bottom: 0.8rem;
+}
+.pd-event-toggles-label {
+    color: #666;
+}
+.pd-event-toggles label {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    cursor: pointer;
+}
+
+.pd-log-card {
+    background: #161625;
+    border: 1px solid #252535;
+    border-radius: 6px;
+    padding: 0.8rem;
+    margin-top: 1.5rem;
+}
+.pd-log-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+.pd-log-header h3 {
+    color: #aaa;
+    font-size: 0.8rem;
+    margin: 0;
+    font-weight: 600;
+}
+.pd-log-header select {
+    background: #0d0d18;
+    color: #ccc;
+    border: 1px solid #2a2a3d;
+    border-radius: 4px;
+    padding: 3px 6px;
+    font-size: 0.76rem;
+}
+.pd-log-scroll {
+    max-height: 320px;
+    overflow-y: auto;
+}
+table.pd-log-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.76rem;
+}
+table.pd-log-table th {
+    background: #1a1a2e;
+    color: #7fbbff;
+    text-align: left;
+    padding: 4px 8px;
+    position: sticky;
+    top: 0;
+}
+table.pd-log-table td {
+    padding: 3px 8px;
+    border-top: 1px solid #1e1e30;
+}
+tr.pd-log-ok td:last-child {
+    color: #7fff7f;
+}
+tr.pd-log-error td:last-child {
+    color: #f87171;
+}

--- a/tools/playtest-dashboard.php
+++ b/tools/playtest-dashboard.php
@@ -39,6 +39,7 @@ if (is_dir($reportDir)) {
             'actions' => $data['actions'] ?? [],
             'rejections' => $data['rejections'] ?? [],
             'sols' => $data['sols'] ?? [],
+            'log' => $data['log'] ?? [],
         ];
     }
 }
@@ -50,6 +51,7 @@ if (is_dir($reportDir)) {
 <title>Nouron Playtest Dashboard</title>
 <link rel="stylesheet" href="/tools/assets/dev-panel.css">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3"></script>
 </head>
 <body>
 
@@ -69,6 +71,12 @@ if (is_dir($reportDir)) {
     </div>
 
     <div class="pd-main">
+        <div class="pd-event-toggles">
+            <span class="pd-event-toggles-label">Ereignis-Marker:</span>
+            <label><input type="checkbox" id="pd-event-cc" checked> CC-Level-Aufstieg</label>
+            <label><input type="checkbox" id="pd-event-advisor" checked> Berater angestellt</label>
+        </div>
+
         <div class="pd-chart-grid">
             <div class="pd-chart-card"><h3>Regolith</h3><canvas id="chart-regolith"></canvas></div>
             <div class="pd-chart-card"><h3>Credits</h3><canvas id="chart-credits"></canvas></div>
@@ -83,6 +91,19 @@ if (is_dir($reportDir)) {
             </thead>
             <tbody id="pd-summary-body"></tbody>
         </table>
+
+        <div class="pd-log-card">
+            <div class="pd-log-header">
+                <h3>Aktions-Log</h3>
+                <select id="pd-log-run-select"></select>
+            </div>
+            <div class="pd-log-scroll">
+                <table class="pd-log-table">
+                    <thead><tr><th>Sol</th><th>Aktion</th><th>Status</th></tr></thead>
+                    <tbody id="pd-log-body"></tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -141,6 +162,33 @@ if (listEl) {
     });
 }
 
+// ── Event markers ────────────────────────────────────────────────────────
+// Derived from sols[] deltas — no extra data needed beyond what's already
+// snapshotted per Sol. Cached per run since RUNS is immutable after load.
+const eventsCache = new Map();
+function eventsFor(run) {
+    if (eventsCache.has(run)) return eventsCache.get(run);
+    const events = [];
+    let prevCc = null;
+    let prevAdvisors = null;
+    run.sols.forEach(s => {
+        if (prevCc !== null && s.cc_level > prevCc) {
+            events.push({ sol: s.sol, type: 'cc', label: `CC → Lv${s.cc_level}` });
+        }
+        if (prevAdvisors !== null && s.advisors > prevAdvisors) {
+            events.push({ sol: s.sol, type: 'advisor', label: `Berater #${s.advisors}` });
+        }
+        prevCc = s.cc_level;
+        prevAdvisors = s.advisors;
+    });
+    eventsCache.set(run, events);
+    return events;
+}
+
+if (window['chartjs-plugin-annotation']) {
+    Chart.register(window['chartjs-plugin-annotation']);
+}
+
 // ── Charts ───────────────────────────────────────────────────────────────
 const chartDefs = [
     { id: 'chart-regolith', field: 'regolith' },
@@ -164,13 +212,52 @@ chartDefs.forEach(def => {
                 x: { type: 'linear', title: { display: true, text: 'Sol', color: '#888' }, ticks: { color: '#888' }, grid: { color: '#1e1e30' } },
                 y: { ticks: { color: '#888' }, grid: { color: '#1e1e30' } },
             },
-            plugins: { legend: { labels: { color: '#ccc', boxWidth: 12, font: { size: 10 } } } },
+            plugins: {
+                legend: { labels: { color: '#ccc', boxWidth: 12, font: { size: 10 } } },
+                annotation: { annotations: {} },
+            },
         },
     });
 });
 
+function activeEventTypes() {
+    const types = [];
+    if (document.getElementById('pd-event-cc')?.checked) types.push('cc');
+    if (document.getElementById('pd-event-advisor')?.checked) types.push('advisor');
+    return types;
+}
+
+function annotationsFor(activeRuns) {
+    const types = activeEventTypes();
+    if (types.length === 0) return {};
+    const annotations = {};
+    let n = 0;
+    activeRuns.forEach(run => {
+        eventsFor(run).filter(e => types.includes(e.type)).forEach(e => {
+            annotations[`ev${n++}`] = {
+                type: 'line',
+                xMin: e.sol,
+                xMax: e.sol,
+                borderColor: colorFor(run),
+                borderWidth: 1,
+                borderDash: [4, 3],
+                label: {
+                    display: true,
+                    content: e.label,
+                    position: 'start',
+                    font: { size: 9 },
+                    color: colorFor(run),
+                    backgroundColor: 'rgba(0,0,0,0.6)',
+                },
+            };
+        });
+    });
+    return annotations;
+}
+
 function render() {
     const activeRuns = [...selected].map(idx => RUNS[idx]).filter(Boolean);
+    const annotations = annotationsFor(activeRuns);
 
     chartDefs.forEach(def => {
         const chart = charts[def.field];
@@ -184,8 +271,13 @@ function render() {
             pointRadius: 0,
             tension: 0.15,
         }));
+        if (chart.options.plugins.annotation) {
+            chart.options.plugins.annotation.annotations = annotations;
+        }
         chart.update();
     });
+
+    renderLogSelect(activeRuns);
 
     const body = document.getElementById('pd-summary-body');
     if (!body) return;
@@ -208,6 +300,40 @@ function render() {
         </tr>`;
     }).join('');
 }
+
+// ── Log panel ────────────────────────────────────────────────────────────
+const logSelect = document.getElementById('pd-log-run-select');
+const logBody = document.getElementById('pd-log-body');
+
+function renderLogSelect(activeRuns) {
+    if (!logSelect) return;
+    const prevValue = logSelect.value;
+    logSelect.innerHTML = activeRuns.map((run, i) => `<option value="${i}">${runLabel(run)}</option>`).join('');
+    const restoreIdx = [...logSelect.options].findIndex(o => o.value === prevValue);
+    logSelect.selectedIndex = restoreIdx >= 0 ? restoreIdx : 0;
+    renderLogTable(activeRuns[logSelect.selectedIndex] ?? null);
+}
+
+function renderLogTable(run) {
+    if (!logBody) return;
+    if (!run || !run.log || run.log.length === 0) {
+        logBody.innerHTML = '<tr><td colspan="3" class="pd-empty">Kein Log in diesem Report (ältere Reports vor 2026-08-17 haben keins).</td></tr>';
+        return;
+    }
+    logBody.innerHTML = run.log.map(entry => `<tr class="${entry.ok ? 'pd-log-ok' : 'pd-log-error'}">
+        <td>${entry.sol}</td>
+        <td>${entry.rule}</td>
+        <td>${entry.ok ? 'OK' : (entry.error || 'error')}</td>
+    </tr>`).join('');
+}
+
+logSelect?.addEventListener('change', () => {
+    const activeRuns = [...selected].map(idx => RUNS[idx]).filter(Boolean);
+    renderLogTable(activeRuns[logSelect.selectedIndex] ?? null);
+});
+
+document.getElementById('pd-event-cc')?.addEventListener('change', render);
+document.getElementById('pd-event-advisor')?.addEventListener('change', render);
 
 render();
 </script>


### PR DESCRIPTION
## Summary
- `RunReport::build()` schreibt jetzt den vollen rohen Aktions-Log (Sol/Regel/OK/Error) ins JSON-Report — bisher nur aggregierte Rejection-Zähler.
- Dashboard: Aktions-Log-Panel pro Lauf (Dropdown, OK/error farbcodiert), plus zwei zuschaltbare Ereignis-Marker ("CC-Level-Aufstieg", "Berater angestellt"), abgeleitet aus den bestehenden `sols[]`-Snapshots, als vertikale annotierte Linien in allen 5 Charts (`chartjs-plugin-annotation` via CDN).

## Test plan
- [x] TDD: Assertion in `PlaytestBotTest` zuerst rot (Undefined array key "log"), dann grün nach Implementierung
- [x] `php bin/phpunit` — 1020/1020 grün
- [x] Playwright-Screenshot-Verifikation: Marker rendern korrekt, Log-Panel füllt sich, Toggle an/aus funktioniert, keine Browser-Console-Errors

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9