### PR TITLE
chore: Playtest-Dashboard 3-Spalten-Layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix: `tools/playtest-dashboard.php` — Chart-Linien/Sidebar-Swatches färbten alle Läufe eines Profils identisch (`colorFor()` keyte auf Profilname statt Lauf), Mehrfachvergleich damit unlesbar. Färbt jetzt pro Lauf (Profil+Seed+Datei).
 - Perf: `game:playtest`s gespawnte `bin/phpunit`-Kindprozesse laufen jetzt mit `-d opcache.enable_cli=1` — `--concurrency=5` überschritt vorher zuverlässig das 120s-Pool-Timeout, läuft jetzt in ~88s durch.
 - Feature: PlaytestBot-Reports tragen jetzt den vollen Aktions-Log (Sol/Regel/OK/Error), nicht mehr nur aggregierte Rejection-Zähler. Dashboard zeigt ihn pro Lauf an + zwei zuschaltbare Ereignis-Marker (CC-Level-Aufstieg, Berater angestellt) als Linien in allen Charts.
+- Chore: `tools/playtest-dashboard.php` auf 3-Spalten-Layout umgestellt (Läufe | Charts gestapelt | Aktions-Log), jede Spalte eigenständig scrollbar über volle Viewport-Höhe.
 
 ## 2026-08-16
 

--- a/tools/assets/dev-panel.css
+++ b/tools/assets/dev-panel.css
@@ -633,12 +633,14 @@ table.hs-matrix .col-active {
 
 .pd-main {
     flex: 1;
+    min-width: 0;
     padding: 1.2rem;
     overflow-y: auto;
+    max-height: calc(100vh - 52px);
 }
-.pd-chart-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+.pd-chart-stack {
+    display: flex;
+    flex-direction: column;
     gap: 1rem;
     margin-bottom: 1.5rem;
 }
@@ -708,17 +710,22 @@ table.pd-summary tr:hover td {
     cursor: pointer;
 }
 
-.pd-log-card {
+.pd-log-panel {
+    width: 340px;
+    flex-shrink: 0;
     background: #161625;
-    border: 1px solid #252535;
-    border-radius: 6px;
-    padding: 0.8rem;
-    margin-top: 1.5rem;
+    border-left: 1px solid #252535;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 52px);
+    overflow: hidden;
 }
 .pd-log-header {
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.4rem;
     margin-bottom: 0.5rem;
 }
 .pd-log-header h3 {
@@ -736,8 +743,9 @@ table.pd-summary tr:hover td {
     font-size: 0.76rem;
 }
 .pd-log-scroll {
-    max-height: 320px;
+    flex: 1;
     overflow-y: auto;
+    min-height: 0;
 }
 table.pd-log-table {
     border-collapse: collapse;

--- a/tools/playtest-dashboard.php
+++ b/tools/playtest-dashboard.php
@@ -77,7 +77,7 @@ if (is_dir($reportDir)) {
             <label><input type="checkbox" id="pd-event-advisor" checked> Berater angestellt</label>
         </div>
 
-        <div class="pd-chart-grid">
+        <div class="pd-chart-stack">
             <div class="pd-chart-card"><h3>Regolith</h3><canvas id="chart-regolith"></canvas></div>
             <div class="pd-chart-card"><h3>Credits</h3><canvas id="chart-credits"></canvas></div>
             <div class="pd-chart-card"><h3>AP (verfügbar)</h3><canvas id="chart-ap"></canvas></div>
@@ -91,18 +91,18 @@ if (is_dir($reportDir)) {
             </thead>
             <tbody id="pd-summary-body"></tbody>
         </table>
+    </div>
 
-        <div class="pd-log-card">
-            <div class="pd-log-header">
-                <h3>Aktions-Log</h3>
-                <select id="pd-log-run-select"></select>
-            </div>
-            <div class="pd-log-scroll">
-                <table class="pd-log-table">
-                    <thead><tr><th>Sol</th><th>Aktion</th><th>Status</th></tr></thead>
-                    <tbody id="pd-log-body"></tbody>
-                </table>
-            </div>
+    <div class="pd-log-panel">
+        <div class="pd-log-header">
+            <h3>Aktions-Log</h3>
+            <select id="pd-log-run-select"></select>
+        </div>
+        <div class="pd-log-scroll">
+            <table class="pd-log-table">
+                <thead><tr><th>Sol</th><th>Aktion</th><th>Status</th></tr></thead>
+                <tbody id="pd-log-body"></tbody>
+            </table>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Sidebar | Charts (gestapelt, eine Spalte) | Aktions-Log — jede Spalte eigenständig scrollbar, volle Viewport-Höhe, statt Log gequetscht unterhalb von Chart-Grid + Summary-Tabelle.

## Test plan
- [x] Playwright-Screenshot: Layout rendert korrekt, keine Console-Errors, Log-Panel + Marker funktionieren weiterhin

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9