### PR TITLE
feat: Organika-Tracking + Dashboard-Chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Balance: 4 Phase-2-Objectives verschärft (`task_credit_reserve` Streak 10→14 + Schwelle 3000→4000, `task_self_sufficiency` Streak 8→15 + Organika-Schwelle 50→75, `task_engineering_output` 200→320) — ein 20-Läufe-Batch zeigte Läufe, die viel zu früh (Sol 39-54 statt angepeilt 80-85) "completed" gingen, weil diese Tasks nebenbei durch normales Spielen erfüllt wurden. `task_expedition_coverage` bleibt bei 16 (bereits am mathematischen Maximum erreichbarer Zone-Tiles). `task_colony_prosperity` (Vertrauen>70) unverändert — vermutlich Trust-Ökonomie-Kalibrierungsproblem, eigenes Ticket.
 - Fix: PlaytestBot stellte nie mehr als 3 Berater ein (hardcoded Deckel in `BotStrategy::nextHireCandidate()`), obwohl 4 Slots existieren (`config('game.advisor.max_slots')`) — verfälschte mid/lategame-AP in jedem bisherigen Report nach unten. Liest jetzt den Config-Wert statt der Magic-3.
 - Chore: `game:playtest`s Kindprozess-Timeout 120s→240s — der gelöste Berater-Deckel + verschärfte Objectives bedeuten mehr AP und mehr Bot-Aktionen pro Sol, ein einzelner Lauf ohne jede Concurrency-Konkurrenz überschritt danach bereits die alte Grenze.
+- Feature: PlaytestBot-Reports tracken jetzt Organika pro Sol (bisher nur Regolith, obwohl beide über Corvans Bar-Offers verkaufbar sind) — eigenes Dashboard-Chart.
 
 ## 2026-08-16
 

--- a/tests/Feature/Playtest/BotStrategy.php
+++ b/tests/Feature/Playtest/BotStrategy.php
@@ -18,6 +18,8 @@ class BotStrategy
 {
     private const RES_REGOLITH = 3;
 
+    private const RES_ORGANICS = 5;
+
     private const RES_CREDITS = 1;
 
     // Engineer -> Scientist -> Pilot -> Trader: matches the sciencelab/hangar/bar
@@ -243,6 +245,15 @@ class BotStrategy
         return (int) (DB::table('colony_resources')
             ->where('colony_id', $b->colonyId)
             ->where('resource_id', self::RES_REGOLITH)
+            ->value('amount') ?? 0);
+    }
+
+    /** Shared with RunReport — the single source for this lookup. */
+    public static function organics(BotSession $b): int
+    {
+        return (int) (DB::table('colony_resources')
+            ->where('colony_id', $b->colonyId)
+            ->where('resource_id', self::RES_ORGANICS)
             ->value('amount') ?? 0);
     }
 

--- a/tests/Feature/Playtest/PlaytestBotTest.php
+++ b/tests/Feature/Playtest/PlaytestBotTest.php
@@ -49,6 +49,11 @@ class PlaytestBotTest extends TestCase
         // sol/rule/ok/error per action — not just the aggregated rejection
         // counts, so the report must carry it through unchanged.
         $this->assertSame($bot->log, $data['log'], 'Report must include the full raw action log for dashboard event markers');
+
+        // Organics wasn't tracked per-Sol at all (2026-08-17, Owner dashboard
+        // review) — only Regolith was, even though both are sellable via
+        // Corvan's bar offers.
+        $this->assertArrayHasKey('organics', $data['sols'][0], 'Each Sol snapshot must include organics for the dashboard chart');
     }
 
     /**

--- a/tests/Feature/Playtest/RunReport.php
+++ b/tests/Feature/Playtest/RunReport.php
@@ -43,6 +43,7 @@ class RunReport
             'trust' => app(TrustService::class)->getTrust($colonyId),
             'credits' => BotStrategy::credits($bot),
             'regolith' => BotStrategy::regolith($bot),
+            'organics' => BotStrategy::organics($bot),
             'ap' => ['total' => $apAvailable],
             'ap_unspent' => $apAvailable,
             'cc_level' => $ccLevel,

--- a/tools/playtest-dashboard.php
+++ b/tools/playtest-dashboard.php
@@ -79,6 +79,7 @@ if (is_dir($reportDir)) {
 
         <div class="pd-chart-stack">
             <div class="pd-chart-card"><h3>Regolith</h3><canvas id="chart-regolith"></canvas></div>
+            <div class="pd-chart-card"><h3>Organika</h3><canvas id="chart-organics"></canvas></div>
             <div class="pd-chart-card"><h3>Credits</h3><canvas id="chart-credits"></canvas></div>
             <div class="pd-chart-card"><h3>AP (verfügbar)</h3><canvas id="chart-ap"></canvas></div>
             <div class="pd-chart-card"><h3>Vertrauen</h3><canvas id="chart-trust"></canvas></div>
@@ -192,6 +193,7 @@ if (window['chartjs-plugin-annotation']) {
 // ── Charts ───────────────────────────────────────────────────────────────
 const chartDefs = [
     { id: 'chart-regolith', field: 'regolith' },
+    { id: 'chart-organics', field: 'organics' },
     { id: 'chart-credits', field: 'credits' },
     { id: 'chart-ap', field: 'ap_unspent' },
     { id: 'chart-trust', field: 'trust' },


### PR DESCRIPTION
## Summary
- RunReport::snapshot() trackt jetzt Organika pro Sol (bisher nur Regolith, obwohl beide über Corvans Bar-Offers verkaufbar sind) — Dashboard bekommt ein passendes Chart.

## Test plan
- [x] TDD: Assertion rot vor der Implementierung, grün danach
- [x] php bin/phpunit — 1022/1022 grün

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9