### PR TITLE
balance: Missions-Credits + Regolith-Ertrag erhöht, Bot-Verkaufspriorisierung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix: PlaytestBot stellte nie mehr als 3 Berater ein (hardcoded Deckel in `BotStrategy::nextHireCandidate()`), obwohl 4 Slots existieren (`config('game.advisor.max_slots')`) — verfälschte mid/lategame-AP in jedem bisherigen Report nach unten. Liest jetzt den Config-Wert statt der Magic-3.
 - Chore: `game:playtest`s Kindprozess-Timeout 120s→240s — der gelöste Berater-Deckel + verschärfte Objectives bedeuten mehr AP und mehr Bot-Aktionen pro Sol, ein einzelner Lauf ohne jede Concurrency-Konkurrenz überschritt danach bereits die alte Grenze.
 - Feature: PlaytestBot-Reports tracken jetzt Organika pro Sol (bisher nur Regolith, obwohl beide über Corvans Bar-Offers verkaufbar sind) — eigenes Dashboard-Chart.
+- Balance: Missions-Credit-Belohnungen +40-45% (lagen effektiv unter dem passiven Einkommenssockel), Regolith-Ertrag +25-30% (`regolith_rich/normal/poor` 24/18/12 → 30/23/15) — PlaytestBot-Daten zeigten chronischen Mangel bei beiden Ressourcen. PlaytestBot priorisiert jetzt Credits-Verkaufsangebote statt wahllos das erste verfügbare Bar-Angebot zu akzeptieren. Regolith bleibt bewusst NICHT verkaufbar (GDD §4b, freigegeben 2026-08-05: Knappheitsordnung sieht Regolith als die Ressource, die verfügbar bleiben soll, nicht als Handelsware — Owner hat diese Linie 2026-08-17 bestätigt statt sie zu kippen).
 
 ## 2026-08-16
 

--- a/config/game.php
+++ b/config/game.php
@@ -91,10 +91,15 @@ return [
     // (relocation is player-triggered, not automatic). ColonyTileService reads the
     // same resource_max map so tile seeding and production can't drift apart.
     'harvester' => [
+        // +25-30% (2026-08-17, game-designer review): PlaytestBot data showed
+        // Regolith crashing to 0-30 within the first 7-10 Sole in most runs —
+        // not enough surplus over build/repair/CC-upgrade consumption to ever
+        // consider selling it. Moderate bump, not a doubling — the depletion/
+        // relocation decision (GDD §4c) still has to matter.
         'fresh_yield' => [
-            'regolith_rich' => 24,
-            'regolith_normal' => 18,
-            'regolith_poor' => 12,
+            'regolith_rich' => 30,
+            'regolith_normal' => 23,
+            'regolith_poor' => 15,
         ],
         'resource_max' => [
             'regolith_rich' => 500,

--- a/config/missions.php
+++ b/config/missions.php
@@ -41,7 +41,10 @@ return [
             'ships' => ['drone'],
             'sol_distance' => 1,
             'requires' => [],
-            'reward' => ['credits' => 60],
+            // 60 → 90 (2026-08-17, game-designer review): effective Cr/Tick of the
+            // active mission schedule sat below the passive income floor
+            // (nexus_subsidy + relay bonus) — not worth the ship/Nav-AP cost.
+            'reward' => ['credits' => 90],
             'repeatable' => true,
         ],
         'mission_recon_flight' => [
@@ -78,8 +81,10 @@ return [
             'ships' => ['drone'],
             'sol_distance' => 5,
             'requires' => ['knowledge' => ['cartography' => 3]],
+            // Credits option 250-400 → 350-550 (2026-08-17, game-designer review),
+            // see mission_courier_run comment.
             'reward' => ['loot_table' => [
-                ['credits' => [250, 400]],
+                ['credits' => [350, 550]],
                 ['compounds' => [8, 12]],
                 ['regolith' => [30, 45]],
             ]],
@@ -99,7 +104,8 @@ return [
             'ships' => ['freighter'],
             'sol_distance' => 3,
             'requires' => ['knowledge' => ['trade' => 1]],
-            'reward' => ['credits' => 180, 'trust_event' => 'trade_success'],
+            // 180 → 260 (2026-08-17), see mission_courier_run comment.
+            'reward' => ['credits' => 260, 'trust_event' => 'trade_success'],
             'repeatable' => true,
         ],
         'mission_aid_transport' => [
@@ -107,7 +113,8 @@ return [
             'sol_distance' => 2,
             'requires' => [], // ungegatet (Stufe 1b) — schließt Pfad-B-Vertrauenslücke, war zuvor an knowledge.health Lv1 gegatet
             'extra_cost' => ['organics' => 10], // aid cargo, on top of provisions
-            'reward' => ['credits' => 60, 'trust_event' => 'encounter_won'],
+            // 60 → 90 (2026-08-17), see mission_courier_run comment.
+            'reward' => ['credits' => 90, 'trust_event' => 'encounter_won'],
             'repeatable' => true,
         ],
 
@@ -126,7 +133,8 @@ return [
             'requires' => ['target' => 'ruin_tile'],
             'target_type' => 'ruin_tile',
             // almanac_unlock reward follows once §17 (Almanach) is implemented
-            'reward' => ['credits' => 150],
+            // 150 → 220 (2026-08-17), see mission_courier_run comment.
+            'reward' => ['credits' => 220],
             'repeatable' => false, // once per revealed ruin tile
         ],
 
@@ -152,7 +160,8 @@ return [
             'ships' => ['corvette'],
             'sol_distance' => 3,
             'requires' => [],
-            'reward' => ['credits' => 200],
+            // 200 → 280 (2026-08-17), see mission_courier_run comment.
+            'reward' => ['credits' => 280],
             'repeatable' => true,
         ],
 

--- a/lang/de/missions.php
+++ b/lang/de/missions.php
@@ -5,7 +5,7 @@ return [
 
     'mission_courier_run_name' => 'Botenflug',
     'mission_courier_run_desc' => 'Die Drohne trägt Datenpakete und Post zum nächsten Relais — kleine Fracht, aber da draußen zahlt jemand gut dafür, verbunden zu bleiben.',
-    'mission_courier_run_reward' => '60 Credits',
+    'mission_courier_run_reward' => '90 Credits',
 
     'mission_recon_flight_name' => 'Erkundungsflug',
     'mission_recon_flight_desc' => 'Die Drohne zieht ihre Bahnen über unkartiertem Gelände und funkt zurück, was hinter dem Horizont liegt.',
@@ -33,11 +33,11 @@ return [
 
     'mission_trade_convoy_name' => 'Handelsfahrt',
     'mission_trade_convoy_desc' => 'Beladen mit allem, was sich entbehren lässt, fährt der Frachter die Handelsroute — und die Kolonisten sehen gern, wenn er schwer zurückkehrt.',
-    'mission_trade_convoy_reward' => '180 Credits + Vertrauen',
+    'mission_trade_convoy_reward' => '260 Credits + Vertrauen',
 
     'mission_aid_transport_name' => 'Hilfsgütertransport',
     'mission_aid_transport_desc' => 'Irgendwo geht es einer Station schlechter als uns — der Frachter bringt Organika hinaus, und die Kolonie weiß wieder, wofür sie arbeitet.',
-    'mission_aid_transport_reward' => '60 Credits + Vertrauen',
+    'mission_aid_transport_reward' => '90 Credits + Vertrauen',
 
     'mission_salvage_sweep_name' => 'Trümmerbergung',
     'mission_salvage_sweep_desc' => 'In den Wrackfeldern liegt, was die Kolonie selbst nicht herstellen kann — die Bergungscrew schneidet heraus, was noch taugt.',
@@ -45,7 +45,7 @@ return [
 
     'mission_ruin_expedition_name' => 'Ruinen-Expedition',
     'mission_ruin_expedition_desc' => 'Wer die Ruine hinterlassen hat, ist lange fort — aber was zwischen ihren Wänden liegt, ist eine Expedition wert.',
-    'mission_ruin_expedition_reward' => '150 Credits',
+    'mission_ruin_expedition_reward' => '220 Credits',
 
     // TODO(content-writer): Platzhalter, GDD §4c "Harvester-Zweitinstanz: Bezugsquelle"
     // Weg B (freigegeben 2026-08-05) — narrative Rahmung folgt (havarierte Förderanlage
@@ -56,7 +56,7 @@ return [
 
     'mission_escort_convoy_name' => 'Konvoi-Begleitung',
     'mission_escort_convoy_desc' => 'Die Korvette begleitet einen fremden Konvoi durch unwegsames Gelände — meist reicht schon ihre Silhouette am Himmel, damit nichts passiert.',
-    'mission_escort_convoy_reward' => '200 Credits',
+    'mission_escort_convoy_reward' => '280 Credits',
 
     // ── Dispatch dialog ──────────────────────────────────────────────────────
 

--- a/lang/en/missions.php
+++ b/lang/en/missions.php
@@ -5,7 +5,7 @@ return [
 
     'mission_courier_run_name' => 'Courier Run',
     'mission_courier_run_desc' => 'The drone carries data packets and mail to the nearest relay — small cargo, but out here someone pays well to stay connected.',
-    'mission_courier_run_reward' => '60 Credits',
+    'mission_courier_run_reward' => '90 Credits',
 
     'mission_recon_flight_name' => 'Recon Flight',
     'mission_recon_flight_desc' => 'The drone sweeps across uncharted terrain, radioing back what lies beyond the horizon.',
@@ -33,11 +33,11 @@ return [
 
     'mission_trade_convoy_name' => 'Trade Convoy',
     'mission_trade_convoy_desc' => 'Loaded with everything the colony can spare, the freighter runs the trade route — and everyone likes to see it come back heavy.',
-    'mission_trade_convoy_reward' => '180 Credits + Trust',
+    'mission_trade_convoy_reward' => '260 Credits + Trust',
 
     'mission_aid_transport_name' => 'Aid Transport',
     'mission_aid_transport_desc' => 'Somewhere a station is worse off than we are — the freighter carries organics out, and the colony remembers what it works for.',
-    'mission_aid_transport_reward' => '60 Credits + Trust',
+    'mission_aid_transport_reward' => '90 Credits + Trust',
 
     'mission_salvage_sweep_name' => 'Salvage Sweep',
     'mission_salvage_sweep_desc' => 'The wreck fields hold what the colony cannot make itself — the salvage crew cuts loose whatever is still good.',
@@ -45,11 +45,11 @@ return [
 
     'mission_ruin_expedition_name' => 'Ruin Expedition',
     'mission_ruin_expedition_desc' => 'Whoever left the ruin is long gone — but what lies between its walls is worth an expedition.',
-    'mission_ruin_expedition_reward' => '150 Credits',
+    'mission_ruin_expedition_reward' => '220 Credits',
 
     'mission_escort_convoy_name' => 'Convoy Escort',
     'mission_escort_convoy_desc' => 'The corvette shadows a convoy through rough country — most days nothing happens, and that is exactly the point.',
-    'mission_escort_convoy_reward' => '200 Credits',
+    'mission_escort_convoy_reward' => '280 Credits',
 
     // ── Dispatch dialog ──────────────────────────────────────────────────────
 

--- a/tests/Feature/GameTick/GameTickResourceGenerationTest.php
+++ b/tests/Feature/GameTick/GameTickResourceGenerationTest.php
@@ -108,7 +108,7 @@ class GameTickResourceGenerationTest extends TestCase
 
     /**
      * Places the Harvester (instance 1) on a fresh regolith_normal tile
-     * (fresh_yield 18, resource_max 300) — the fixture's default harvester
+     * (fresh_yield 23, resource_max 300) — the fixture's default harvester
      * row has no tile_x/tile_y, so production requires explicit placement
      * under the §4c depletion mechanic.
      */
@@ -141,7 +141,7 @@ class GameTickResourceGenerationTest extends TestCase
 
     /**
      * Harvester placed on a full-reserve regolith_normal tile produces exactly
-     * its fresh value (18) per tick at neutral trust — GDD §4c.
+     * its fresh value (23) per tick at neutral trust — GDD §4c.
      */
     public function test_harvester_generates_regolith_from_placed_tile(): void
     {
@@ -151,8 +151,8 @@ class GameTickResourceGenerationTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11200]);
 
         $after = $this->getColonyResource(self::RES_REGOLITH);
-        $this->assertEquals($before + 18, $after,
-            'Harvester on a full-reserve regolith_normal tile must produce exactly 18 Regolith per tick');
+        $this->assertEquals($before + 23, $after,
+            'Harvester on a full-reserve regolith_normal tile must produce exactly 23 Regolith per tick');
     }
 
     /**
@@ -196,8 +196,8 @@ class GameTickResourceGenerationTest extends TestCase
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
         $organics = $this->getColonyResource(self::RES_ORGANICS);
 
-        // harvester on full-reserve regolith_normal tile → 18 Regolith; bioFacility level 1 → 8 Organics
-        $this->assertEquals(18, $regolith, 'Harvester on full-reserve regolith_normal tile must produce 18 Regolith');
+        // harvester on full-reserve regolith_normal tile → 23 Regolith; bioFacility level 1 → 8 Organics
+        $this->assertEquals(23, $regolith, 'Harvester on full-reserve regolith_normal tile must produce 23 Regolith');
         $this->assertEquals(8, $organics, 'BioFacility level 1 must produce 8 Organics');
     }
 
@@ -247,14 +247,14 @@ class GameTickResourceGenerationTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11211]);
 
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
-        $this->assertEquals(18, $regolith, 'Yield must stay at the tile fresh value regardless of the stored level');
+        $this->assertEquals(23, $regolith, 'Yield must stay at the tile fresh value regardless of the stored level');
     }
 
     // ── Trust multiplier interaction ────────────────────────────────────────────
 
     /**
      * High trust (>60) applies a 1.20× production multiplier.
-     * harvester fresh yield 18 × 1.20 = round(21.6) = 22.
+     * harvester fresh yield 23 × 1.20 = round(27.6) = 28.
      */
     public function test_high_trust_applies_production_bonus(): void
     {
@@ -276,14 +276,14 @@ class GameTickResourceGenerationTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11220]);
 
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
-        // fresh yield 18; yield = round(18 × 1.20) = 22
-        $this->assertEquals(22, $regolith,
-            'Production at trust=75 must apply 1.20× multiplier → 22 Regolith');
+        // fresh yield 23; yield = round(23 × 1.20) = 28
+        $this->assertEquals(28, $regolith,
+            'Production at trust=75 must apply 1.20× multiplier → 28 Regolith');
     }
 
     /**
      * Low trust (<-60) applies a 0.70× production penalty.
-     * harvester fresh yield 18 × 0.70 = round(12.6) = 13.
+     * harvester fresh yield 23 × 0.70 = round(16.1) = 16.
      */
     public function test_low_trust_applies_production_penalty(): void
     {
@@ -305,9 +305,9 @@ class GameTickResourceGenerationTest extends TestCase
         Artisan::call('game:tick', ['--tick' => 11221]);
 
         $regolith = $this->getColonyResource(self::RES_REGOLITH);
-        // fresh yield 18; yield = round(18 × 0.70) = 13
-        $this->assertEquals(13, $regolith,
-            'Production at trust=-80 must apply 0.70× penalty → 13 Regolith');
+        // fresh yield 23; yield = round(23 × 0.70) = 16
+        $this->assertEquals(16, $regolith,
+            'Production at trust=-80 must apply 0.70× penalty → 16 Regolith');
     }
 
     // ── agronomy Kenntnis bonus ──────────────────────────────────────────────

--- a/tests/Feature/GameTick/HarvesterDepletionTest.php
+++ b/tests/Feature/GameTick/HarvesterDepletionTest.php
@@ -94,14 +94,14 @@ class HarvesterDepletionTest extends TestCase
 
     public function test_harvester_yield_at_full_reserves_equals_fresh_value(): void
     {
-        // regolith_normal: fresh 18, resource_max 300, remaining 300 → ratio 1.0 → 18.
-        $this->assertSame(18, GameTick::harvesterYield('regolith_normal', 300, 300, 0));
+        // regolith_normal: fresh 23, resource_max 300, remaining 300 → ratio 1.0 → 23.
+        $this->assertSame(23, GameTick::harvesterYield('regolith_normal', 300, 300, 0));
     }
 
     public function test_harvester_yield_near_depletion_approaches_half_fresh_value(): void
     {
-        // remaining=10/300 → ratio ~0.033 → 18*(0.5+0.5*0.033) ≈ 9.3 → round 9.
-        $this->assertSame(9, GameTick::harvesterYield('regolith_normal', 10, 300, 0));
+        // remaining=10/300 → ratio ~0.033 → 23*(0.5+0.5*0.033) ≈ 11.88 → round 12.
+        $this->assertSame(12, GameTick::harvesterYield('regolith_normal', 10, 300, 0));
     }
 
     public function test_harvester_yield_is_zero_when_exhausted(): void
@@ -113,7 +113,7 @@ class HarvesterDepletionTest extends TestCase
     {
         // Legacy tile with resource_amount > resource_max (pre-2026-08-03 seed) — ratio
         // clamps at 1.0, never exceeds the fresh value.
-        $this->assertSame(18, GameTick::harvesterYield('regolith_normal', 500, 300, 0));
+        $this->assertSame(23, GameTick::harvesterYield('regolith_normal', 500, 300, 0));
     }
 
     // ── Teil A — integration via game:tick ──────────────────────────────────
@@ -122,8 +122,8 @@ class HarvesterDepletionTest extends TestCase
     {
         Artisan::call('game:tick', ['--tick' => 20001]);
 
-        $this->assertSame(18, $this->regolithAmount());
-        $this->assertSame(300 - 18, $this->tileRemaining());
+        $this->assertSame(23, $this->regolithAmount());
+        $this->assertSame(300 - 23, $this->tileRemaining());
     }
 
     public function test_tick_credits_reduced_yield_near_depletion(): void
@@ -134,8 +134,8 @@ class HarvesterDepletionTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 20002]);
 
-        $this->assertSame(9, $this->regolithAmount());
-        $this->assertSame(1, $this->tileRemaining());
+        $this->assertSame(12, $this->regolithAmount());
+        $this->assertSame(0, $this->tileRemaining(), 'yield (12) exceeds remaining (10) — clamps to 0, never negative');
     }
 
     public function test_tick_credits_nothing_once_tile_exhausted(): void
@@ -159,7 +159,7 @@ class HarvesterDepletionTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 20004]);
 
-        $this->assertSame(18, $this->regolithAmount(), 'yield must not exceed fresh value even with a stale over-cap remaining');
+        $this->assertSame(23, $this->regolithAmount(), 'yield must not exceed fresh value even with a stale over-cap remaining');
         $this->assertSame(
             300,
             (int) DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->where('q', 3)->where('r', 0)->value('resource_max'),
@@ -171,12 +171,12 @@ class HarvesterDepletionTest extends TestCase
 
     public function test_harvester_yield_pure_function_adds_geology_bonus(): void
     {
-        $this->assertSame(18 + 3, GameTick::harvesterYield('regolith_normal', 300, 300, 1));
-        $this->assertSame(18 + 6, GameTick::harvesterYield('regolith_normal', 300, 300, 2));
-        $this->assertSame(18 + 8, GameTick::harvesterYield('regolith_normal', 300, 300, 3));
-        $this->assertSame(18 + 12, GameTick::harvesterYield('regolith_normal', 300, 300, 5));
+        $this->assertSame(23 + 3, GameTick::harvesterYield('regolith_normal', 300, 300, 1));
+        $this->assertSame(23 + 6, GameTick::harvesterYield('regolith_normal', 300, 300, 2));
+        $this->assertSame(23 + 8, GameTick::harvesterYield('regolith_normal', 300, 300, 3));
+        $this->assertSame(23 + 12, GameTick::harvesterYield('regolith_normal', 300, 300, 5));
         // Cap: level beyond the configured curve does not add further bonus.
-        $this->assertSame(18 + 12, GameTick::harvesterYield('regolith_normal', 300, 300, 99));
+        $this->assertSame(23 + 12, GameTick::harvesterYield('regolith_normal', 300, 300, 99));
     }
 
     public function test_tick_applies_geology_bonus_once_per_colony_not_per_instance(): void
@@ -186,7 +186,7 @@ class HarvesterDepletionTest extends TestCase
             ['level' => 2, 'status_points' => 20, 'ap_spend' => 0]
         );
 
-        // Second Harvester instance on a regolith_poor tile (fresh 12, max 160).
+        // Second Harvester instance on a regolith_poor tile (fresh 15, max 160).
         DB::table('colony_tiles')->where('colony_id', self::COLONY_ID)->where('q', -3)->where('r', 0)->delete();
         DB::table('colony_tiles')->insert([
             'colony_id' => self::COLONY_ID, 'q' => -3, 'r' => 0, 'ring' => 3,
@@ -200,10 +200,10 @@ class HarvesterDepletionTest extends TestCase
 
         Artisan::call('game:tick', ['--tick' => 20005]);
 
-        // Without any bonus: 18 (normal, instance 1) + 12 (poor, instance 2) = 30.
-        // Geology level 2 bonus is +6 applied ONCE per colony → 36 total.
-        // (If it were applied per instance instead, the total would be 30 + 12 = 42.)
-        $this->assertSame(36, $this->regolithAmount());
+        // Without any bonus: 23 (normal, instance 1) + 15 (poor, instance 2) = 38.
+        // Geology level 2 bonus is +6 applied ONCE per colony → 44 total.
+        // (If it were applied per instance instead, the total would be 38 + 12 = 50.)
+        $this->assertSame(44, $this->regolithAmount());
     }
 
     public function test_geology_bonus_not_credited_when_no_harvester_active(): void

--- a/tests/Feature/Hangar/HangarMissionResolutionTest.php
+++ b/tests/Feature/Hangar/HangarMissionResolutionTest.php
@@ -160,7 +160,7 @@ class HangarMissionResolutionTest extends TestCase
         $this->assertNotNull($log);
         $params = json_decode($log->parameters, true);
         $this->assertSame('mission_courier_run', $params['mission_key']);
-        $this->assertSame(60, $params['rewards']['credits']);
+        $this->assertSame(90, $params['rewards']['credits']);
     }
 
     public function test_completion_does_not_fire_before_return_tick(): void

--- a/tests/Feature/Playtest/BotStrategy.php
+++ b/tests/Feature/Playtest/BotStrategy.php
@@ -584,6 +584,13 @@ class BotStrategy
      * still be able to earn credits, just not spend them (qa-tester finding: the
      * old whole-rule guard also blocked income, exactly when the bot needed
      * credits most).
+     *
+     * Even when not guard-blocked, a credit-income offer is preferred over any
+     * other available offer that Sol (2026-08-17, Owner review: the bot picked
+     * whichever offer happened to have the lowest id, never weighing whether
+     * selling a resource for Credits was worth prioritizing over spending
+     * them) — the bot otherwise has no reason to prefer earning over spending,
+     * and chronic Credit shortage was a top playtest finding.
      */
     private static function barOfferCandidate(BotSession $b, bool $guardBlocks = false): ?object
     {
@@ -603,6 +610,7 @@ class BotStrategy
             ->where('expires_tick', '>', $tick)
             ->where('is_accepted', false)
             ->when($guardBlocks, fn ($q) => $q->where('get_resource_id', self::RES_CREDITS))
+            ->orderByRaw('CASE WHEN get_resource_id = ? THEN 0 ELSE 1 END', [self::RES_CREDITS])
             ->orderBy('id')
             ->first();
     }


### PR DESCRIPTION
## Summary
- Missions-Credit-Belohnungen +40-45% (lagen effektiv unter dem passiven Einkommenssockel) — mission_courier_run 60→90, mission_trade_convoy 180→260, mission_aid_transport 60→90, mission_escort_convoy 200→280, mission_ruin_expedition 150→220, mission_long_range_expedition Credits-Loot 250-400→350-550.
- Regolith-Ertrag +25-30% (`regolith_rich/normal/poor` 24/18/12 → 30/23/15) — PlaytestBot zeigte Regolith-Absturz auf 0-30 in den ersten 7-10 Solen der meisten Läufe.
- PlaytestBot priorisiert jetzt Credits-Verkaufsangebote statt wahllos das erste verfügbare Bar-Angebot (`barOfferCandidate()`).
- **Bewusst NICHT geändert:** Regolith bleibt nicht verkaufbar. GDD §4b hat einen Regolith-Verkaufskanal bereits geprüft und verworfen (Knappheitsordnung: Regolith soll verfügbar bleiben, nicht Handelsware werden). Owner hat diese Linie explizit bestätigt (AskUserQuestion), statt sie zu kippen.

## Test plan
- [x] Alle betroffenen Tests (Harvester-Yield-Formel, Missions-Reward-Assertion) auf neue Werte aktualisiert
- [x] `php bin/phpunit` — 1022/1022 grün
- [x] Standard-Playtest-Seed 4242 wechselt von `failed (time_limit)` zu `completed` bei Sol 61, `resource_limit`-Rejections deutlich gesunken

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9