### PR TITLE
balance: Berater-Unterhalt gesenkt, Relay-Bonus erhöht + Doku-Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-08-18
+
+- Balance: `advisor.upkeep[3]` 50→35, `credits.relay_bonus_per_uplink_level` 35→45 — die zwei am 2026-08-17 durchgerechneten, kleinen Fixes gegen die Credits-Pfad-Lücke (4×Rang3-Unterhalt 200→140 Cr/Tick, pfadneutraler zweiter Hebel für Nicht-Cantina-Läufe).
+- Fix: `merchant.items.information.label` hieß noch "Systemkarte vollständig" (Rest der 2026-06-20 gestrichenen Galaxiekarte) — beschreibt jetzt den echten Effekt (alle Kolonie-Kacheln erkundet).
+- Docs: `GameTick.php`-Klassen-Docblock (Tick-Schritt-Liste) neu durchnummeriert (war lückenhaft 0→4→6, fehlende Schritte ergänzt), Credits-Mechanik-Beschreibung korrigiert.
+
 ## 2026-08-17
 
 - Fix: `tools/playtest-dashboard.php` — Chart-Linien/Sidebar-Swatches färbten alle Läufe eines Profils identisch (`colorFor()` keyte auf Profilname statt Lauf), Mehrfachvergleich damit unlesbar. Färbt jetzt pro Lauf (Profil+Seed+Datei).

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -31,18 +31,27 @@ use Illuminate\Support\Facades\DB;
  * Run for a given run:  php artisan game:tick --run=1
  * Override tick number: php artisan game:tick --tick=16300
  *
- * Steps per tick:
- *  0. Hangar deliveries   — transition building→docked ships; expire pending ships
- *  4. Building decay      — decrement status_points (per-type decay_rate); level-down at ≤ 0
- *  6. Research decay      — decrement colony_researches.status_points; level-down at ≤ 0
- *  7. Supply cap          — SET user_resources.supply = CC_flat + housing_level × 8 (cap model)
- *  8. Resource generation — produce colony resources per industry building level (trust multiplier applied)
- *  8b. Trust calculation  — recalculate colony trust and store in colony_resources (resource_id=12)
- *  8c. Passive Credits    — Nexus subsidy (30 Cr) + colony tax per housing level (20 Cr/level) added to user Credits
- *  8d. Advisor upkeep     — deduct Credits per active advisor by rank (10/50/160 Cr); clamped to ≥ 0
- *  9. Advisor ticks       — increment active_ticks, check rank promotions
- * 10. Bar offers          — expire stale offers, generate new NPC offers per colony with Bar
- * 11. Merchant spawn      — check each colony for a new Traveling Merchant visit
+ * Steps per tick (renumbered sequentially 2026-08-18 — was gapped 0→4→6 from
+ * removed/merged steps, and missing several since added; step order below
+ * matches handle()'s actual call order):
+ *  1. Hangar deliveries   — transition building→docked ships; expire pending ships
+ *  2. Hangar missions     — resolve dispatched missions (complete/abort), apply rewards
+ *  3. Building decay      — decrement status_points (per-type decay_rate); level-down at ≤ 0
+ *  4. Research decay      — decrement colony_researches.status_points; level-down at ≤ 0
+ *  5. Supply cap          — SET user_resources.supply = CC_flat + housing_level × 8 (cap model)
+ *  6. Resource generation — produce colony resources per industry building level (trust multiplier applied)
+ *  7. Food consumption    — deduct Organics per colonist; trust penalty on shortfall
+ *  8. Encounters          — roll GDD §9 hazards (storm/instability/plague) per colony, Phase-1 ramp applies
+ *  9. Trust calculation   — recalculate colony trust and store in colony_resources (resource_id=12)
+ * 10. Passive Credits     — nexus_subsidy (config('game.credits.nexus_subsidy')) + Uplink Station level ×
+ *                           relay_bonus_per_uplink_level, added to user Credits
+ * 11. Advisor upkeep      — deduct Credits per active advisor by rank (config('game.advisor.upkeep')); clamped to ≥ 0
+ * 12. Advisor ticks       — increment active_ticks, check rank promotions
+ * 13. Bar offers          — expire stale offers, generate new NPC/Corvan offers per colony with Bar
+ * 14. Merchant spawn      — check each colony for a new Traveling Merchant visit
+ * 15. Run structure       — phase transitions, objective progress, run-end checks (outside the DB transaction
+ *                           above so endRun() can commit independently — see inline comment at the call site)
+ * 15a. Nexus interventions — Phase-2-only: Sol-30/50/65/80 warnings/sanctions, nexus_debt fail
  */
 class GameTick extends Command
 {
@@ -159,7 +168,7 @@ class GameTick extends Command
             $this->line("  Merchant visits spawned:  {$n}");
         });
 
-        // Step 12 — Run structure: phase transitions, objective progress, run-end checks.
+        // Step 15 — Run structure: phase transitions, objective progress, run-end checks.
         // Runs outside the main DB::transaction so that endRun() can commit independently
         // and return early without rolling back the tick's resource/decay work.
         $run->refresh();
@@ -178,7 +187,7 @@ class GameTick extends Command
         if ($run->phase === 2) {
             $runProgressService->updateObjectiveProgress($run);
 
-            // Step 12a — Nexus interventions (warnings, sanctions, nexus_debt fail).
+            // Step 15a — Nexus interventions (warnings, sanctions, nexus_debt fail).
             $runProgressService->checkNexusInterventions($run);
             $run->refresh();
 

--- a/config/game.php
+++ b/config/game.php
@@ -329,7 +329,13 @@ return [
         // checked the Rang-2 case; the Rang-2→3 jump stayed at 2.67× and was the actual,
         // *permanent* Post-Phase-1 collapse trigger (advisors never demote). See GDD §18.4
         // Nachtrag 2026-08-14 for the full break-even derivation.
-        'upkeep' => [1 => 10, 2 => 25, 3 => 50],
+        // Rank-3 50 → 35 (2026-08-18, game-designer review): with the 4th advisor
+        // slot now reachable (max_slots above), 4× Rank-3 = 200 Cr/Tick against a
+        // realistic ~110-155 Cr/Tick non-Cantina income — structurally negative.
+        // 35 brings 4× Rank-3 down to 140 Cr/Tick, a small positive-to-neutral
+        // margin instead of -40 to -90 Cr/Tick (see docs re: Post-Phase-1 collapse,
+        // ROADMAP.md "Offene Pfad-Paritäts-Fragen").
+        'upkeep' => [1 => 10, 2 => 25, 3 => 35],
     ],
 
     // Passive Credits income per tick (GDD §3).
@@ -349,7 +355,12 @@ return [
         // 20 → 35 (GDD §18.4 Nachtrag 2026-08-14) — Uplink Station doesn't conflict
         // with the Sciencelab/Hangar/Cantina path choice (separate CC-Lv2 gate), so
         // it's the deliberate active-effort lever for players who skip the Cantina.
-        'relay_bonus_per_uplink_level' => 35,
+        // 35 → 45 (2026-08-18, game-designer review): non-Cantina paths' income
+        // (nexus_subsidy + this + episodic missions) still sat below 4-advisor
+        // upkeep even after the upkeep[3] cut above — this is the second, smaller
+        // lever, chosen because it's path-neutral (doesn't inflate the already
+        // overcompensating Cantina/Corvan channel).
+        'relay_bonus_per_uplink_level' => 45,
         // "Handelsvertrag" — Cr/Tick flat income while a Konsul (trader advisor,
         // personell_id 92) is assigned to the colony AND the Cantina (Bar, building_id
         // 52) is built (level >= 1). Keyed by the Konsul's current rank. Represents the
@@ -547,7 +558,11 @@ return [
         'items' => [
             'ap_flex' => ['label' => 'AP-Paket (flexibel)',       'cost' => 800,  'ap_amount' => 20],
             'ap_targeted' => ['label' => 'AP-Paket (Kenntnis)',       'cost' => 500,  'ap_amount' => 15],
-            'information' => ['label' => 'Systemkarte vollständig',   'cost' => 1200],
+            // Label corrected 2026-08-18 — "Systemkarte" was the pre-2026-06-20
+            // galaxy map feature (removed); this item actually sets
+            // colony_tiles.is_explored=true for every tile (MerchantService::apply(),
+            // case 'information'), not a system-wide map.
+            'information' => ['label' => 'Vollständige Kartierung (alle Kacheln)',   'cost' => 1200],
             'repair_kit' => ['label' => 'Reparatur-Kit (+30 SP)',    'cost' => 400,  'sp_amount' => 30],
             'trust_boost' => ['label' => 'Vertrauensschub (+15)',     'cost' => 600,  'trust_amount' => 15],
         ],


### PR DESCRIPTION
## Summary
- Zwei am 2026-08-17 durchgerechnete, freigegebene Zahlen-Fixes gegen die Credits-Pfad-Lücke: `advisor.upkeep[3]` 50→35, `credits.relay_bonus_per_uplink_level` 35→45.
- `merchant.items.information.label` korrigiert (war Rest der gestrichenen Galaxiekarte, beschreibt jetzt den echten Effekt).
- `GameTick.php`-Docblock-Tick-Schritt-Liste neu durchnummeriert (war lückenhaft), Credits-Mechanik-Text korrigiert.

## Test plan
- [x] `php bin/phpunit --exclude-group=playtest` — 1022/1022 grün

https://claude.ai/code/session_01AcRpcgaFXBwDrrkd8xEaF9