### PR TITLE
docs: GDD-Code-Drift-Fixes (Rang-System, Kenntnis-Effekte, Vertrauen, Aufgabenpool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Docs: Anhänge aus GDD ausgegliedert — `docs/gdd-balance-checklist.md` (Balance-Index, Playtest-Instrumentierung) + `docs/gdd-config-audit.md` (GDD↔Config-Drifts). GDD 4034 → 3900 Zeilen.
 - Docs: ADR 0004 umgesetzt — GDD-Zahlen-Scope Reorganisation (Zwei-Schichten-Modell). GDD behält Mechanik/Formeln/Beispiele, alle konkreten Zahlenwerte raus (~265 Zeilen), Config wird Source of Truth für alle Spielwerte, game-reference.md als Lookup-Tabellen-Layer. GDD 3900 → 3635 Zeilen nach game-designer Cleanup.
 - Docs: CLAUDE.md aktualisiert — neue Sektion "GDD Dokumentation (ADR 0004)" mit Zwei-Schichten-Modell dokumentiert.
+- Docs: frischer GDD↔Code-Drift-Audit (`docs/gdd-config-audit.md` neu geschrieben, ersetzt Stand 2026-08-02) — 6 Abweichungen behoben: §13 Rang-System auf den echten AP-Pool umgeschrieben (alte per-Berater-Tabelle war Vor-Konsolidierung-Stand), §10 Kenntnis-Effekte an die tatsächliche Implementierung angepasst (totes Primär-/Sekundäreffekt-Modell + toter Config-Key entfernt), §14 "Moralsystem" → "Vertrauenssystem" umbenannt (Implementierungs-TODOs waren längst erledigt), §15 Aufgabenpool-Tabelle auf die echten 8 `RunProgressService`-Tasks korrigiert, Decay-Dezimalwert-Range korrigiert, `game-reference.md` Schiffs-Supply-Kosten (waren 6/14, tatsächlich 0) + Promotion-Zeilenbeschriftung gefixt.
 
 ## 2026-08-18 (Nachtrag)
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -35,7 +35,7 @@
     - 13.5 [Instandhaltungslast und die Regolith-Grenze](#135-instandhaltungslast-und-die-regolith-grenze)
     - 13.6 [Zahlenvorschlag, erste Fassung (überholt)](#136-zahlenvorschlag-erste-fassung-überholt--siehe-137)
     - 13.7 [Regolith-Zahlensatz, hergeleitet](#137-regolith-zahlensatz-hergeleitet-stand-2026-08-02--vorschlag)
-14. [Moralsystem](#14-moralsystem)
+14. [Vertrauenssystem](#14-vertrauenssystem)
 15. [Run-Struktur (Roguelike-Modus)](#15-run-struktur-roguelike-modus)
 16. [Onboarding](gdd/onboarding.md) → eigene Datei
 17. [Progressive Discovery System](gdd/progressive-discovery.md) → eigene Datei
@@ -1099,14 +1099,15 @@ Entropie ist ein übergreifendes Designprinzip: Ohne aktive Pflege degradiert di
 
 Gebäude verfallen ohne aktive Pflege. Jedes Exemplar hat individuelle Werte für `max_status_points` und `decay_rate` (SP/Sol, intern SP/Tick), die in den Stammdaten-Tabellen (`buildings`) gespeichert sind.
 
-**Fraktionaler Decay:** Die `decay_rate` ist ein Dezimalwert (0.05–0.3 SP/Sol). Pro Sol wird dieser Wert von den `status_points` des Exemplars abgezogen. Ein ganzer SP geht erst verloren, wenn sich genug Verlust akkumuliert hat.
+**Fraktionaler Decay:** Die `decay_rate` ist ein Dezimalwert, gestaffelt in Klassen von "Robust" (langsamster Verfall) bis "Fragil" (schnellster Verfall) — siehe `config/buildings.php` bzw. die vollständige Tabelle in `docs/game-reference.md#4-gebäude-decay-raten--status-points`. Pro Sol wird dieser Wert von den `status_points` des Exemplars abgezogen. Ein ganzer SP geht erst verloren, wenn sich genug Verlust akkumuliert hat.
 
 ```
-Beispiel: max_status_points=5, decay_rate=0.3
-  Nach Sol 1: status_points = 4.70
-  Nach Sol 2: status_points = 4.40
-  Nach Sol 3: status_points = 4.10
-  Nach Sol 4: status_points = 3.80  ← erster ganzer SP verloren
+Beispiel (Formel-Illustration, nicht die aktuelle Klasse "Robust"):
+max_status_points=5, decay_rate=0.5
+  Nach Sol 1: status_points = 4.50
+  Nach Sol 2: status_points = 4.00
+  Nach Sol 3: status_points = 3.50
+  Nach Sol 4: status_points = 3.00  ← zwei ganze SP verloren
 ```
 
 **Konsequenzen nach Building-Typ:**
@@ -1461,32 +1462,19 @@ Jedes Level wird durch Investition von Analytiker-AP erarbeitet. AP-Kosten steig
 > **Wichtig:** Diese Kostenkurve ist an `game.ap.base`/`advisor.ap_per_rank` gekoppelt — bei Änderung dort erneut gegen die AP/Sol-Rate prüfen, nicht isoliert betrachten.
 > **Zusätzlicher Bugfix (2026-07-14):** Die Techtree-UI zeigte bis dahin für jede Kenntnis konstant 3 AP an (Fortschrittsleiste + Ausbau-Button) — ein stiller Off-Sync zwischen dem statischen `researches.ap_for_levelup`-DB-Feld (nur beim initialen Migrations-Seed gesetzt, nie synchronisiert) und den tatsächlichen, gestaffelten `levelup_costs` in dieser Config. Das Serverbackend (`ResearchService::resolveApForLevelup`) verlangte schon immer den korrekten, höheren Wert — nur die UI-Anzeige und die Klick-Grenze der Leiste hingen am veralteten Wert, sodass eine Investition über 3 AP hinaus optisch möglich schien, aber lautlos nichts bewirkte. `TechtreeController` liest den Kenntnis-Kostenwert jetzt dynamisch aus derselben Quelle wie das Backend.
 
-### Zwei Effekt-Ebenen
+### Effekte wirken direkt aus dem Kenntnis-Level
 
-Jede Kenntnis hat:
+Kenntnis-Effekte werden **automatisch** wirksam, sobald die Kenntnis das nötige Level erreicht hat — ohne dass sie einem Berater zugewiesen werden muss. Das frühere Modell (Primär-/Sekundäreffekt mit Berater-Zuweisungspflicht für den zweiten Effekt) ist entfallen; es gibt keine Zuweisungs-UI und keine Slot-Beschränkung mehr.
 
-- **Primäreffekt** — aktiv sobald freigeschaltet, unabhängig von Beratern (z.B. Supply-Cap-Bonus, Vertrauenseffekt)
-- **Sekundäreffekt** — nur aktiv wenn die Kenntnis einem Berater zugewiesen ist; variiert je nach Berater-Typ
+Bereits implementierte Effekte (`config/knowledge.php`):
 
-Jede Kenntnis-Berater-Kombination bietet einen Sekundäreffekt, der die Domäne des Beraters mit dem Wissen der Kenntnis verbindet. Beispiele: geology als Baumeister senkt Gebäudekosten, geology als Konsul verbessert Rohstoff-Preise, cartography als Raumfahrer verbessert Erkundungs-Effizienz, etc.
+- `construction`, `cartography`, `trade` senken additiv die AP-Kosten von Gebäude-Levelups (§13.3) — glockenförmig über die Level gestaffelt (`ap_cost_reduction_per_lv`).
+- `trade` erhöht zusätzlich die Zahl gleichzeitig aktiver Cantina-Angebote (§12), siehe `bar_offer_boost_per_lv`.
+- `agronomy`, `health`, `defense` wirken auf das Vertrauen (§14), siehe `trust_per_lv`.
 
-Konkrete Sekundär-Effekt-Werte und komplette 7×4-Matrix: siehe `config/game.php → knowledge_effects.*` und `docs/game-reference.md#wissen-sekundär-effekte`.
+Nicht jede Kenntnis trägt zwingend einen mechanischen Effekt dieser Art — alle Kenntnisse tragen zusätzlich einheitlich zum Supply-Cap-Wachstum bei (§7). Welche Kenntnis welchen Effekt trägt und in welcher Höhe, ist ausschließlich in `config/knowledge.php` gepflegt; Lookup-Tabelle: `docs/game-reference.md#kenntnisse-7-levelup-kosten-effekte`.
 
-> **TODO Design:** Vollständige 7×4-Matrix (alle Kenntnisse × alle Berater) ausarbeiten — nach erstem Playtest, wenn klar ist welche Kombinationen strategisch interessant sind.
->
-> **Korrektur (Juli 2026):** Die ursprünglichen Platzhalterwerte für `defense`/`advisor_pilot` ("AP-Kosten für Angriff") und `cartography`/`advisor_pilot` ("Bewegungsreichweite") referenzierten die 2026-06-20 gestrichene Flotten-/Systemkarten-Mechanik (Angriffsorder, Flottenbewegung). Durch zivile Äquivalente ersetzt (Schutzmissions-AP, Tile-Erkundung) — weiterhin nur Platzhalter, keine finalen Werte.
-
-### Berater-Zuweisung
-
-Freigeschaltete Kenntnisse können einem Berater zugewiesen werden (UI: Drag & Drop). Der Sekundäreffekt der Kenntnis wird durch den zugewiesenen Berater bestimmt.
-
-**Slots je Berater nach Rang:** Jüngere Berater können keine Kenntnisse zugewiesen bekommen (kein Spezialisierungswissen). Bei Rang 2 ändert sich das — der Berater kann eine Kenntnis haben. Rang 3 erweitert das nicht weiter (dafür steigt der AP-Bonus — §13). Dadurch ist Rang-Aufstieg strategisch wertvoll nicht nur für mehr AP, sondern auch für Spezialisierungsmöglichkeiten.
-
-**Max. aktive Sekundäreffekte:** 4 (je ein Slot pro Berater, wenn alle auf Rang 2+ — vier Berater-Typen seit Zurückstellung des Strategen, 2026-08-02). Bezogen auf den vollen Kenntnisbaum (7 Kenntnisse, 4 Slots) bleiben 3 Kenntnisse ohne Sekundäreffekt.
-
-> ⚠️ BALANCE CONCERN: Innerhalb eines einzelnen Runs ist der volle Baum ohnehin nicht verfügbar (§ "Roguelike-Variabilität", z.B. 5 von 7 Kenntnissen). Bei 5 Kenntnissen und 4 Slots bleibt nur noch 1 Kenntnis ohne Sekundäreffekt — die Spezialisierungsentscheidung, die dieser Abschnitt als Designziel nennt, ist auf Run-Ebene damit deutlich schwächer als auf Baum-Ebene (war bei 5 Slots / 5-von-7 bereits 0, also eine Verbesserung, aber die Zielaussage "erzeugt echte Spezialisierungsentscheidungen" gilt so nur für den Baum, nicht für den Run). Nach erstem Playtest prüfen, ob Run-Ziehungsgröße oder Slot-/Kenntnisanzahl nachjustiert werden muss, damit auf Run-Ebene tatsächlich eine spürbare Auswahl entsteht.
-
-> **Balancing-Notiz:** Slot-Anzahl und Kenntnisanzahl sind Ausgangswerte für den ersten Playtest. Nach Erfahrungen aus dem Betrieb können zusätzliche Kenntnisse und/oder ein zweiter Slot bei Rang 3 eingeführt werden.
+> **TODO Design:** Weitere Kenntnis-Effekte (insbesondere für Kenntnisse ohne eigenen mechanischen Effekt bislang) sind offen für spätere Balancing-Passes — nach Playtest, wenn klar ist, welche Lücken am meisten drücken.
 
 ### Roguelike-Variabilität
 
@@ -1592,6 +1580,8 @@ Ohne zugewiesenen Konsul entfällt diese Einnahme vollständig — **beabsichtig
 **Bar-Level-Progression:**
 
 Höhere Bar-Level erhöhen die Angebots-Gültigkeit (Dauer) und die maximale Anzahl gleichzeitig aktiver Angebote. Details: siehe `config/buildings.php`.
+
+Zusätzlich zum Bar-Level selbst erhöht die Kenntnis **Handel** (`trade`) ab einem bestimmten Level die Zahl gleichzeitig aktiver Angebots-Slots weiter — der Effekt wirkt direkt aus dem Kenntnis-Level, ohne dass ein Berater zugewiesen sein muss (§10). Details: `config/knowledge.php → trade.bar_offer_boost_per_lv`, `docs/game-reference.md#kenntnisse-7-levelup-kosten-effekte`.
 
 **Konsul (advisor_trader) — Rang-Effekte:**
 
@@ -2148,32 +2138,19 @@ Missions-Auflösung läuft in **Tick-Schritt 7** (Advisor Ticks), nach AP-Berech
 
 ### Rang-System
 
-Jeder Berater hat einen von drei Rängen. Der Rang bestimmt den AP-Bonus pro Sol und den laufenden Upkeep in Credits.
+Jeder Berater hat einen von drei Rängen. Der Rang bestimmt, wie stark der Berater den gemeinsamen AP-Pool erhöht (§13.1) und wie hoch sein laufender Upkeep in Credits ist — beide Werte wachsen mit dem Rang, additiv auf den gemeinsamen Pool angerechnet, unabhängig von der Domäne des Beraters.
 
-| Rang | Bezeichnung | AP-Bonus/Sol | Gesamt-AP/Sol | Upkeep (Cr/Sol) |
-|------|-------------|--------------|---------------|-----------------|
-| 1 | Junior | +4 | 10 | 10 |
-| 2 | Senior | +7 | 13 | 25 |
-| 3 | Experte | +12 | 18 | 50 |
+Exakte Werte (AP-Bonus je Rang, Upkeep, Rang-Aufstiegs-Schwellen in aktiven Ticks, Beförderungskosten): siehe `config/game.php → advisor` und `docs/game-reference.md#5-berater-advisors-hire-kosten--ap-beiträge`.
 
-*(Gesamt-AP = 6 Grundwert + AP-Bonus)*
+> **Balance-Historie:** Die Upkeep-Kurve wurde mehrfach abgeflacht (2026-07-19, 2026-08-14, 2026-08-18) — ursprünglich steile Rang-Sprünge ließen die Credits-Ökonomie strukturell kollabieren, sobald mehrere Berater gleichzeitig aufstiegen (Playtest-Bot-Befund, PR #218; volle Herleitung inkl. Break-even-Rechnung siehe §18.4 Balancing-Richtlinien, `task_credit_reserve`). Begleitend wurden die Rang-Aufstiegs-Schwellen gestreckt — mehr Zeit, um Uplink-Station und Cantina vor dem teureren Upkeep hochzuziehen.
 
-> **Balance-Entscheidung (2026-07-19):** Upkeep-Kurve gegenüber der ursprünglichen Kalibrierung (10/50/160) abgeflacht — die alte Kurve ließ die Credits-Ökonomie strukturell kollabieren, sobald mehrere Berater gleichzeitig Rang 2 erreichten (Playtest-Bot-Befund, PR #218). Begleitend wurden die Beförderungs-Schwellen (`rank_thresholds`) von `[1=>10, 2=>20]` auf **`[1=>15, 2=>45]`** aktive Ticks gestreckt — mehr Zeit, um Uplink-Station und Cantina vor dem teureren Upkeep hochzuziehen.
->
-> **Nachtrag (2026-08-14):** die 07-19-Rechnung prüfte nur den Rang-2-Fall — der Rang-2→3-Sprung (30→80, 2,67×) blieb fast so scharf wie vorher und war der eigentliche, dauerhafte Kollaps-Auslöser in Phase 2 (Credits fielen dauerhaft auf 0, nicht nur vorübergehend). Upkeep-Kurve daher erneut abgeflacht auf **10/25/50** (Rang-3-Sprung jetzt 2,0×). Volle Herleitung inkl. Break-even-Rechnung für Rang 2 UND 3: siehe §18.4 Balancing-Richtlinien (`task_credit_reserve`, Nachtrag 2026-08-14).
+**Einstellungskosten (Rang 1) — typ-spezifisch:** Baumeister ist der günstigste Einstieg (Kernanforderung Tag 1); Analytiker, Raumfahrer und Konsul sind höher gestaffelt, gekoppelt an ihre spätere Verfügbarkeit (Analytiker erst ab CC Lv2, Raumfahrer voller Nutzen erst mit Hangar, Konsul mittlere Priorität). Exakte Beträge: `config/advisors.php`, `docs/game-reference.md`.
 
-**Einstellungskosten (Rang 1) — typ-spezifisch:**
-
-| Beratertyp | Kosten (Cr) | Begründung |
-|------------|-------------|-----------|
-| Baumeister | 300 | Kernanforderung Tag 1 — günstigster Einstieg |
-| Analytiker | 400 | Mittlere Priorität — erst bei CC Lv2 verfügbar |
-| Raumfahrer | 500 | Erkundungs-/Missions-fokussiert — voller Nutzen erst mit Hangar |
-| Konsul | 350 | Handelssupport — mittlere Priorität |
+**Beförderung** kostet beim Erreichen von Rang 2 bzw. Rang 3 zusätzlich zum laufenden Upkeep einen einmaligen Credits-Betrag (`config/game.php → advisor.promotion_costs`). Kann der Spieler die Beförderung nicht bezahlen, wird sie auf den nächsten Sol verschoben, bis genug Credits verfügbar sind.
 
 - **Upkeep** wird jeden Sol von den Colony-Credits abgezogen, solange der Berater `colony_id` gesetzt hat (Berater ist aktiv zugewiesen).
-- **Rang-Aufstieg:** automatisch nach ausreichend kumulierten `active_ticks` (`config/game.php → advisors.rank_thresholds`).
-- Alle Werte stehen in `config/game.php → advisor` (Einstellungskosten, AP, Upkeep, Rang-Thresholds).
+- **Rang-Aufstieg:** automatisch nach ausreichend kumulierten `active_ticks` (`config/game.php → advisor.rank_thresholds`).
+- Alle Werte stehen in `config/game.php → advisor` (Einstellungskosten, AP-Bonus, Upkeep, Rang-Thresholds, Beförderungskosten).
 
 > **UI-Anforderung:** Die Berater-Verwaltung zeigt für jeden aktiven Berater: Rang, AP-Beitrag/Sol, laufender Upkeep (Cr/Sol) und `active_ticks` zum nächsten Rang-Aufstieg. Diese vier Werte müssen auf einen Blick lesbar sein.
 
@@ -2212,7 +2189,7 @@ availableAP = Grundwert + Σ AP_bonus(rank) über alle zugewiesenen Berater − 
 
 Ein einziger Pool je Kolonie (13.1). `AP_bonus(rank)` ist der Beitrag jedes aktuell zugewiesenen Beraters, unabhängig von seiner Domäne — vier Berater erhöhen denselben Pool viermal. AP-Locks verfallen automatisch zum nächsten Sol; der Pool wird täglich vollständig erneuert.
 
-> **⚠️ Offen — Grundwert:** Der frühere Grundwert war 6 AP/Sol **pro Typ** (5 × 6 = 30 AP/Sol nominell, praktisch unbrauchbar wegen der Nicht-Mischbarkeit). Der neue Grundwert des gemeinsamen Pools ist noch nicht festgelegt und muss zusammen mit den Projektkosten kalibriert werden (13.5). Er darf nicht die Summe der alten Werte sein — sonst wächst die effektive Handlungsfähigkeit sprunghaft.
+Der Grundwert des gemeinsamen Pools ist seit 2026-08-03 kalibriert und freigegeben (`config/game.php → ap.base`) — bewusst deutlich kleiner als die Summe der früheren fünf Einzel-Pools, damit die effektive Handlungsfähigkeit gegenüber dem Vor-Konsolidierungs-Modell nicht sprunghaft wächst. Vertrauens- und Seuchen-Multiplikatoren (§9, §14) wirken zusätzlich multiplikativ auf den fertigen Grundwert+Bonus-Betrag, siehe `AdvisorService::getApBreakdown`. Exakter Wert: `docs/game-reference.md#9-action-points-ap`.
 
 ### AP-Verbrauch
 
@@ -2800,7 +2777,7 @@ Verfügbar(N) = Startbestand + 17×(N−1) − 2,94×N = Startbestand − 17 + 1
 
 ---
 
-## 14. Moralsystem
+## 14. Vertrauenssystem
 
 ### Design-Absicht
 
@@ -2983,7 +2960,7 @@ Vertrauen beeinflusst den Supply-Cap **nicht**. Das Supply-System ist ein separa
 
 **Kein neues Schema erforderlich.** `colony_resources.amount` (resource_id=12) speichert den aktuellen Vertrauenswert als Integer im Bereich -100 bis +100. Das ist ausreichend — Vertrauen ist ein Zustand, keine akkumulierte Menge.
 
-**Benötigt wird ausschließlich eine Konfiguration** in `config/game.php` unter dem Schlüssel `moral`. Die vollständigen Werte (buildings, researches, ships, ships_cap, production_multiplier, ap_multiplier, events) sind dort implementiert — `config/game.php` ist die einzige Quelle der Wahrheit für alle Zahlenwerte. Dieses Dokument beschreibt die Semantik; die konkreten Zahlen stehen in der Konfigurationsdatei.
+**Die Konfiguration** steht produktiv in `config/game.php` unter dem Schlüssel `trust` (Umbenennung von `moral`→`trust` abgeschlossen). Die vollständigen Werte (buildings, researches, ships, ships_cap, production_multiplier, ap_multiplier, events) sind dort implementiert — `config/game.php` ist die einzige Quelle der Wahrheit für alle Zahlenwerte. Dieses Dokument beschreibt die Semantik; die konkreten Zahlen stehen in der Konfigurationsdatei.
 
 ### Sol-Integration
 
@@ -2997,14 +2974,16 @@ Vertrauen wird als neuer **Tick-Schritt 6b** nach der Ressourcenproduktion berec
 
 Die Reihenfolge ist bewusst: Die Produktion von Sol N verwendet den Vertrauenswert von Sol N-1. Der neue Vertrauenswert gilt erst ab Sol N+1. Das verhindert zirkuläre Abhängigkeiten.
 
-### Implementierungsschritte
+### Implementierung (Stand)
 
-1. `config/game.php` — `moral`-Block hinzufügen (alle Werte aus obiger Tabelle)
-2. `app/Services/VertrauenService.php` — Service mit Methode `calculate(int $colonyId): int`
-3. `app/Services/ResourceService.php` (oder TickService) — `VertrauenService::calculate()` in Schritt 6b aufrufen und `colony_resources` (res_id=12) schreiben
-4. `app/Services/Techtree/PersonellService.php` — AP-Berechnung um `vertrauen_multiplier` erweitern
-5. Produktionslogik (`config/game.php → production`) — Vertrauen-Multiplikator anwenden
-6. UI: Vertrauen-Anzeige in der Ressourcenleiste (existiert als resource_id=12 bereits)
+Vollständig implementiert, kein offener TODO mehr:
+
+1. `config/game.php` — `trust`-Block produktiv (alle Werte, siehe oben).
+2. `app/Services/TrustService.php` — berechnet den Vertrauenswert je Kolonie.
+3. Tick-Integration in Schritt 6b (siehe unten) — schreibt `colony_resources` (res_id=12).
+4. `app/Services/AdvisorService.php` — AP-Berechnung berücksichtigt den Trust-AP-Multiplikator (`getApBreakdown`).
+5. Produktionslogik — Trust-Produktionsmultiplikator wird angewandt.
+6. UI: Vertrauen-Anzeige in der Ressourcenleiste (resource_id=12).
 
 ### Mögliche Erweiterungen (nach Playtest)
 
@@ -3062,24 +3041,22 @@ Startet direkt nach Phase 1. Dem Spieler werden 3 Aufgaben aus dem Aufgabenpool 
 
 ### Aufgabenpool
 
-10 Aufgabentypen (Pool). Pro Run werden 3 gezogen — mehr Varianz reduziert Wiederholungsgefühl. Alle Aufgaben sind zivil erfüllbar (es gibt keinen Kampf mehr — Flotte/Systemkarte gestrichen, §8). Jede Aufgabe passt zu vorhandenen Spielmechaniken.
+8 Aufgabentypen (Pool, `RunProgressService::TASK_CATEGORIES`/`TASK_TARGETS`). Pro Run werden 3 gezogen — Varianz reduziert Wiederholungsgefühl. Alle Aufgaben sind zivil erfüllbar (es gibt keinen Kampf mehr — Flotte/Systemkarte gestrichen, §8). Jede Aufgabe passt zu vorhandenen Spielmechaniken.
 
-| # | Aufgabe | Kernmechanik | Spielstil |
-|---|---------|-------------|-----------|
-| 1 | **Handelsnetz** | X Handelsrouten aktiv + Gesamtvolumen Y Credits/Sol uber Z Sole aufrecht halten | Wirtschaft |
-| 2 | **Forschungsvorsprung** | Mindestens 3 Forschungen auf Level 5+ bringen | Forschung/Aufbau |
-| 3 | **Kolonieblute** | Vertrauen > 70 fur 10 aufeinanderfolgende Sole | Diplomatie/Zivilaufbau |
-| 4 | **Selbstversorgung** | Organika positiv produzieren (Netto > 0) **und** einen Werkstoff-Vorrat ≥ X Einheiten bei durchgehend positivem Credits-Saldo halten — für 15 aufeinanderfolgende Sole. (Werkstoffe sind nicht produzierbar, §3 — getestet wird stabiles Import-Management, nicht Eigenproduktion.) | Wirtschaft/Aufbau |
-| 5 | **Expeditionsstatus** | Alle Tiles der Exploration Zone vollständig aufgedeckt (gesamter äußerer Bereich, nicht nur Ring 1–2) | Exploration/Navigation |
-| 7 | **Handelspartner** | Mindestens X Transaktionen mit dem Reisenden Händler abgeschlossen + Credits-Saldo danach stets positiv | Wirtschaft |
-| 8 | **Ingenieursleistung** | Gesamt-SP-Kapazität aller Gebäude (Summe `max_status_points` aller colony_buildings) uber Schwelle Y | Aufbau/Optimierung |
-| 9 | **Kreditimperium** | Credits-Bestand X Sole uber Schwelle Y halten (kein einmaliger Peak, sondern anhaltender Wohlstand) | Wirtschaft |
-| 10 | **Expertenstab** | Alle Berater-Slots besetzt + mindestens 2 Berater auf Rang Senior oder höher | Aufbau/Personal |
-| 11 | **Effizienzsprung** | AP-Nutzungsrate >= 90% fur 5 aufeinanderfolgende Sole (verbrauchte AP / produzierte AP) | Optimierung/Hardcore |
+| Aufgabe (`task_key`) | Kategorie | Kernmechanik |
+|---|---|---|
+| Handelsnetz (`task_trade_volume`) | Wirtschaft | Abgeschlossene Transaktionen mit dem Reisenden Händler im laufenden Run über einer Schwelle |
+| Forschungsvorsprung (`task_research_lead`) | Forschung/Aufbau | Mindestens einige Kenntnisse auf Höchstlevel gebracht |
+| Kolonieblüte (`task_colony_prosperity`) | Diplomatie/Zivilaufbau | Vertrauen über einer Schwelle für mehrere aufeinanderfolgende Sole |
+| Selbstversorgung (`task_self_sufficiency`) | Wirtschaft/Aufbau | Regolith- **und** Organika-Vorrat gleichzeitig über ihren jeweiligen Mindestschwellen **und** Supply > 0 — alle drei Bedingungen gleichzeitig, für mehrere aufeinanderfolgende Sole; jeder einzelne Ausfall setzt den Streak zurück |
+| Expeditionsstatus (`task_expedition_coverage`) | Exploration/Navigation | Alle Tiles der Kolonie-Zone erkundet |
+| Ingenieursleistung (`task_engineering_output`) | Aufbau/Optimierung | Gesamt-SP-Kapazität aller Gebäude (Summe `status_points` aller `colony_buildings`) über einer Schwelle |
+| Kreditreserve (`task_credit_reserve`) | Wirtschaft | Credits-Bestand über einer Schwelle für mehrere aufeinanderfolgende Sole (kein einmaliger Peak, sondern anhaltender Wohlstand) |
+| Expertenstab (`task_senior_advisors`) | Aufbau/Personal | Alle Berater-Slots besetzt + mindestens 2 Berater auf Rang Senior oder höher |
 
-> ⚠️ BALANCE CONCERN: Aufgaben 1, 7, 9 (alle Wirtschaft) dürfen nicht alle drei gleichzeitig gezogen werden. Aufgaben-Sets müssen mindestens 2 verschiedene Spielstilkategorien abdecken — eine Kombo-Blacklist ist vor der Implementierung zu definieren.
+Exakte Schwellen, Streak-Längen und Herleitung: `docs/game-reference.md#18-run-struktur`, vollständige Balancing-Historie unten in §18.4.
 
-> ⚠️ BALANCE CONCERN: Aufgabe 11 (Effizienz) kollidiert strukturell mit massivem Bauen (Aufgaben 2, 8) — "AP-effizient" und "viel bauen" sind Gegensätze. Aufgabe 11 sollte nie zusammen mit Aufgabe 2 oder 8 gezogen werden.
+> ⚠️ BALANCE CONCERN: Aufgaben-Sets sollten mindestens 2 verschiedene Kategorien abdecken, damit ein Run nicht ausschließlich Wirtschaftsaufgaben zieht (`task_trade_volume` + `task_credit_reserve` sind beide Wirtschaft). Eine Kombo-Blacklist bzw. -Regel für die Ziehung ist noch nicht implementiert.
 
 ---
 

--- a/docs/game-reference.md
+++ b/docs/game-reference.md
@@ -121,8 +121,10 @@ Alle levelup via Analytik-Labor. Keine Credits-Kosten (=0). Alle Kurven glockenf
 | Schiff | Supply-Kosten | Max SP | Decay-Rate | Hangar-Gate | Stärkewert |
 |---|---|---|---|---|---|
 | **Drohne** | 0 | ? | ? | Nein | 0 |
-| **Frachter** | 6 | ? | ? | Ja (Hangar Lv1) | 0 |
-| **Korvette** | 14 | ? | ? | Ja (Hangar Lv3) | 3 |
+| **Frachter** | 0 | ? | ? | Ja (Hangar Lv1) | 0 |
+| **Korvette** | 0 | ? | ? | Ja (Hangar Lv3) | 3 |
+
+> **Supply-Kosten**: alle Schiffe 0 — Schiffe verbrauchen kein Supply (Design-Entscheidung 2026-06-08, `config/ships.php` → `supply_cost`)
 
 > **Hangar-Level = Schiffsklasse**: Lv1 = Drohne, Lv2 = Frachter, Lv3 = Korvette
 > Instanzen sind separate Achse (supply-limitiert, unbegrenzt Slots theoretisch)
@@ -226,7 +228,7 @@ Alle Werte Cr/Tick, angewendet nach Ressourcen-Generierung in GameTick Schritt 8
 | Aktion | Betrag |
 |---|---|
 | Advisor Hire (Rang 1) | je Typ: 300–500 Cr |
-| Advisor Rank 2 → 3 Promotion | 150 Cr (einmalig) |
+| Advisor Rank 1 → 2 Promotion | 150 Cr (einmalig) |
 | Advisor Rank 2 → 3 Promotion | 250 Cr (einmalig) |
 | Advisor Upkeep (Rang 1–3) | 10/25/35 Cr/Tick (laufend) |
 

--- a/docs/gdd-config-audit.md
+++ b/docs/gdd-config-audit.md
@@ -1,34 +1,50 @@
-# GDD ↔ Config Drift Audit
+# GDD ↔ Code/Config Drift-Audit
 
-Gefunden bei der Durchsicht am 2026-08-02, alle unabhängig von den Designfragen und **alle noch offen**. Wo GDD und Code auseinanderlaufen, gilt laut CLAUDE.md der Code bzw. die Config als kanonisch — das GDD ist nachzuziehen, nicht umgekehrt.
+Stand: 2026-08-21, nach GDD-Konsolidierung (ADR 0004). Ersetzt die Fassung vom 2026-08-02 — die meisten dortigen Zahlen-Drifts sind durch die Konsolidierung obsolet geworden, ein Rest bleibt unten unter "Bereits bekannt" bestehen. Wo GDD und Code auseinanderlaufen, gilt Code/Config als kanonisch (CLAUDE.md) — GDD ist nachzuziehen.
 
-## Dokumentierte Drifts
+## 1. Verbleibende Zahlen im GDD-Prosa-Text (Verstoß gegen ADR 0004)
 
-| Ort | GDD/Doku sagt | Config/Code sagt |
-|---|---|---|
-| §4 „Level-Up" | CC-Upgrade = Ziel-Level × **30** Rg (Lv2 = 60) | `cc_upgrade_regolith_per_level = 20` (Lv2 = 40) |
-| §7 „Fraktionaler Decay" | Dezimalwert 0,05–0,3 SP/Sol | tatsächlich 0,33–2,0 |
-| §6 Config-Block | listet `supply.ship_cost` (Korvette 14, Frachter 6) | Key existiert in `config/game.php` nicht; die §6-Prosa sagt korrekt „Schiffe kosten kein Supply" |
-| §13 „Rang-System" | Gesamt-AP = 6 + Bonus (10/13/18) | mit dem gemeinsamen Pool obsolet (§13.1) |
-| `config/knowledge.php` (Kommentar) | „base 6 + Rang-1-Bonus 4", „Rang 2 bei 10 aktiven Ticks" | `rank_thresholds = [1 => 15, 2 => 45]`; Grundwert ändert sich mit §13.6 |
-| `config/advisors.php` | `strategist` (id 93) + Slot-5-Kommentar | Stratege zurückgestellt (§13) |
-| `data/sql/testdata.sqlite.sql` | Hangar supply 6, Cantina 4, Krankenstation decay 2.0 | `config/buildings.php`: 4 / 6 / 0.67 — Testfixture ist auf dem Stand **vor** dem Pfadwahl-Rebalancing 2026-06-28 |
-| §15 „Aufgabenpool" (Prosa, Z. 3423–3444) | listet 10 Aufgaben mit anderen Mechaniken (z. B. „Selbstversorgung" prüft Werkstoff-Vorrat + Credits-Saldo) | tatsächlich 8 Tasks (`RunProgressService::TASK_TARGETS`/`TASK_CATEGORIES`), z. B. `updateSelfSufficiency()` prüft `regolith > 25 && organics > 75 && supply > 0` — keine Werkstoffe, kein Credits-Saldo. §18 ist die autoritative Quelle (§18.5-Hinweis „§15-Prosa ist alt"), restated die Liste dort aber nicht vollständig — gefunden 2026-08-18, nicht neu, nur vorher nicht explizit hier erfasst |
+- `docs/GDD.md:2153-2172` §13 „Rang-System" — Tabellen AP-Bonus +4/+7/+12, Gesamt-AP 10/13/18, Upkeep 10/25/50, Einstellungskosten 300/400/500/350. Zusätzlich inhaltlich falsch (siehe §2). Eigener Task, hohe Priorität.
+- `docs/GDD.md:1102` — Decay-Dezimalwert-Range „0.05–0.3 SP/Sol" + Beispielrechnung. Verstößt gegen ADR 0004 und ist falsch. Klein, schnell.
+- `docs/GDD.md:3166-3170` — Nexus-Schulden „3.000 Cr Vorschuss", „Schuldenlimit 12.000 Cr". `12000` ist laut §18.6 ohnehin nur hardcodiert in `RunProgressService`, kein Config-Key — an das dortige TODO ("Config-Key anlegen") drankoppeln.
+- `docs/GDD.md:3185` Highscore-Formel — als Formel-Beispiel gekennzeichnet, von ADR 0004 erlaubt. Kein Task.
 
-## ⚠️ Akut: `harvester.max_level` — DB und Config widersprechen sich
+## 2. Mechanik-Beschreibungen, die nicht mehr zum Code passen
 
-**Die laufende Datenbank hat `max_level = 1`, `config/buildings.php` hat 8.** `game:sync-config` schreibt `max_level` aus der Config in die DB (`SyncConfig.php` Z. 130) — **ein Sync-Lauf setzt den Harvester still auf 8 zurück.** Die Config ist vor jedem weiteren Sync anzugleichen. `data/sql/testdata.sqlite.sql` hat ebenfalls bereits `max_level = 1`, ist hier also mit der DB konsistent.
+- `docs/GDD.md:2149-2215` §13 „Rang-System" + „Verfügbare AP" — beschreibt Vor-Konsolidierung-Modell (fixer Gesamt-AP pro Berater). Tatsächlich: gemeinsamer Pool, `ap.base=12`, `ap_per_rank=[1=>2,2=>3,3=>4]`, `upkeep=[1=>10,2=>25,3=>35]` (nicht 50). „Verfügbare AP"-Absatz markiert Grundwert noch als offen, obwohl `ap.base=12` seit 2026-08-03 freigegeben ist. **Kapitel komplett neu schreiben — höchste Priorität.**
+- `docs/GDD.md:1464-1489` §10 „Zwei Effekt-Ebenen" — beschreibt Primär-/Sekundäreffekt-Modell mit Berater-Zuweisungspflicht + `config('game.knowledge_effects.*')` (Key existiert nicht mehr). Tatsächlich (`config/knowledge.php`, `ProjectBonusService.php:22-32`): `ap_cost_reduction_per_lv`/`bar_offer_boost_per_lv` wirken direkt aus Kenntnis-Level, keine Zuweisungsprüfung. Eigener Task.
+- `docs/GDD.md:3063-3078` §15 „Aufgabenpool" — Tabelle mit 10 Einträgen (Lücke bei 6). Code (`RunProgressService.php:27-51`) hat nur 8 Tasks. „Selbstversorgung"-Kriterium im GDD (Werkstoff+Credits-Saldo) ≠ Code (`regolith>25 && organics>75 && supply>0`). Bereits 2026-08-18 in alter Audit-Datei vermerkt, weiterhin ungefixt.
+- `docs/GDD.md:2803,2986,3002` §14 — Kapitel „Moralsystem", Text sagt „Config-Schlüssel `moral` hinzufügen" als TODO. Tatsächlich: Umbenennung `moral`→`trust` abgeschlossen, `config/game.php:414` hat `trust`-Block produktiv. Liest sich wie Pre-Implementation-Hinweis, ist aber längst erledigt.
 
-**Nebenfolge:** Die Glockenkurve aus PR #220 ist für den Harvester wirkungslos. `game.production_curve[27]` definiert Level 1–8, aber bei `max_level = 1` greift nur der erste Eintrag — **8 Rg/Sol, dauerhaft**. Der Config-Kommentar („Growth beyond Lv8 comes only from Kenntnisse/Missionen/Handel") beschreibt einen Zustand, den es in der DB nicht gibt. Beim Agrardom (`max_level = NULL`, unbegrenzt) wirkt die Kurve dagegen voll.
+## 3. Fehlende Dokumentation
 
-**Sieben Gebäude haben `max_level = NULL`** (unbegrenzt): Sciencelab, Temple, Agrardom, Hangar, Krankenstation, Monument, Cantina. Für sie läuft die `f(L)`-Kostenkurve aus §13.6 ohne natürlichen Endpunkt weiter — bei Lv10 wäre `f` = 4,2, bei Lv15 = 6,2. Ob das gewollt ist oder ob diese Gebäude Deckel brauchen, ist offen.
+- Kenntnis-Effekte `ap_cost_reduction_per_lv`/`bar_offer_boost_per_lv` (Spec 2026-08-15) — weder in §10 noch §12 „Bar-Level-Progression" erwähnt. Im selben Task wie §2/§10 erledigen.
+- `promotion_costs` (`config/game.php:318`, [2=>150,3=>250]) — in §13 nicht erwähnt, nur in game-reference.md. Im Rang-System-Task miterledigen.
+- `bioFacility.max_level=8` (seit 2026-07-20 gesetzt) — Anhang A.4 listet Instanz-Deckel noch als offene Frage. Evtl. nur Instanz- vs. Level-Deckel-Verwechslung, kein eigener Task, bei nächster Anhang-A-Pflege prüfen.
 
-## ✅ Erledigt: `ap_for_levelup` verifiziert (2026-08-02)
+## 4. game-reference.md Drift
 
-Owner hat die laufende DB geprüft. Ergebnis: **`ap_for_levelup` ist überall 10**, einzige Ausnahme Monument (50) mit 20. Die Migration `2026_04_17_000003_calibrate_building_ap_costs.php` (CC 10 / die meisten 20 / Hangar 30) ist **nicht aktiv** — entweder zurückgerollt oder später überschrieben.
+- `docs/game-reference.md:121-125` „Schiffe" — Supply-Kosten Frachter=6/Korvette=14. Tatsächlich `config/ships.php`: `supply_cost=0` für alle Schiffe (seit 2026-06-08, Schiffe kosten kein Supply). Echte, verifizierte Differenz — eigener kleiner Task.
+- `docs/game-reference.md:229-230` — Promotion-Zeilen-Beschriftung vertauscht/unklar (Rank 2→3 doppelt statt Rank 1→2 + Rank 2→3). Trivial.
+- Stichproben ok: Berater-Upkeep 10/25/35, `ap_per_rank` +2/+3/+4, Promotion-Kosten 150/250, Hangar-Baukosten 95 Rg, Decay-Klassen — konsistent mit Config. game-reference.md insgesamt aktueller als GDD-Prosa.
 
-Damit ist die Onboarding-Budgetrechnung (`gdd/onboarding.md` §16.5) korrekt und die Kalibrierung in §13.6 steht auf der Basis, die sie unterstellt hat.
+## 5. Terminologie-Drift
 
-**Aber: eine flache 10 über alle Gebäude ist kein Balancing, sondern ein Default.** Dass der Wert die playgetestete Rampe reproduziert, macht ihn nicht richtig — es macht ihn nur konsistent mit dem, was bisher gespielt wurde. Er gehört zu den Platzhaltern und ist bei der Herleitung der Projektkosten frei wählbar.
+- `docs/GDD.md:38,2803` Kapitelüberschrift „Moralsystem" statt „Vertrauenssystem" — letzte Strukturstelle mit altem Begriff (Fließtext im Kapitel nutzt bereits „Vertrauen"). Klein.
+- Config-Schlüssel `moral` in Zeile 2986/3002 (siehe §2).
+- Grep auf Angriff/Kampfsystem/Fleet-Commander/Steuern/Forschungshandel/Tradecenter/Rassen/Battlecruiser/Koloniekommandant: keine Treffer außer historisch gekennzeichnete Stellen (§1.1). Sprachregeln sonst sauber eingehalten.
 
-**Bei Umsetzung mitzuziehen:** `app/Console/Commands/ResetPlayer.php` — alle fünf Szenarien (`pre-phase2`, `phase2`, `near-fail-trust`, `near-deadline`, `objectives-done`) haben hartcodierte `supply`- und `regolith`-Werte samt Herleitungskommentaren, die an `ap_for_levelup` und den Supply-Formeln hängen.
+## Priorisierung (empfohlene Task-Reihenfolge)
+
+1. §13 „Rang-System" + „Verfügbare AP" komplett neu schreiben (Kategorie 1+2+3 kombiniert)
+2. §10 „Zwei Effekt-Ebenen" an tatsächliche Kenntnis-Effekt-Implementierung anpassen, toten Config-Verweis entfernen, `bar_offer_boost_per_lv` in §12 nachtragen
+3. §14-Überschrift + moral→trust in Zeile 2986/3002 korrigieren
+4. §15 Aufgabenpool-Tabelle auf 8 echte Tasks korrigieren (oder auf §18 verweisen)
+5. `docs/GDD.md:1102` Decay-Range korrigieren/auf game-reference.md verweisen
+6. `docs/game-reference.md` Schiffs-Supply-Kosten auf 0 korrigieren
+
+## Bereits bekannt, nicht neu erhoben (aus Audit 2026-08-02, weiterhin gültig)
+
+- `data/sql/testdata.sqlite.sql`: Hangar/Krankenstation/Cantina `decay_rate` veraltet (0.67/2.0/1.0 statt 0.60/0.80/0.80), Cantina `supply_cost=4` statt 6 — relevant für nächste `ResetPlayer.php`-Szenario-Pflege.
+- ⚠️ `harvester.max_level`: DB hatte `1` vs. Config `8` — bei nächstem `game:sync-config`-Lauf prüfen, ob noch aktuell.
+- Sieben Gebäude mit `max_level=NULL` (Sciencelab, Temple, Agrardom, Hangar, Krankenstation, Monument, Cantina) — Kostenkurve läuft ohne Endpunkt, offen ob gewollt.


### PR DESCRIPTION
## Summary
- Frischer GDD↔Code-Drift-Audit (`docs/gdd-config-audit.md`, ersetzt Stand 2026-08-02, nach ADR 0004 GDD-Konsolidierung) fand 6 Abweichungen — alle behoben.
- §13 Rang-System auf den echten gemeinsamen AP-Pool umgeschrieben (alte Tabelle war Vor-Konsolidierung-Stand mit fixem AP pro Berater).
- §10 Kenntnis-Effekte an tatsächliche Implementierung angepasst (totes Primär-/Sekundäreffekt-Modell + toter Config-Key entfernt).
- §14 "Moralsystem" → "Vertrauenssystem" umbenannt, Implementierungs-TODOs korrigiert (moral→trust war längst erledigt).
- §15 Aufgabenpool-Tabelle auf die echten 8 `RunProgressService`-Tasks korrigiert.
- Decay-Dezimalwert-Range korrigiert, `game-reference.md` Schiffs-Supply-Kosten (6/14 → 0) + Promotion-Zeilenbeschriftung gefixt.
- CHANGELOG-Eintrag ergänzt.

## Test plan
- [x] Reine Doku-Änderung, kein Codepfad betroffen (TDD-Ausnahme laut CLAUDE.md) — kein Testlauf nötig.
- [x] Jeder Punkt gegen aktuellen Code/Config verifiziert (`config/game.php`, `config/knowledge.php`, `config/ships.php`, `RunProgressService.php`, `TrustService.php`, `ProjectBonusService.php`) vor dem Edit.