### PR TITLE
feat: Handelsposten-Kanal-Rabatte (Plan 2/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-27
+
+- Feat: Handelsposten (tradingPost) bekommt seine erste echte Spielwirkung — Kanal-Rabatt-Freischaltung je Ausbaustufe (I=Cantina, II=+Reisender Händler, III=+Nexus/Corporate Contact), kumulativ, kein Stack-Effekt mit dem Konsul-Rang-Verhandlungsbonus. Bisher komplett wirkungsloser `merchant_price_bonus`-Config-Wert wird jetzt tatsächlich angewendet. Neuer `TradingPostService`, verdrahtet in `BarService`/`MerchantService`/`CorporateContactService`.
+
 ## 2026-08-26
 
 - Docs: Design-Spec für Gebäude-Ausbaustufen-System fertiggestellt (`docs/superpowers/specs/2026-08-23-building-tier-system-design.md`) — CC behält Level, alle 9 anderen Gebäude auf max. 3 benannte Ausbaustufen umgestellt (Struktur, keine Zahlen, ADR 0004). Zwei echte Implementierungslücken mitgeschlossen: Handelsposten (bisher leere Hülle) bekommt kanalweise Rabattfreischaltung, Analytik-Labor Lv4/5 (bisher wirkungslos) bekommt Domänen-Effizienzbonus "Wissen". Wohnhabitat-Level-Deckel korrigiert (6→3, Doppelachse mit Instanzen war historische Drift). Finale Beinamen nach 4 content-writer-Namensrunden freigegeben. Exklusive Ausbau-Varianten und Bauten außerhalb der Koloniezone geprüft und zurückgestellt/verworfen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-27
 
+- Fix: Whole-Branch-Review-Fund am Handelsposten-Kanal-Rabatt — `BarService::acceptOffer()` prüfte Affordability/Reserve-Floor gegen den vollen statt den rabattierten Preis (dieselbe Lücke, die in `MerchantService::buyItem()` schon behoben war), + 2 Regressionstests. GDD-Absatz präzisiert (nur der explizite Verhandlungsbonus ist vom Stack-Ausschluss erfasst, der passive `trader_discount` stackt noch ungeprüft — offene Design-Frage) und veralteter `merchant_price_bonus`-Kommentar in `config/buildings.php` aktualisiert.
 - Feat: Handelsposten (tradingPost) bekommt seine erste echte Spielwirkung — Kanal-Rabatt-Freischaltung je Ausbaustufe (I=Cantina, II=+Reisender Händler, III=+Nexus/Corporate Contact), kumulativ, kein Stack-Effekt mit dem Konsul-Rang-Verhandlungsbonus. Bisher komplett wirkungsloser `merchant_price_bonus`-Config-Wert wird jetzt tatsächlich angewendet. Neuer `TradingPostService`, verdrahtet in `BarService`/`MerchantService`/`CorporateContactService`.
 
 ## 2026-08-26

--- a/app/Enums/BuildingId.php
+++ b/app/Enums/BuildingId.php
@@ -22,4 +22,5 @@ enum BuildingId: int
     case Hangar = 44;
     case Bar = 52;
     case UplinkStation = 54;
+    case TradingPost = 55;
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -15,6 +15,7 @@ use App\Services\Techtree\ResearchService;
 use App\Services\Techtree\ShipService;
 use App\Services\Techtree\TechtreeColonyService;
 use App\Services\TickService;
+use App\Services\TradingPostService;
 use App\Services\TrustService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -52,6 +53,7 @@ class AppServiceProvider extends ServiceProvider
             $app->make(AdvisorService::class),
             $app->make(BarService::class),
             $app->make(ResourcesService::class),
+            $app->make(TradingPostService::class),
         ));
         $this->app->bind(ResourcesService::class, ResourcesService::class);
         $this->app->bind(TrustService::class, fn ($app) => new TrustService(

--- a/app/Services/BarService.php
+++ b/app/Services/BarService.php
@@ -161,30 +161,12 @@ class BarService
             }
         }
 
-        // Check player can afford the give side
-        $giveBalance = $this->getResourceBalance($colonyId, $userId, $offer->give_resource_id);
-        if ($giveBalance < $offer->give_amount) {
-            return ['ok' => false, 'error' => __('colony.bar_offer_insufficient_resources')];
-        }
-
-        // Reserve floor (GDD §4b) — only for Corvan's Organika sell offers
-        // (visit_id set). Re-checked here, not just at generation, because stock
-        // can drop between generation and accept (an earlier lot accepted in the
-        // same visit, or ongoing food consumption) — see generateCommodityOffers().
-        if ($offer->visit_id !== null) {
-            $sellResId = (int) config('game.merchant.commodity.sell_resource_id', 5);
-            if ((int) $offer->give_resource_id === $sellResId) {
-                $reserveMultiplier = (int) config('game.merchant.commodity.sell_reserve_multiplier', 2);
-                $reserve = $reserveMultiplier * $this->resourcesService->foodNeed($colonyId);
-                if (($giveBalance - $offer->give_amount) < $reserve) {
-                    return ['ok' => false, 'error' => __('colony.bar_offer_reserve_floor')];
-                }
-            }
-        }
-
         // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — nur auf
         // nicht-verhandelte Angebote, kein Stack-Effekt mit dem
-        // Konsul-Rang-Verhandlungsbonus aus negotiateOffer().
+        // Konsul-Rang-Verhandlungsbonus aus negotiateOffer(). Berechnet VOR dem
+        // Affordability-Check, damit dieser gegen den tatsächlich fälligen
+        // Betrag läuft (Whole-Branch-Review-Fund 2026-08-27 — derselbe Bug,
+        // der in MerchantService::buyItem() bereits behoben wurde).
         $giveAmount = $offer->give_amount;
         $getAmount = $offer->get_amount;
         if (! $offer->is_negotiated) {
@@ -197,6 +179,27 @@ class BarService
                 $getAmount = $isCreditsOffer
                     ? $offer->get_amount
                     : (int) max(1, round($offer->get_amount * (1 + $discount)));
+            }
+        }
+
+        // Check player can afford the give side
+        $giveBalance = $this->getResourceBalance($colonyId, $userId, $offer->give_resource_id);
+        if ($giveBalance < $giveAmount) {
+            return ['ok' => false, 'error' => __('colony.bar_offer_insufficient_resources')];
+        }
+
+        // Reserve floor (GDD §4b) — only for Corvan's Organika sell offers
+        // (visit_id set). Re-checked here, not just at generation, because stock
+        // can drop between generation and accept (an earlier lot accepted in the
+        // same visit, or ongoing food consumption) — see generateCommodityOffers().
+        if ($offer->visit_id !== null) {
+            $sellResId = (int) config('game.merchant.commodity.sell_resource_id', 5);
+            if ((int) $offer->give_resource_id === $sellResId) {
+                $reserveMultiplier = (int) config('game.merchant.commodity.sell_reserve_multiplier', 2);
+                $reserve = $reserveMultiplier * $this->resourcesService->foodNeed($colonyId);
+                if (($giveBalance - $giveAmount) < $reserve) {
+                    return ['ok' => false, 'error' => __('colony.bar_offer_reserve_floor')];
+                }
             }
         }
 

--- a/app/Services/BarService.php
+++ b/app/Services/BarService.php
@@ -21,6 +21,7 @@ class BarService
     public function __construct(
         private readonly ResourcesService $resourcesService,
         private readonly AdvisorService $advisorService,
+        private readonly TradingPostService $tradingPostService,
     ) {}
 
     public function generateOffersForColony(int $colonyId, int $tick): void
@@ -181,10 +182,28 @@ class BarService
             }
         }
 
+        // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — nur auf
+        // nicht-verhandelte Angebote, kein Stack-Effekt mit dem
+        // Konsul-Rang-Verhandlungsbonus aus negotiateOffer().
+        $giveAmount = $offer->give_amount;
+        $getAmount = $offer->get_amount;
+        if (! $offer->is_negotiated) {
+            $discount = $this->tradingPostService->discountFor($colonyId, 'bar');
+            if ($discount > 0.0) {
+                $isCreditsOffer = $offer->give_resource_id === self::RES_CREDITS;
+                $giveAmount = $isCreditsOffer
+                    ? (int) max(1, round($offer->give_amount * (1 - $discount)))
+                    : $offer->give_amount;
+                $getAmount = $isCreditsOffer
+                    ? $offer->get_amount
+                    : (int) max(1, round($offer->get_amount * (1 + $discount)));
+            }
+        }
+
         // Execute trade atomically — partial transfer must not persist
-        DB::transaction(function () use ($offer, $colonyId, $apCost): void {
-            $this->resourcesService->decreaseAmount($colonyId, $offer->give_resource_id, $offer->give_amount);
-            $this->resourcesService->increaseAmount($colonyId, $offer->get_resource_id, $offer->get_amount);
+        DB::transaction(function () use ($offer, $colonyId, $apCost, $giveAmount, $getAmount): void {
+            $this->resourcesService->decreaseAmount($colonyId, $offer->give_resource_id, $giveAmount);
+            $this->resourcesService->increaseAmount($colonyId, $offer->get_resource_id, $getAmount);
             $offer->is_accepted = true;
             $offer->save();
             if ($apCost > 0) {
@@ -196,17 +215,17 @@ class BarService
             'colony_id' => $colonyId,
             'offer_id' => $offerId,
             'give_resource_id' => $offer->give_resource_id,
-            'give_amount' => $offer->give_amount,
+            'give_amount' => $giveAmount,
             'get_resource_id' => $offer->get_resource_id,
-            'get_amount' => $offer->get_amount,
+            'get_amount' => $getAmount,
         ]);
 
         return [
             'ok' => true,
             'give_resource_id' => $offer->give_resource_id,
-            'give_amount' => $offer->give_amount,
+            'give_amount' => $giveAmount,
             'get_resource_id' => $offer->get_resource_id,
-            'get_amount' => $offer->get_amount,
+            'get_amount' => $getAmount,
         ];
     }
 

--- a/app/Services/CorporateContactService.php
+++ b/app/Services/CorporateContactService.php
@@ -25,6 +25,7 @@ class CorporateContactService
 {
     public function __construct(
         private readonly HarvesterEntitlementService $harvesterEntitlementService,
+        private readonly TradingPostService $tradingPostService,
     ) {}
 
     /**
@@ -48,7 +49,16 @@ class CorporateContactService
             return null;
         }
 
-        return ['price' => $this->priceRoll($colonyId, $tick)];
+        $price = $this->priceRoll($colonyId, $tick);
+
+        // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — Stufe 3 schaltet
+        // den Nexus/Corporate-Contact-Kanal frei.
+        $discount = $this->tradingPostService->discountFor($colonyId, 'corporate_contact');
+        if ($discount > 0.0) {
+            $price = (int) max(1, round($price * (1 - $discount)));
+        }
+
+        return ['price' => $price];
     }
 
     /**

--- a/app/Services/MerchantService.php
+++ b/app/Services/MerchantService.php
@@ -43,6 +43,7 @@ class MerchantService
         private readonly AdvisorService $advisorService,
         private readonly BarService $barService,
         private readonly ResourcesService $resourcesService,
+        private readonly TradingPostService $tradingPostService,
     ) {}
 
     public function getActiveVisit(int $colonyId, int $currentTick): ?object
@@ -307,20 +308,28 @@ class MerchantService
             return ['ok' => false, 'error' => 'Der Händler ist nicht mehr anwesend.'];
         }
 
+        // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — Stufe 2 schaltet
+        // den Reisender-Händler-Kanal frei. Vor dem Credits-Check berechnet, damit
+        // die Affordability-Prüfung gegen den tatsächlich fälligen Betrag läuft.
+        $discount = $this->tradingPostService->discountFor($colonyId, 'merchant');
+        $chargedCredits = $discount > 0.0
+            ? (int) max(1, round($item->cost_credits * (1 - $discount)))
+            : $item->cost_credits;
+
         // Check credits
         $credits = (int) (DB::table('user_resources')
             ->where('user_id', $userId)
             ->value('credits') ?? 0);
 
-        if ($credits < $item->cost_credits) {
+        if ($credits < $chargedCredits) {
             return ['ok' => false, 'error' => 'Nicht genug Credits.'];
         }
 
         // Deduct credits, apply effect and mark sold atomically.
-        DB::transaction(function () use ($item, $itemId, $colonyId, $userId): void {
+        DB::transaction(function () use ($item, $itemId, $colonyId, $userId, $chargedCredits): void {
             DB::table('user_resources')
                 ->where('user_id', $userId)
-                ->decrement('credits', $item->cost_credits);
+                ->decrement('credits', $chargedCredits);
 
             $this->applyItemEffect($item, $colonyId);
 
@@ -334,7 +343,7 @@ class MerchantService
             'user_id' => $userId,
             'item_id' => $itemId,
             'item_type' => $item->item_type,
-            'cost_credits' => $item->cost_credits,
+            'cost_credits' => $chargedCredits,
         ]);
 
         $newCredits = (int) (DB::table('user_resources')

--- a/app/Services/TradingPostService.php
+++ b/app/Services/TradingPostService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\BuildingId;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Handelsposten (tradingPost) — Kanal-Rabatt-Freischaltung (Design-Spec
+ * 2026-08-23, Abschnitt "Handelsposten"). Jede Ausbaustufe schaltet einen
+ * zusätzlichen Handelskanal für den (bisher toten) merchant_price_bonus frei:
+ * Stufe 1 = Cantina-Zufallsangebote, Stufe 2 = + Reisender Händler,
+ * Stufe 3 = + Nexus/Corporate Contact. Kumulativ, nicht exklusiv — Stufe 3
+ * gewährt den Rabatt auf allen drei Kanälen gleichzeitig.
+ */
+class TradingPostService
+{
+    /** @var array<string, int> Handelskanal => benötigte Handelsposten-Stufe */
+    private const CHANNEL_THRESHOLDS = [
+        'bar' => 1,
+        'merchant' => 2,
+        'corporate_contact' => 3,
+    ];
+
+    public function discountFor(int $colonyId, string $channel): float
+    {
+        $threshold = self::CHANNEL_THRESHOLDS[$channel] ?? null;
+        if ($threshold === null) {
+            return 0.0;
+        }
+
+        $level = (int) (DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', BuildingId::TradingPost->value)
+            ->value('level') ?? 0);
+
+        if ($level < $threshold) {
+            return 0.0;
+        }
+
+        return (float) config('buildings.tradingPost.merchant_price_bonus', 0.0);
+    }
+}

--- a/config/buildings.php
+++ b/config/buildings.php
@@ -374,7 +374,7 @@ return [
         // (Cantina → Reisender Händler → Nexus/Corporate Contact), echter
         // Fähigkeits-Sprung pro Stufe (Design-Spec, Abschnitt "Handelsposten").
         'tiers' => [1, 2, 3],
-        'merchant_price_bonus' => 0.12,    // +12% trade value when Reisender Händler present
+        'merchant_price_bonus' => 0.12,    // discount rate applied per unlocked channel (see TradingPostService)
     ],
 
 ];

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -457,14 +457,16 @@ Die Uplink-Station ist das einzige Kommunikationsgebäude der Kolonie — 1 Inst
 
 ### Handelsposten (tradingPost) — Mechanik
 
-Der Handelsposten ist ein auf 1 Instanz begrenztes Wirtschaftsgebäude (CC Lv4, konkurriert mit Religiöser Stätte um dasselbe Tile-Budget). Er stärkt den Handels-AP-Effizienz und den Nexus-Handelskanal:
+Der Handelsposten ist ein auf 1 Instanz begrenztes Wirtschaftsgebäude (CC Lv4, konkurriert mit Religiöser Stätte um dasselbe Tile-Budget). Er verbessert Handelskonditionen über mehrere Kanäle hinweg:
 
 <!-- TODO: Konsul-Effizienz-Absatz prüfen, evtl. Verwechslung mit trade-Kenntnis-Domäneneffizienz — separater Task -->
 **Passiv — Konsul-Effizienz:**
 Trade-Orders erhalten einen Bonus (AP-Kostenreduktion). Nur relevant wenn ein Konsul aktiv ist — dies ist ein Beispiel für einen Domänen-Effizienzbonus (§13.3). Exakte Werte: `config/buildings.php`.
 
 **Passiv — Kanal-Rabatt (Design-Spec 2026-08-23):**
-Jede Ausbaustufe schaltet einen zusätzlichen Handelskanal für einen Preisrabatt frei, kumulativ: Stufe I (Bekannter Gast) den Kanal Cantina-Zufallsangebote, Stufe II (Fester Kunde) zusätzlich den Reisenden Händler, Stufe III (Persönlicher Kontakt) zusätzlich Nexus/Corporate Contact (Orin). Beim Cantina-Kanal gilt: kein Stack-Effekt mit dem Konsul-Rang-Verhandlungsbonus — der Rabatt gilt nur für nicht verhandelte Angebote. Exakter Rabattsatz: `config/buildings.php` → `merchant_price_bonus`.
+Jede Ausbaustufe schaltet einen zusätzlichen Handelskanal für einen Preisrabatt frei, kumulativ: Stufe I (Bekannter Gast) den Kanal Cantina-Zufallsangebote, Stufe II (Fester Kunde) zusätzlich den Reisenden Händler, Stufe III (Persönlicher Kontakt) zusätzlich Nexus/Corporate Contact (Orin). Beim Cantina-Kanal gilt: kein Stack-Effekt mit dem expliziten Konsul-Verhandlungsbonus (`negotiate_bonus`, ausgelöst über den "Verhandeln"-Button) — der Rabatt gilt nur für nicht verhandelte Angebote.
+> **TODO Balance/Design:** Der passive, bereits bei der Angebots-Generierung eingerechnete Konsul-Rang-Rabatt (`trader_discount`, siehe `BarService::generateOffersForColony()`) ist von diesem Ausschluss NICHT erfasst und stackt aktuell multiplikativ mit dem Handelsposten-Rabatt (z.B. Rang-3-Konsul 30% + Handelsposten-Stufe-I 12% = kombiniert 38,4%). Ob das gewollt ist, wurde noch nicht bewertet — Whole-Branch-Review-Fund 2026-08-27, offene Design-Frage für den nächsten Balance-Pass.
+Exakter Rabattsatz: `config/buildings.php` → `merchant_price_bonus`.
 
 > **TODO Balance:** Baukosten und Decay nach erstem Playtest festlegen (siehe `config/buildings.php`).
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -459,13 +459,14 @@ Die Uplink-Station ist das einzige Kommunikationsgebäude der Kolonie — 1 Inst
 
 Der Handelsposten ist ein auf 1 Instanz begrenztes Wirtschaftsgebäude (CC Lv4, konkurriert mit Religiöser Stätte um dasselbe Tile-Budget). Er stärkt den Handels-AP-Effizienz und den Nexus-Handelskanal:
 
+<!-- TODO: Konsul-Effizienz-Absatz prüfen, evtl. Verwechslung mit trade-Kenntnis-Domäneneffizienz — separater Task -->
 **Passiv — Konsul-Effizienz:**
 Trade-Orders erhalten einen Bonus (AP-Kostenreduktion). Nur relevant wenn ein Konsul aktiv ist — dies ist ein Beispiel für einen Domänen-Effizienzbonus (§13.3). Exakte Werte: `config/buildings.php`.
 
-**Passiv — Händlerkonditionen:**
-Der Reisende Händler bietet bei Anwesenheit eines Handelspostens bessere Preiskonditionen (Bonus auf Handelswert). Konkreter Wert nach Playtest kalibrieren (siehe `config/buildings.php`).
+**Passiv — Kanal-Rabatt (Design-Spec 2026-08-23):**
+Jede Ausbaustufe schaltet einen zusätzlichen Handelskanal für einen Preisrabatt frei, kumulativ: Stufe I (Bekannter Gast) den Kanal Cantina-Zufallsangebote, Stufe II (Fester Kunde) zusätzlich den Reisenden Händler, Stufe III (Persönlicher Kontakt) zusätzlich Nexus/Corporate Contact (Orin). Beim Cantina-Kanal gilt: kein Stack-Effekt mit dem Konsul-Rang-Verhandlungsbonus — der Rabatt gilt nur für nicht verhandelte Angebote. Exakter Rabattsatz: `config/buildings.php` → `merchant_price_bonus`.
 
-> **TODO Balance:** Baukosten und Decay nach erstem Playtest festlegen (siehe `config/buildings.php`). Handelswert-Bonus muss mit dem Konsul-Rang-System abgestimmt werden (kein Stack-Effekt wenn Konsul Experte + Handelsposten).
+> **TODO Balance:** Baukosten und Decay nach erstem Playtest festlegen (siehe `config/buildings.php`).
 
 ---
 

--- a/docs/superpowers/plans/2026-08-26-tradingpost-channel-discounts.md
+++ b/docs/superpowers/plans/2026-08-26-tradingpost-channel-discounts.md
@@ -1,0 +1,835 @@
+# Handelsposten-Kanal-Rabatte Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Handelsposten (tradingPost) bekommt seine erste echte Spielwirkung — je Ausbaustufe schaltet sich ein Rabatt-Kanal auf einen der drei bestehenden Handelswege frei (Cantina-Zufallsangebote → Reisender Händler → Nexus/Corporate Contact), statt der bisher komplett wirkungslosen `merchant_price_bonus`-Config.
+
+**Architecture:** Ein neuer, kleiner `TradingPostService` kapselt die Level-Schwellen-Logik (`discountFor(int $colonyId, string $channel): float`) und liest den Rabattsatz aus dem bereits bestehenden `config('buildings.tradingPost.merchant_price_bonus')`. Die drei bestehenden Handels-Services (`BarService`, `MerchantService`, `CorporateContactService`) rufen diesen Service beim tatsächlichen Preis-/Mengen-Vollzug auf — nicht bei der Angebots-Generierung, damit Level-Änderungen sofort wirken, ohne bereits generierte Angebote invalidieren zu müssen. `BarService` wendet den Rabatt nur an, wenn das Angebot NICHT bereits über den Konsul verhandelt wurde (GDD-Vorgabe: kein Stack-Effekt zwischen Konsul-Rang-Verhandlungsbonus und Handelsposten-Rabatt).
+
+**Tech Stack:** PHP/Laravel, PHPUnit (`bin/phpunit`), Larastan (`bin/phpstan`).
+
+**Spec:** `docs/superpowers/specs/2026-08-23-building-tier-system-design.md` (Abschnitt „Handelsposten (tradingPost) — alle 3 Stufen neu")
+
+## Global Constraints
+
+- Kanal-Schwellen (aus der Spec, bindend): Stufe 1 = Rabatt auf Cantina-Zufallsangebote, Stufe 2 = zusätzlich Reisender Händler, Stufe 3 = zusätzlich Nexus/Corporate Contact. Jede höhere Stufe schaltet zusätzlich zu den niedrigeren frei (kumulativ, nicht exklusiv).
+- Rabattsatz kommt unverändert aus dem bereits vorhandenen `config('buildings.tradingPost.merchant_price_bonus')` (aktuell 0.12) — keine neue Zahl einführen, keine Kalibrierung in diesem Plan (ADR 0004, Zahlen-Feinschliff ist Folge-Task nach Playtest).
+- Kein Stack-Effekt mit dem Konsul-Rang-Verhandlungsbonus (`BarService::negotiateOffer()`) — der Handelsposten-Rabatt gilt nur für nicht-verhandelte Cantina-Angebote (`$offer->is_negotiated === false`).
+- TDD-Pflicht für alle Tasks außer Task 1 (reine Enum-Ergänzung ohne eigenes Verhalten) und Task 6 (Doku).
+- Reihenfolge der Tasks ist absichtlich: Task 2 (Service) muss vor 3-5 (Verdrahtung) stehen, da 3-5 den Service konsumieren.
+
+---
+
+### Task 1: `BuildingId::TradingPost` Enum-Case ergänzen
+
+**Files:**
+- Modify: `app/Enums/BuildingId.php`
+
+**Interfaces:**
+- Produces: `BuildingId::TradingPost` (int-backed, Wert `55`) — konsumiert von Task 2's `TradingPostService`.
+
+- [ ] **Step 1: Case ergänzen**
+
+In `app/Enums/BuildingId.php`, nach `case UplinkStation = 54;` einfügen:
+
+```php
+    case TradingPost = 55;
+```
+
+- [ ] **Step 2: Syntax prüfen**
+
+Run: `php -l app/Enums/BuildingId.php`
+Expected: `No syntax errors detected`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Enums/BuildingId.php
+git commit -m "feat: BuildingId::TradingPost Enum-Case ergänzen"
+```
+
+---
+
+### Task 2: `TradingPostService::discountFor()` (TDD)
+
+**Files:**
+- Create: `app/Services/TradingPostService.php`
+- Test: `tests/Feature/TradingPostServiceTest.php`
+
+**Interfaces:**
+- Consumes: `BuildingId::TradingPost` (Task 1), `config('buildings.tradingPost.merchant_price_bonus')`.
+- Produces: `TradingPostService::discountFor(int $colonyId, string $channel): float` — konsumiert von Task 3 (`'bar'`), Task 4 (`'merchant'`), Task 5 (`'corporate_contact'`). Gültige `$channel`-Werte: `'bar'`, `'merchant'`, `'corporate_contact'`. Rückgabe: der konfigurierte Rabattsatz (float, z.B. `0.12`), oder `0.0` wenn kein Handelsposten gebaut ist oder dessen Level die Kanal-Schwelle nicht erreicht. Ein unbekannter `$channel`-String liefert `0.0` (kein Fehler).
+
+- [ ] **Step 1: Fehlschlagenden Test schreiben**
+
+Neue Datei `tests/Feature/TradingPostServiceTest.php`:
+
+```php
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\TradingPostService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * TradingPostService::discountFor() — Kanal-Rabatt-Schwellen (Design-Spec
+ * 2026-08-23, Abschnitt "Handelsposten"): Stufe 1 = Cantina, Stufe 2 = +Reisender
+ * Händler, Stufe 3 = +Nexus/Corporate Contact. Kumulativ, nicht exklusiv.
+ */
+class TradingPostServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const TRADING_POST_ID = 55;
+
+    private TradingPostService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        $this->service = $this->app->make(TradingPostService::class);
+    }
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', self::TRADING_POST_ID)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => self::TRADING_POST_ID,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_no_trading_post_gives_zero_discount_on_every_channel(): void
+    {
+        $this->setTradingPostLevel(null);
+
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_level_1_unlocks_only_bar_channel(): void
+    {
+        $this->setTradingPostLevel(1);
+
+        $expected = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_level_2_unlocks_bar_and_merchant_cumulatively(): void
+    {
+        $this->setTradingPostLevel(2);
+
+        $expected = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_level_3_unlocks_all_three_channels(): void
+    {
+        $this->setTradingPostLevel(3);
+
+        $expected = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_unknown_channel_returns_zero_not_an_error(): void
+    {
+        $this->setTradingPostLevel(3);
+
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'not_a_real_channel'));
+    }
+}
+```
+
+- [ ] **Step 2: Test laufen lassen, Fehlschlag bestätigen**
+
+Run: `bin/phpunit --filter TradingPostServiceTest`
+Expected: FAIL — Klasse `App\Services\TradingPostService` existiert nicht.
+
+- [ ] **Step 3: `TradingPostService` implementieren**
+
+Neue Datei `app/Services/TradingPostService.php`:
+
+```php
+<?php
+
+namespace App\Services;
+
+use App\Enums\BuildingId;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Handelsposten (tradingPost) — Kanal-Rabatt-Freischaltung (Design-Spec
+ * 2026-08-23, Abschnitt "Handelsposten"). Jede Ausbaustufe schaltet einen
+ * zusätzlichen Handelskanal für den (bisher toten) merchant_price_bonus frei:
+ * Stufe 1 = Cantina-Zufallsangebote, Stufe 2 = + Reisender Händler,
+ * Stufe 3 = + Nexus/Corporate Contact. Kumulativ, nicht exklusiv — Stufe 3
+ * gewährt den Rabatt auf allen drei Kanälen gleichzeitig.
+ */
+class TradingPostService
+{
+    /** @var array<string, int> Handelskanal => benötigte Handelsposten-Stufe */
+    private const CHANNEL_THRESHOLDS = [
+        'bar' => 1,
+        'merchant' => 2,
+        'corporate_contact' => 3,
+    ];
+
+    public function discountFor(int $colonyId, string $channel): float
+    {
+        $threshold = self::CHANNEL_THRESHOLDS[$channel] ?? null;
+        if ($threshold === null) {
+            return 0.0;
+        }
+
+        $level = (int) (DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', BuildingId::TradingPost->value)
+            ->value('level') ?? 0);
+
+        if ($level < $threshold) {
+            return 0.0;
+        }
+
+        return (float) config('buildings.tradingPost.merchant_price_bonus', 0.0);
+    }
+}
+```
+
+- [ ] **Step 4: Test laufen lassen, Erfolg bestätigen**
+
+Run: `bin/phpunit --filter TradingPostServiceTest`
+Expected: PASS (6 Tests)
+
+- [ ] **Step 5: Larastan prüfen**
+
+Run: `bin/phpstan analyse app/Services/TradingPostService.php --no-progress`
+Expected: `[OK] No errors`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/TradingPostService.php tests/Feature/TradingPostServiceTest.php
+git commit -m "feat: TradingPostService mit Kanal-Rabatt-Schwellen (Cantina/Händler/Nexus)"
+```
+
+---
+
+### Task 3: Rabatt in `BarService::acceptOffer()` verdrahten (TDD)
+
+**Files:**
+- Modify: `app/Services/BarService.php`
+- Test: `tests/Feature/Bar/BarServiceTest.php`
+
+**Interfaces:**
+- Consumes: `TradingPostService::discountFor($colonyId, 'bar')` (Task 2).
+- Produces: nichts Neues nach außen — `acceptOffer()`s Rückgabeformat bleibt gleich, nur `give_amount`/`get_amount` sind bei aktivem Kanal-Rabatt günstiger für den Spieler.
+
+- [ ] **Step 1: Fehlschlagende Tests schreiben**
+
+In `tests/Feature/Bar/BarServiceTest.php`, am Ende der Klasse (vor der schließenden `}`) einfügen — orientiert an der bestehenden `test_accept_offer_with_credits_as_give()`-Struktur:
+
+```php
+    // ── Handelsposten-Rabatt (Design-Spec 2026-08-23) ──────────────────────────
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 55)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => 55,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_accept_offer_applies_trading_post_discount_when_credits_are_the_give_side(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(1); // Stufe 1 schaltet den Cantina-Kanal frei
+
+        $giveAmount = 500;
+        $getAmount = 20;
+
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => $getAmount,
+            'expires_tick' => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertTrue($result['ok']);
+        $bonus = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedGive = (int) max(1, round($giveAmount * (1 - $bonus)));
+        $this->assertSame($expectedGive, $result['give_amount'], 'give_amount (Credits) must be discounted by the trading post channel rate');
+        $this->assertSame(1000 - $expectedGive, $this->getCredits());
+    }
+
+    public function test_accept_offer_has_no_discount_without_trading_post(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(null);
+
+        $giveAmount = 500;
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => 20,
+            'expires_tick' => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertSame($giveAmount, $result['give_amount'], 'no trading post → no discount, unchanged amount');
+    }
+
+    public function test_accept_offer_does_not_stack_trading_post_discount_with_negotiation(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(1);
+        $this->assignTrader(3); // rank 3 Konsul, siehe bestehende assignTrader()-Helper
+
+        $giveAmount = 500;
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => 20,
+            'expires_tick' => 20,
+        ]);
+
+        // Verhandeln setzt is_negotiated=true und passt give_amount bereits über den
+        // Konsul-Rang-Bonus an — der Handelsposten-Rabatt darf hier NICHT zusätzlich
+        // draufkommen (GDD: kein Stack-Effekt).
+        config(['game.bypass.ap_checks' => true]);
+        $negotiateResult = $this->barService->negotiateOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+        $this->assertTrue($negotiateResult['ok']);
+        $this->assertTrue($negotiateResult['success'] ?? false, 'negotiate must succeed for this assertion to be meaningful — check negotiate_success_chance fixture for rank 3');
+
+        $negotiatedGiveAmount = DB::table('bar_offers')->where('id', $offerId)->value('give_amount');
+
+        $acceptResult = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertSame((int) $negotiatedGiveAmount, $acceptResult['give_amount'], 'trading post discount must not stack on top of an already-negotiated offer');
+    }
+```
+
+**Hinweis für den Implementierer:** `test_accept_offer_does_not_stack_trading_post_discount_with_negotiation` hängt von `config('game.bar.negotiate_success_chance.3')` ab, das in den Testdaten >0 sein muss, damit der Roll zuverlässig erfolgreich ist. Falls der Test flaky ist (Zufalls-Roll schlägt manchmal fehl), prüfe `pseudoRand()` in `BarService` — der Roll ist deterministisch aus `$offer->id * 7919 + $currentTick * 131`, mit den festen Werten in diesem Test (offerId aus `insertOffer()`, tick=10) sollte das Ergebnis reproduzierbar sein. Falls der Roll bei diesen konkreten Werten fehlschlägt, passe `$currentTick` im Testaufruf an, bis der Roll erfolgreich ist — nicht die Erfolgswahrscheinlichkeit in der Config ändern.
+
+- [ ] **Step 2: Tests laufen lassen, Fehlschlag bestätigen**
+
+Run: `bin/phpunit --filter test_accept_offer_applies_trading_post_discount_when_credits_are_the_give_side`
+Expected: FAIL — `give_amount` ist noch nicht rabattiert (voller `$giveAmount` statt reduziertem Wert).
+
+- [ ] **Step 3: Rabatt in `acceptOffer()` verdrahten**
+
+In `app/Services/BarService.php`, im Konstruktor `TradingPostService` als Abhängigkeit ergänzen:
+
+```php
+    public function __construct(
+        private readonly ResourcesService $resourcesService,
+        private readonly AdvisorService $advisorService,
+        private readonly TradingPostService $tradingPostService,
+    ) {}
+```
+
+(Import ergänzen: `use App\Services\TradingPostService;` — falls die Datei bereits im selben Namespace `App\Services` liegt, ist kein `use` nötig, `BarService` liegt selbst in `App\Services`, kein Import erforderlich.)
+
+In `acceptOffer()`, direkt vor dem `DB::transaction(function () use ($offer, $colonyId, $apCost): void {`-Block (unmittelbar nach dem Reserve-Floor-Check) einfügen:
+
+```php
+        // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — nur auf
+        // nicht-verhandelte Angebote, kein Stack-Effekt mit dem
+        // Konsul-Rang-Verhandlungsbonus aus negotiateOffer().
+        $giveAmount = $offer->give_amount;
+        $getAmount = $offer->get_amount;
+        if (! $offer->is_negotiated) {
+            $discount = $this->tradingPostService->discountFor($colonyId, 'bar');
+            if ($discount > 0.0) {
+                $isCreditsOffer = $offer->give_resource_id === self::RES_CREDITS;
+                $giveAmount = $isCreditsOffer
+                    ? (int) max(1, round($offer->give_amount * (1 - $discount)))
+                    : $offer->give_amount;
+                $getAmount = $isCreditsOffer
+                    ? $offer->get_amount
+                    : (int) max(1, round($offer->get_amount * (1 + $discount)));
+            }
+        }
+```
+
+Dann im `DB::transaction(...)`-Block die Verwendung von `$offer->give_amount`/`$offer->get_amount` durch die neuen lokalen Variablen `$giveAmount`/`$getAmount` ersetzen:
+
+```php
+        DB::transaction(function () use ($offer, $colonyId, $apCost, $giveAmount, $getAmount): void {
+            $this->resourcesService->decreaseAmount($colonyId, $offer->give_resource_id, $giveAmount);
+            $this->resourcesService->increaseAmount($colonyId, $offer->get_resource_id, $getAmount);
+            $offer->is_accepted = true;
+            $offer->save();
+            if ($apCost > 0) {
+                $this->advisorService->lockActionPoints($colonyId, $apCost, self::TRADER_ADVISOR_ID);
+            }
+        });
+```
+
+Und im anschließenden `Log::info('bar_trade', [...])`-Aufruf sowie im finalen Return-Array `give_amount`/`get_amount` ebenfalls auf `$giveAmount`/`$getAmount` umstellen (statt `$offer->give_amount`/`$offer->get_amount`), damit Logging und Rückgabewert den tatsächlich vollzogenen (ggf. rabattierten) Betrag zeigen:
+
+```php
+        Log::info('bar_trade', [
+            'colony_id' => $colonyId,
+            'offer_id' => $offerId,
+            'give_resource_id' => $offer->give_resource_id,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => $offer->get_resource_id,
+            'get_amount' => $getAmount,
+        ]);
+
+        return [
+            'ok' => true,
+            'give_resource_id' => $offer->give_resource_id,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => $offer->get_resource_id,
+            'get_amount' => $getAmount,
+        ];
+```
+
+- [ ] **Step 4: Tests laufen lassen, Erfolg bestätigen**
+
+Run: `bin/phpunit --filter BarServiceTest`
+Expected: PASS (alle bisherigen Tests weiterhin grün + die 3 neuen)
+
+- [ ] **Step 5: Larastan prüfen**
+
+Run: `bin/phpstan analyse app/Services/BarService.php --no-progress`
+Expected: `[OK] No errors`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/BarService.php tests/Feature/Bar/BarServiceTest.php
+git commit -m "feat: Handelsposten-Rabatt in BarService::acceptOffer() verdrahten (kein Stack mit Konsul-Verhandlung)"
+```
+
+---
+
+### Task 4: Rabatt in `MerchantService::buyItem()` verdrahten (TDD)
+
+**Files:**
+- Modify: `app/Services/MerchantService.php`
+- Test: `tests/Feature/MerchantServiceTest.php`
+
+**Interfaces:**
+- Consumes: `TradingPostService::discountFor($colonyId, 'merchant')` (Task 2).
+- Produces: `buyItem()`s Rückgabe-Array bekommt das bestehende Format, `cost_credits` im geloggten/abgerechneten Betrag ist bei aktivem Kanal-Rabatt niedriger.
+
+- [ ] **Step 1: Fehlschlagende Tests schreiben**
+
+In `tests/Feature/MerchantServiceTest.php`, am Ende der Klasse (vor der schließenden `}`) einfügen — nutzt die bestehenden Helper `insertVisit()`/`insertItem()`/`setCredits()`/`getCredits()`/`mockTick()`:
+
+```php
+    // ── Handelsposten-Rabatt (Design-Spec 2026-08-23) ──────────────────────────
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 55)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => 55,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_buy_item_applies_trading_post_discount_to_cost(): void
+    {
+        $this->mockTick(20);
+        $this->setTradingPostLevel(2); // Stufe 2 schaltet den Reisender-Händler-Kanal frei
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId = $this->insertItem($visitId, [
+            'item_type' => 'trust_boost',
+            'payload' => json_encode(['trust_amount' => 15]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(300);
+        $this->setColonyResource(self::TRUST_RESOURCE_ID, 50);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertTrue($result['ok']);
+        $discount = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedCharge = (int) max(1, round(100 * (1 - $discount)));
+        $this->assertSame(300 - $expectedCharge, $result['credits'], 'buyItem must deduct the trading-post-discounted cost, not the full cost_credits');
+        $this->assertSame(300 - $expectedCharge, $this->getCredits());
+    }
+
+    public function test_buy_item_has_no_discount_without_trading_post(): void
+    {
+        $this->mockTick(20);
+        $this->setTradingPostLevel(null);
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId = $this->insertItem($visitId, [
+            'item_type' => 'trust_boost',
+            'payload' => json_encode(['trust_amount' => 15]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(300);
+        $this->setColonyResource(self::TRUST_RESOURCE_ID, 50);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(200, $result['credits'], 'no trading post → full cost_credits (100) deducted, unchanged from pre-existing behaviour');
+    }
+```
+
+- [ ] **Step 2: Tests laufen lassen, Fehlschlag bestätigen**
+
+Run: `bin/phpunit --filter test_buy_item_applies_trading_post_discount_to_cost`
+Expected: FAIL — `$result['credits']` ist `200` (voller Abzug) statt des rabattierten Werts.
+
+- [ ] **Step 3: Rabatt in `buyItem()` verdrahten**
+
+In `app/Services/MerchantService.php`, Konstruktor um `TradingPostService` ergänzen (gleiches Muster wie Task 3 Step 3):
+
+```php
+    public function __construct(
+        private readonly AdvisorService $advisorService,
+        private readonly BarService $barService,
+        private readonly ResourcesService $resourcesService,
+        private readonly TradingPostService $tradingPostService,
+    ) {}
+```
+
+In `buyItem(int $itemId, int $colonyId, int $userId): array`: der Rabatt muss VOR dem Credits-Check berechnet werden, damit ein Spieler, der sich den vollen Preis nicht leisten kann, den rabattierten aber schon, nicht fälschlich abgewiesen wird. Ersetze den bestehenden Block
+
+```php
+        // Check credits
+        $credits = (int) (DB::table('user_resources')
+            ->where('user_id', $userId)
+            ->value('credits') ?? 0);
+
+        if ($credits < $item->cost_credits) {
+            return ['ok' => false, 'error' => 'Nicht genug Credits.'];
+        }
+
+        // Deduct credits, apply effect and mark sold atomically.
+        DB::transaction(function () use ($item, $itemId, $colonyId, $userId): void {
+            DB::table('user_resources')
+                ->where('user_id', $userId)
+                ->decrement('credits', $item->cost_credits);
+
+            $this->applyItemEffect($item, $colonyId);
+
+            DB::table('merchant_items')
+                ->where('id', $itemId)
+                ->update(['sold' => true, 'updated_at' => now()]);
+        });
+
+        Log::info('merchant_purchase', [
+            'colony_id' => $colonyId,
+            'user_id' => $userId,
+            'item_id' => $itemId,
+            'item_type' => $item->item_type,
+            'cost_credits' => $item->cost_credits,
+        ]);
+```
+
+durch:
+
+```php
+        // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — Stufe 2 schaltet
+        // den Reisender-Händler-Kanal frei. Vor dem Credits-Check berechnet, damit
+        // die Affordability-Prüfung gegen den tatsächlich fälligen Betrag läuft.
+        $discount = $this->tradingPostService->discountFor($colonyId, 'merchant');
+        $chargedCredits = $discount > 0.0
+            ? (int) max(1, round($item->cost_credits * (1 - $discount)))
+            : $item->cost_credits;
+
+        // Check credits
+        $credits = (int) (DB::table('user_resources')
+            ->where('user_id', $userId)
+            ->value('credits') ?? 0);
+
+        if ($credits < $chargedCredits) {
+            return ['ok' => false, 'error' => 'Nicht genug Credits.'];
+        }
+
+        // Deduct credits, apply effect and mark sold atomically.
+        DB::transaction(function () use ($item, $itemId, $colonyId, $userId, $chargedCredits): void {
+            DB::table('user_resources')
+                ->where('user_id', $userId)
+                ->decrement('credits', $chargedCredits);
+
+            $this->applyItemEffect($item, $colonyId);
+
+            DB::table('merchant_items')
+                ->where('id', $itemId)
+                ->update(['sold' => true, 'updated_at' => now()]);
+        });
+
+        Log::info('merchant_purchase', [
+            'colony_id' => $colonyId,
+            'user_id' => $userId,
+            'item_id' => $itemId,
+            'item_type' => $item->item_type,
+            'cost_credits' => $chargedCredits,
+        ]);
+```
+
+**Hinweis:** Der finale Return-Block (`return ['ok' => true, 'message' => ..., 'credits' => $newCredits];`) braucht KEINE Änderung — `$newCredits` wird bereits nach dem `DB::transaction(...)`-Aufruf frisch aus der DB gelesen (`DB::table('user_resources')->where('user_id', $userId)->value('credits')`) und spiegelt damit automatisch den rabattierten Abzug wider.
+
+- [ ] **Step 4: Tests laufen lassen, Erfolg bestätigen**
+
+Run: `bin/phpunit --filter MerchantServiceTest`
+Expected: PASS (alle bisherigen + die 2 neuen)
+
+- [ ] **Step 5: Larastan prüfen**
+
+Run: `bin/phpstan analyse app/Services/MerchantService.php --no-progress`
+Expected: `[OK] No errors`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/MerchantService.php tests/Feature/MerchantServiceTest.php
+git commit -m "feat: Handelsposten-Rabatt in MerchantService::buyItem() verdrahten"
+```
+
+---
+
+### Task 5: Rabatt in `CorporateContactService` verdrahten (TDD)
+
+**Files:**
+- Modify: `app/Services/CorporateContactService.php`
+- Test: `tests/Feature/Colony/CorporateContactServiceTest.php`
+
+**Interfaces:**
+- Consumes: `TradingPostService::discountFor($colonyId, 'corporate_contact')` (Task 2).
+- Produces: `getActiveOffer()`s `price`-Feld ist bei aktivem Kanal-Rabatt (Stufe 3) niedriger — `buyHarvesterOffer()` re-derived denselben Preis, bleibt also automatisch konsistent (bestehendes "single source of truth"-Designprinzip dieser Klasse, siehe Klassendoc).
+
+- [ ] **Step 1: Fehlschlagende Tests schreiben**
+
+In `tests/Feature/Colony/CorporateContactServiceTest.php`, am Ende der Klasse (vor der schließenden `}`) einfügen. Nutzt `self::OFFER_HIT_TICK` (=71, dokumentiert deterministisch: Preis rollt ohne Rabatt auf 495 Cr, siehe Klassendoc) — der `setUp()` der Klasse hat bereits CC-Lv3 gesetzt und eine Harvester-Instanz platziert, beides für den Offer-Gate nötig:
+
+```php
+    // ── Handelsposten-Rabatt (Design-Spec 2026-08-23) ──────────────────────────
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 55)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => 55,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_active_offer_price_is_discounted_with_trading_post_level_3(): void
+    {
+        $this->setTradingPostLevel(null);
+        $offerWithoutDiscount = $this->service->getActiveOffer(self::COLONY_ID, self::USER_ID, self::OFFER_HIT_TICK);
+        $this->assertNotNull($offerWithoutDiscount);
+        $fullPrice = $offerWithoutDiscount['price'];
+
+        $this->setTradingPostLevel(3); // Stufe 3 schaltet den Nexus/Corporate-Contact-Kanal frei
+        $offerWithDiscount = $this->service->getActiveOffer(self::COLONY_ID, self::USER_ID, self::OFFER_HIT_TICK);
+        $this->assertNotNull($offerWithDiscount);
+
+        $discount = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedPrice = (int) max(1, round($fullPrice * (1 - $discount)));
+        $this->assertSame($expectedPrice, $offerWithDiscount['price'], 'active offer price must reflect the trading post discount at level 3');
+        $this->assertLessThan($fullPrice, $offerWithDiscount['price'], 'discounted price must be strictly lower than the undiscounted price');
+    }
+
+    public function test_active_offer_price_has_no_discount_below_level_3(): void
+    {
+        $this->setTradingPostLevel(2); // Schwelle für diesen Kanal ist 3, Level 2 unlockt ihn noch nicht
+
+        $offer = $this->service->getActiveOffer(self::COLONY_ID, self::USER_ID, self::OFFER_HIT_TICK);
+
+        $this->assertNotNull($offer);
+        $this->assertSame(495, $offer['price'], 'below the level-3 threshold, price must equal the documented undiscounted roll (495 Cr at OFFER_HIT_TICK)');
+    }
+```
+
+- [ ] **Step 2: Tests laufen lassen, Fehlschlag bestätigen**
+
+Run: `bin/phpunit --filter test_active_offer_price_is_discounted_with_trading_post_level_3`
+Expected: FAIL — `$offerWithDiscount['price']` ist identisch zu `$fullPrice` (kein Rabatt angewendet).
+
+- [ ] **Step 3: Rabatt verdrahten**
+
+In `app/Services/CorporateContactService.php`, Konstruktor um `TradingPostService` ergänzen:
+
+```php
+    public function __construct(
+        private readonly HarvesterEntitlementService $harvesterEntitlementService,
+        private readonly TradingPostService $tradingPostService,
+    ) {}
+```
+
+In `getActiveOffer(int $colonyId, int $userId, int $tick): ?array`, die letzte Zeile `return ['price' => $this->priceRoll($colonyId, $tick)];` ersetzen durch:
+
+```php
+        $price = $this->priceRoll($colonyId, $tick);
+
+        // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — Stufe 3 schaltet
+        // den Nexus/Corporate-Contact-Kanal frei.
+        $discount = $this->tradingPostService->discountFor($colonyId, 'corporate_contact');
+        if ($discount > 0.0) {
+            $price = (int) max(1, round($price * (1 - $discount)));
+        }
+
+        return ['price' => $price];
+```
+
+Da `buyHarvesterOffer()` den Preis über `getActiveOffer()` re-derived (nicht separat berechnet), ist keine weitere Änderung in `buyHarvesterOffer()` nötig — Anzeige- und Kaufpfad bleiben automatisch konsistent.
+
+- [ ] **Step 4: Tests laufen lassen, Erfolg bestätigen**
+
+Run: `bin/phpunit --filter CorporateContactServiceTest`
+Expected: PASS (alle bisherigen + die 2 neuen)
+
+- [ ] **Step 5: Larastan prüfen**
+
+Run: `bin/phpstan analyse app/Services/CorporateContactService.php --no-progress`
+Expected: `[OK] No errors`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/CorporateContactService.php tests/Feature/Colony/CorporateContactServiceTest.php
+git commit -m "feat: Handelsposten-Rabatt in CorporateContactService verdrahten"
+```
+
+---
+
+### Task 6: GDD-Abschnitt „Handelsposten" aktualisieren
+
+**Files:**
+- Modify: `docs/GDD.md` (Abschnitt „Handelsposten (tradingPost) — Mechanik", aktuell ca. Zeile 458-467)
+
+**Interfaces:** keine (reine Doku).
+
+- [ ] **Step 1: „Händlerkonditionen"-Absatz umschreiben**
+
+Der aktuelle Absatz:
+
+```
+**Passiv — Händlerkonditionen:**
+Der Reisende Händler bietet bei Anwesenheit eines Handelspostens bessere Preiskonditionen (Bonus auf Handelswert). Konkreter Wert nach Playtest kalibrieren (siehe `config/buildings.php`).
+```
+
+wird ersetzt durch:
+
+```
+**Passiv — Kanal-Rabatt (Design-Spec 2026-08-23):**
+Jede Ausbaustufe schaltet einen zusätzlichen Handelskanal für einen Preisrabatt frei, kumulativ: Stufe I (Bekannter Gast) den Kanal Cantina-Zufallsangebote, Stufe II (Fester Kunde) zusätzlich den Reisenden Händler, Stufe III (Persönlicher Kontakt) zusätzlich Nexus/Corporate Contact (Orin). Beim Cantina-Kanal gilt: kein Stack-Effekt mit dem Konsul-Rang-Verhandlungsbonus — der Rabatt gilt nur für nicht verhandelte Angebote. Exakter Rabattsatz: `config/buildings.php` → `merchant_price_bonus`.
+```
+
+- [ ] **Step 2: Veralteten TODO-Balance-Hinweis anpassen**
+
+Der aktuelle Satz `Handelswert-Bonus muss mit dem Konsul-Rang-System abgestimmt werden (kein Stack-Effekt wenn Konsul Experte + Handelsposten).` im `> **TODO Balance:**`-Absatz ist jetzt umgesetzt (siehe Task 3) — Satz entfernen, der Rest des TODO-Balance-Absatzes (Baukosten/Decay-Kalibrierung) bleibt unverändert stehen.
+
+- [ ] **Step 3: Bekannte, NICHT in diesem Plan behobene Diskrepanz nicht anfassen**
+
+Der Absatz „**Passiv — Konsul-Effizienz:**" (AP-Kostenreduktion für Trade-Orders) beschreibt einen Effekt, der in `config/buildings.php` für `tradingPost` nicht existiert (kein entsprechendes Config-Feld) — das ist vermutlich eine Verwechslung mit der bereits an anderer Stelle implementierten `trade`-Kenntnis-Domäneneffizienz (§13.3). **Nicht in diesem Plan beheben** — außerhalb des Scopes (dieser Plan behandelt ausschließlich den Kanal-Rabatt-Mechanismus). Kurz als Kommentar `<!-- TODO: Konsul-Effizienz-Absatz prüfen, evtl. Verwechslung mit trade-Kenntnis-Domäneneffizienz — separater Task -->` direkt vor dem Absatz einfügen, damit es beim nächsten GDD-Audit auffällt.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/GDD.md
+git commit -m "docs: Handelsposten-GDD-Abschnitt an Kanal-Rabatt-Mechanik anpassen"
+```
+
+---
+
+### Task 7: Gesamtabnahme
+
+**Files:** keine neuen — Verifikations-Task.
+
+- [ ] **Step 1: Volle Test-Suite laufen lassen**
+
+Run: `bin/phpunit`
+Expected: alle Tests PASS (bestehende + alle in Tasks 2-5 neu hinzugekommenen)
+
+- [ ] **Step 2: Larastan über das ganze Projekt laufen lassen**
+
+Run: `bin/phpstan analyse --no-progress`
+Expected: `[OK] No errors`
+
+- [ ] **Step 3: CHANGELOG-Eintrag ergänzen**
+
+In `CHANGELOG.md`, unter dem aktuellen Tagesdatum (neue Sektion anlegen, falls der Tag noch keine hat, sonst bestehende Sektion ergänzen):
+
+```
+- Feat: Handelsposten (tradingPost) bekommt seine erste echte Spielwirkung — Kanal-Rabatt-Freischaltung je Ausbaustufe (I=Cantina, II=+Reisender Händler, III=+Nexus/Corporate Contact), kumulativ, kein Stack-Effekt mit dem Konsul-Rang-Verhandlungsbonus. Bisher komplett wirkungsloser `merchant_price_bonus`-Config-Wert wird jetzt tatsächlich angewendet. Neuer `TradingPostService`, verdrahtet in `BarService`/`MerchantService`/`CorporateContactService`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: CHANGELOG-Eintrag für Handelsposten-Kanal-Rabatte"
+```
+
+---
+
+## Self-Review-Notiz (vom Planautor, nicht Teil der Ausführung)
+
+- **Spec-Abdeckung:** Kanal-Schwellen I/II/III → Task 2. Verdrahtung in alle 3 bestehenden Handelskanäle → Task 3-5. Kein-Stack-Regel mit Konsul → Task 3 explizit getestet. GDD-Umschreibung → Task 6.
+- **Bewusst nicht Teil dieses Plans** (siehe Haupt-Spec „Offene Folge-Tasks"): Zahlen-Kalibrierung des Rabattsatzes, die im GDD als Diskrepanz markierte „Konsul-Effizienz"-Behauptung (Task 6 Step 3 markiert sie nur, behebt sie nicht).
+- **Cross-Task-Konsistenz geprüft:** Alle drei Verdrahtungs-Tasks (3-5) rufen exakt dieselbe `TradingPostService::discountFor()`-Signatur mit den exakt in Task 2 definierten Channel-Strings (`'bar'`, `'merchant'`, `'corporate_contact'`) auf — keine abweichenden String-Literale.

--- a/tests/Feature/Bar/BarServiceTest.php
+++ b/tests/Feature/Bar/BarServiceTest.php
@@ -1208,4 +1208,110 @@ class BarServiceTest extends TestCase
 
         $this->assertEquals($baseMax, $activeCount, 'trade Lv0 must leave the concurrent offer cap unchanged');
     }
+
+    // ── Handelsposten-Rabatt (Design-Spec 2026-08-23) ──────────────────────────
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 55)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => 55,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_accept_offer_applies_trading_post_discount_when_credits_are_the_give_side(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(1); // Stufe 1 schaltet den Cantina-Kanal frei
+
+        $giveAmount = 500;
+        $getAmount = 20;
+
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => $getAmount,
+            'expires_tick' => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertTrue($result['ok']);
+        $bonus = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedGive = (int) max(1, round($giveAmount * (1 - $bonus)));
+        $this->assertSame($expectedGive, $result['give_amount'], 'give_amount (Credits) must be discounted by the trading post channel rate');
+        $this->assertSame(1000 - $expectedGive, $this->getCredits());
+    }
+
+    public function test_accept_offer_has_no_discount_without_trading_post(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(null);
+
+        $giveAmount = 500;
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => 20,
+            'expires_tick' => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertSame($giveAmount, $result['give_amount'], 'no trading post → no discount, unchanged amount');
+    }
+
+    public function test_accept_offer_does_not_stack_trading_post_discount_with_negotiation(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(1);
+        $this->assignTrader(3); // rank 3 Konsul, siehe bestehende assignTrader()-Helper
+
+        $giveAmount = 500;
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => 20,
+            'expires_tick' => 20,
+        ]);
+
+        // Verhandeln setzt is_negotiated=true und passt give_amount bereits über den
+        // Konsul-Rang-Bonus an — der Handelsposten-Rabatt darf hier NICHT zusätzlich
+        // draufkommen (GDD: kein Stack-Effekt).
+        config(['game.bypass.ap_checks' => true]);
+        // tick=11 (not 10) — deterministic pseudoRand roll for this offerId/rank
+        // combination only lands as a negotiation success at tick=11; see brief note.
+        $negotiateResult = $this->barService->negotiateOffer(self::COLONY_ID, $offerId, self::USER_ID, 11);
+        $this->assertTrue($negotiateResult['ok']);
+        $this->assertTrue($negotiateResult['success'] ?? false, 'negotiate must succeed for this assertion to be meaningful — check negotiate_success_chance fixture for rank 3');
+
+        $negotiatedGiveAmount = DB::table('bar_offers')->where('id', $offerId)->value('give_amount');
+
+        $acceptResult = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 11);
+
+        $this->assertSame((int) $negotiatedGiveAmount, $acceptResult['give_amount'], 'trading post discount must not stack on top of an already-negotiated offer');
+    }
 }

--- a/tests/Feature/Bar/BarServiceTest.php
+++ b/tests/Feature/Bar/BarServiceTest.php
@@ -1314,4 +1314,83 @@ class BarServiceTest extends TestCase
 
         $this->assertSame((int) $negotiatedGiveAmount, $acceptResult['give_amount'], 'trading post discount must not stack on top of an already-negotiated offer');
     }
+
+    /**
+     * Whole-Branch-Review-Fund 2026-08-27: the affordability check must run against
+     * the DISCOUNTED price, not the offer's full give_amount — otherwise a player
+     * who can afford the discounted price but not the full price is wrongly
+     * rejected with bar_offer_insufficient_resources.
+     */
+    public function test_accept_offer_succeeds_when_only_discounted_price_is_affordable(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(1); // Stufe 1 schaltet den Cantina-Kanal frei, 12% Rabatt
+
+        $giveAmount = 500;
+        $getAmount = 20;
+
+        // 450 liegt zwischen dem rabattierten Preis (~440 bei 12%) und dem vollen
+        // Preis (500) — mit dem alten Bug wäre die Prüfung gegen 500 gelaufen und
+        // hätte fälschlich abgelehnt.
+        $this->setCredits(450);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => $getAmount,
+            'expires_tick' => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $bonus = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedGive = (int) max(1, round($giveAmount * (1 - $bonus)));
+        $this->assertLessThan($giveAmount, $expectedGive, 'fixture assumption: discounted price must be strictly below the full price for this test to be meaningful');
+        $this->assertLessThanOrEqual(450, $expectedGive, 'fixture assumption: discounted price must be affordable at 450 credits for this test to be meaningful');
+
+        $this->assertTrue($result['ok'] ?? false, 'offer must be accepted when the player can afford the discounted price, even if not the full price');
+        $this->assertSame($expectedGive, $result['give_amount']);
+        $this->assertSame(450 - $expectedGive, $this->getCredits());
+    }
+
+    /**
+     * Covers the previously-untested non-credits branch of the trading post
+     * discount: when the give side is a colony resource (not credits), the
+     * discount instead increases the get_amount the player receives.
+     */
+    public function test_accept_offer_discount_applies_to_get_amount_when_resources_are_the_give_side(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(1); // Stufe 1 schaltet den Cantina-Kanal frei, 12% Rabatt
+
+        $giveAmount = 20;
+        $originalGetAmount = 10;
+
+        $this->setColonyResource(self::RES_REGOLITH, 100);
+        $this->setCredits(0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_REGOLITH,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_CREDITS,
+            'get_amount' => $originalGetAmount,
+            'expires_tick' => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $bonus = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedGet = (int) max(1, round($originalGetAmount * (1 + $bonus)));
+        $this->assertGreaterThan($originalGetAmount, $expectedGet, 'fixture assumption: discount must actually raise get_amount for this test to be meaningful');
+
+        $this->assertTrue($result['ok'] ?? false);
+        $this->assertSame($giveAmount, $result['give_amount'], 'give_amount must be unchanged on the non-credits branch');
+        $this->assertSame($expectedGet, $result['get_amount'], 'get_amount must be boosted by the discount rate when resources (not credits) are the give side');
+        $this->assertSame($expectedGet, $this->getCredits());
+        $this->assertSame(100 - $giveAmount, $this->getColonyResource(self::RES_REGOLITH));
+    }
 }

--- a/tests/Feature/Colony/CorporateContactServiceTest.php
+++ b/tests/Feature/Colony/CorporateContactServiceTest.php
@@ -166,4 +166,49 @@ class CorporateContactServiceTest extends TestCase
         $this->assertTrue($entitlementService->hasEntitlement(self::USER_ID));
         $this->assertFalse($entitlementService->isSalvageSourced(self::USER_ID), 'purchase path must not be marked as salvage-sourced');
     }
+
+    // ── Handelsposten-Rabatt (Design-Spec 2026-08-23) ──────────────────────────
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 55)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => 55,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_active_offer_price_is_discounted_with_trading_post_level_3(): void
+    {
+        $this->setTradingPostLevel(null);
+        $offerWithoutDiscount = $this->service->getActiveOffer(self::COLONY_ID, self::USER_ID, self::OFFER_HIT_TICK);
+        $this->assertNotNull($offerWithoutDiscount);
+        $fullPrice = $offerWithoutDiscount['price'];
+
+        $this->setTradingPostLevel(3); // Stufe 3 schaltet den Nexus/Corporate-Contact-Kanal frei
+        $offerWithDiscount = $this->service->getActiveOffer(self::COLONY_ID, self::USER_ID, self::OFFER_HIT_TICK);
+        $this->assertNotNull($offerWithDiscount);
+
+        $discount = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedPrice = (int) max(1, round($fullPrice * (1 - $discount)));
+        $this->assertSame($expectedPrice, $offerWithDiscount['price'], 'active offer price must reflect the trading post discount at level 3');
+        $this->assertLessThan($fullPrice, $offerWithDiscount['price'], 'discounted price must be strictly lower than the undiscounted price');
+    }
+
+    public function test_active_offer_price_has_no_discount_below_level_3(): void
+    {
+        $this->setTradingPostLevel(2); // Schwelle für diesen Kanal ist 3, Level 2 unlockt ihn noch nicht
+
+        $offer = $this->service->getActiveOffer(self::COLONY_ID, self::USER_ID, self::OFFER_HIT_TICK);
+
+        $this->assertNotNull($offer);
+        $this->assertSame(495, $offer['price'], 'below the level-3 threshold, price must equal the documented undiscounted roll (495 Cr at OFFER_HIT_TICK)');
+    }
 }

--- a/tests/Feature/MerchantServiceTest.php
+++ b/tests/Feature/MerchantServiceTest.php
@@ -812,4 +812,65 @@ class MerchantServiceTest extends TestCase
 
         $this->assertTrue($foreignStillFalse, 'markVisited must not affect visits belonging to other colonies');
     }
+
+    // ── Handelsposten-Rabatt (Design-Spec 2026-08-23) ──────────────────────────
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', 55)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => 55,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_buy_item_applies_trading_post_discount_to_cost(): void
+    {
+        $this->mockTick(20);
+        $this->setTradingPostLevel(2); // Stufe 2 schaltet den Reisender-Händler-Kanal frei
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId = $this->insertItem($visitId, [
+            'item_type' => 'trust_boost',
+            'payload' => json_encode(['trust_amount' => 15]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(300);
+        $this->setColonyResource(self::TRUST_RESOURCE_ID, 50);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertTrue($result['ok']);
+        $discount = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $expectedCharge = (int) max(1, round(100 * (1 - $discount)));
+        $this->assertSame(300 - $expectedCharge, $result['credits'], 'buyItem must deduct the trading-post-discounted cost, not the full cost_credits');
+        $this->assertSame(300 - $expectedCharge, $this->getCredits());
+    }
+
+    public function test_buy_item_has_no_discount_without_trading_post(): void
+    {
+        $this->mockTick(20);
+        $this->setTradingPostLevel(null);
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId = $this->insertItem($visitId, [
+            'item_type' => 'trust_boost',
+            'payload' => json_encode(['trust_amount' => 15]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(300);
+        $this->setColonyResource(self::TRUST_RESOURCE_ID, 50);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(200, $result['credits'], 'no trading post → full cost_credits (100) deducted, unchanged from pre-existing behaviour');
+    }
 }

--- a/tests/Feature/TradingPostServiceTest.php
+++ b/tests/Feature/TradingPostServiceTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\TradingPostService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * TradingPostService::discountFor() — Kanal-Rabatt-Schwellen (Design-Spec
+ * 2026-08-23, Abschnitt "Handelsposten"): Stufe 1 = Cantina, Stufe 2 = +Reisender
+ * Händler, Stufe 3 = +Nexus/Corporate Contact. Kumulativ, nicht exklusiv.
+ */
+class TradingPostServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const TRADING_POST_ID = 55;
+
+    private TradingPostService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        $this->service = $this->app->make(TradingPostService::class);
+    }
+
+    private function setTradingPostLevel(?int $level): void
+    {
+        DB::table('colony_buildings')->where('colony_id', self::COLONY_ID)->where('building_id', self::TRADING_POST_ID)->delete();
+
+        if ($level !== null) {
+            DB::table('colony_buildings')->insert([
+                'colony_id' => self::COLONY_ID,
+                'building_id' => self::TRADING_POST_ID,
+                'instance_id' => 1,
+                'level' => $level,
+                'status_points' => 20,
+                'ap_spend' => 0,
+            ]);
+        }
+    }
+
+    public function test_no_trading_post_gives_zero_discount_on_every_channel(): void
+    {
+        $this->setTradingPostLevel(null);
+
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_level_1_unlocks_only_bar_channel(): void
+    {
+        $this->setTradingPostLevel(1);
+
+        $expected = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_level_2_unlocks_bar_and_merchant_cumulatively(): void
+    {
+        $this->setTradingPostLevel(2);
+
+        $expected = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_level_3_unlocks_all_three_channels(): void
+    {
+        $this->setTradingPostLevel(3);
+
+        $expected = (float) config('buildings.tradingPost.merchant_price_bonus');
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'bar'));
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'merchant'));
+        $this->assertSame($expected, $this->service->discountFor(self::COLONY_ID, 'corporate_contact'));
+    }
+
+    public function test_unknown_channel_returns_zero_not_an_error(): void
+    {
+        $this->setTradingPostLevel(3);
+
+        $this->assertSame(0.0, $this->service->discountFor(self::COLONY_ID, 'not_a_real_channel'));
+    }
+}


### PR DESCRIPTION
## Summary
Zweite Umsetzungsphase der Ausbaustufen-Spec (`docs/superpowers/specs/2026-08-23-building-tier-system-design.md`) — per Subagent-Driven-Development (7 Tasks + Whole-Branch-Review + Fix-Wave):

- Handelsposten (tradingPost), bisher eine komplett wirkungslose Hülle, bekommt seine erste echte Spielwirkung
- Neuer `TradingPostService::discountFor()` mit Kanal-Schwellen: Stufe I=Cantina-Zufallsangebote, II=+Reisender Händler, III=+Nexus/Corporate Contact — kumulativ
- Verdrahtet in `BarService`, `MerchantService`, `CorporateContactService`
- Kein Stack-Effekt mit dem expliziten Konsul-Verhandlungsbonus (`negotiate_bonus`) — Rabatt gilt nur für nicht verhandelte Cantina-Angebote
- GDD-Abschnitt „Handelsposten" entsprechend aktualisiert

**Whole-Branch-Review-Funde (behoben):**
- Echter Bug: `BarService::acceptOffer()` prüfte die Bezahlbarkeit gegen den vollen statt den rabattierten Betrag — derselbe Fehler, der in `MerchantService::buyItem()` bereits korrekt vermieden wurde, hier aber übersehen. Fix + 2 Regressionstests.
- Doku-Übertreibung korrigiert: die GDD-Aussage "kein Stack-Effekt mit dem Konsul-Rang-Bonus" deckte nur den expliziten Verhandlungsbonus ab — der passive, bei Angebots-Generierung eingerechnete Rang-Rabatt (`trader_discount`) stackt weiterhin und ist als offene Design-/Balance-Frage im GDD vermerkt statt fälschlich als gelöst dargestellt.

Bewusst NICHT Teil dieses PRs: die trader_discount-Stacking-Frage selbst lösen (Design-Entscheidung außerhalb des Scopes), UI-Live-Anzeige des Rabatts bei Bar/Merchant (Corporate Contact zeigt ihn schon korrekt), Balance-Kalibrierung (ADR 0004).

## Test plan
- [x] `bin/phpunit` komplett grün (1042 Tests)
- [x] `bin/phpstan analyse` fehlerfrei
- [x] Jeder der 7 Tasks einzeln task-reviewed (spec + quality), finale Whole-Branch-Review (opus) + Fix-Wave + Scoped-Re-Review durchlaufen — alle Findings adressiert