### PR TITLE
feat: Analytik-Labor-Kenntnis-Effizienzbonus (Plan 3/5, Kenntnis-Effekte)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-28
+
+- Feat: Analytik-Labor (sciencelab) Stufe IV/V bekommen ihre erste echte Spielwirkung — Domänen-Effizienzbonus "Wissen", senkt die AP-Kosten für Kenntnis-Levelups (bisher komplett unrabattiert), additiv und unabhängig vom bestehenden Gebäude-Rabatt-Pool (`ProjectBonusService::DOMAIN_KNOWLEDGE_KEYS`, Mitglieder je nach Ausführungsreihenfolge mit dem cartography-Plan variabel — construction+trade oder construction+cartography+trade). Neue `ProjectBonusService::knowledgeApDiscountPercent()`/`effectiveKnowledgeApForLevelup()`, verdrahtet in `ResearchService::knowledgeLevelupCost()`.
+
 ## 2026-08-27
 
 - Fix: Whole-Branch-Review-Fund am Handelsposten-Kanal-Rabatt — `BarService::acceptOffer()` prüfte Affordability/Reserve-Floor gegen den vollen statt den rabattierten Preis (dieselbe Lücke, die in `MerchantService::buyItem()` schon behoben war), + 2 Regressionstests. GDD-Absatz präzisiert (nur der explizite Verhandlungsbonus ist vom Stack-Ausschluss erfasst, der passive `trader_discount` stackt noch ungeprüft — offene Design-Frage) und veralteter `merchant_price_bonus`-Kommentar in `config/buildings.php` aktualisiert.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2026-08-28
 
-- Feat: Analytik-Labor (sciencelab) Stufe IV/V bekommen ihre erste echte Spielwirkung — Domänen-Effizienzbonus "Wissen", senkt die AP-Kosten für Kenntnis-Levelups (bisher komplett unrabattiert), additiv und unabhängig vom bestehenden Gebäude-Rabatt-Pool (`ProjectBonusService::DOMAIN_KNOWLEDGE_KEYS`, Mitglieder je nach Ausführungsreihenfolge mit dem cartography-Plan variabel — construction+trade oder construction+cartography+trade). Neue `ProjectBonusService::knowledgeApDiscountPercent()`/`effectiveKnowledgeApForLevelup()`, verdrahtet in `ResearchService::knowledgeLevelupCost()`.
+- Feat: Analytik-Labor (sciencelab) Stufe IV/V bekommen ihre erste echte Spielwirkung — Domänen-Effizienzbonus "Wissen", senkt die AP-Kosten für Kenntnis-Levelups (bisher komplett unrabattiert), additiv und unabhängig vom bestehenden Gebäude-Rabatt-Pool (`ProjectBonusService::DOMAIN_KNOWLEDGE_KEYS`, derzeit construction+cartography+trade). Neue `ProjectBonusService::knowledgeApDiscountPercent()`/`effectiveKnowledgeApForLevelup()`, verdrahtet in `ResearchService::knowledgeLevelupCost()` und `GameTick::grantResearchAp()`.
 
 ## 2026-08-27
 

--- a/app/Console/Commands/GameTick.php
+++ b/app/Console/Commands/GameTick.php
@@ -17,6 +17,7 @@ use App\Services\EventService;
 use App\Services\HarvesterEntitlementService;
 use App\Services\MerchantService;
 use App\Services\OnboardingTriggerService;
+use App\Services\ProjectBonusService;
 use App\Services\ResourcesService;
 use App\Services\RunProgressService;
 use App\Services\TickService;
@@ -67,6 +68,7 @@ class GameTick extends Command
         private readonly TrustService $trustService,
         private readonly ResourcesService $resourcesService,
         private readonly OnboardingTriggerService $onboardingTriggerService,
+        private readonly ProjectBonusService $projectBonusService,
         private readonly BarService $barService,
         private readonly MerchantService $merchantService,
         private readonly HarvesterEntitlementService $harvesterEntitlementService,
@@ -492,7 +494,10 @@ class GameTick extends Command
 
         $currentLevel = (int) ($row->level ?? 0);
         $costs = collect(config('knowledge'))->firstWhere('id', $researchId)['levelup_costs'] ?? [];
-        $threshold = (int) ($costs[$currentLevel + 1] ?? PHP_INT_MAX);
+        $rawThreshold = (int) ($costs[$currentLevel + 1] ?? PHP_INT_MAX);
+        $threshold = $rawThreshold === PHP_INT_MAX
+            ? PHP_INT_MAX
+            : $this->projectBonusService->effectiveKnowledgeApForLevelup($colonyId, $rawThreshold);
         $newSpend = min(((int) ($row->ap_spend ?? 0)) + $points, $threshold);
 
         DB::table('colony_researches')->updateOrInsert(

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Services\ColonyService;
 use App\Services\EventService;
 use App\Services\MerchantService;
 use App\Services\OnboardingHintService;
+use App\Services\ProjectBonusService;
 use App\Services\ResourcesService;
 use App\Services\Techtree\BuildingService;
 use App\Services\Techtree\ResearchService;
@@ -74,6 +75,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(ResearchService::class, fn ($app) => new ResearchService(
             $app->make(TickService::class),
             $app->make(ResourcesService::class),
+            $app->make(ProjectBonusService::class),
             $app->make(AdvisorService::class),
         ));
         $this->app->bind(ShipService::class, fn ($app) => new ShipService(

--- a/app/Services/ProjectBonusService.php
+++ b/app/Services/ProjectBonusService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Console\Commands\GameTick;
+use App\Enums\BuildingId;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -40,6 +41,33 @@ class ProjectBonusService
     public function effectiveApForLevelup(int $colonyId, int $baseApForLevelup): int
     {
         $discountPercent = $this->buildingApDiscountPercent($colonyId);
+        $minCostFactor = (float) config('game.project_min_cost_factor', 0.5);
+
+        return self::applyDiscount($baseApForLevelup, $discountPercent, $minCostFactor);
+    }
+
+    /**
+     * Additive AP-cost discount for Kenntnis-Levelups, sourced from the
+     * Analytik-Labor (sciencelab) building level — a separate, independent pool
+     * from buildingApDiscountPercent() above. Only levels 4-5 carry an effect
+     * (levels 1-3 remain pure knowledge-gate thresholds, no discount of their
+     * own — see docs/superpowers/plans/2026-08-26-building-tier-foundation.md).
+     */
+    public function knowledgeApDiscountPercent(int $colonyId): int
+    {
+        $level = (int) (DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', BuildingId::Sciencelab->value)
+            ->value('level') ?? 0);
+
+        $curve = config('buildings.sciencelab.ap_cost_reduction_per_lv', []);
+
+        return GameTick::cumulativeCurveYield($curve, $level);
+    }
+
+    public function effectiveKnowledgeApForLevelup(int $colonyId, int $baseApForLevelup): int
+    {
+        $discountPercent = $this->knowledgeApDiscountPercent($colonyId);
         $minCostFactor = (float) config('game.project_min_cost_factor', 0.5);
 
         return self::applyDiscount($baseApForLevelup, $discountPercent, $minCostFactor);

--- a/app/Services/ProjectBonusService.php
+++ b/app/Services/ProjectBonusService.php
@@ -11,7 +11,9 @@ use Illuminate\Support\Facades\DB;
  * three "domain knowledge" curves (construction, cartography, trade) — advisor-rank
  * and CC-level bonus sources from the same GDD table are not yet implemented (out of
  * scope for this plan, see docs/superpowers/specs/2026-08-15-knowledge-effects-and-
- * encounters-design.md §2).
+ * encounters-design.md §2). Also hosts a second, independent discount pool for
+ * Kenntnis-Levelup-AP-Kosten, sourced from the Analytik-Labor (sciencelab) building
+ * level — see knowledgeApDiscountPercent() below.
  */
 class ProjectBonusService
 {
@@ -60,7 +62,7 @@ class ProjectBonusService
             ->where('building_id', BuildingId::Sciencelab->value)
             ->value('level') ?? 0);
 
-        $curve = config('buildings.sciencelab.ap_cost_reduction_per_lv', []);
+        $curve = config('buildings.sciencelab.knowledge_ap_cost_reduction_per_lv', []);
 
         return GameTick::cumulativeCurveYield($curve, $level);
     }

--- a/app/Services/Techtree/ResearchService.php
+++ b/app/Services/Techtree/ResearchService.php
@@ -3,6 +3,10 @@
 namespace App\Services\Techtree;
 
 use App\Enums\BuildingId;
+use App\Services\AdvisorService;
+use App\Services\ProjectBonusService;
+use App\Services\ResourcesService;
+use App\Services\TickService;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -13,6 +17,15 @@ use Illuminate\Support\Facades\DB;
  */
 class ResearchService extends AbstractTechnologyService
 {
+    public function __construct(
+        TickService $tickService,
+        ResourcesService $resourcesService,
+        private readonly ProjectBonusService $projectBonusService,
+        ?AdvisorService $advisorService = null,
+    ) {
+        parent::__construct($tickService, $resourcesService, $advisorService);
+    }
+
     protected function masterTable(): string
     {
         return 'researches';
@@ -110,6 +123,8 @@ class ResearchService extends AbstractTechnologyService
         $targetLevel = $currentLevel + 1;
         $costs = collect(config('knowledge'))->firstWhere('id', $entityId)['levelup_costs'] ?? [];
 
-        return (int) ($costs[$targetLevel] ?? $fallback);
+        $rawCost = (int) ($costs[$targetLevel] ?? $fallback);
+
+        return $this->projectBonusService->effectiveKnowledgeApForLevelup($colonyId, $rawCost);
     }
 }

--- a/config/buildings.php
+++ b/config/buildings.php
@@ -160,6 +160,15 @@ return [
         // (separater Folge-Plan, noch nicht implementiert — Level-Deckel wird
         // hier vorab gesetzt, damit er nicht vergessen wird).
         'max_level' => 5,
+        // Domänen-Effizienzbonus "Wissen" (Design-Spec 2026-08-23) — senkt die
+        // AP-Kosten für Kenntnis-Levelups, analog zu den ap_cost_reduction_per_lv-
+        // Effekten von construction/cartography/trade (die Gebäude-Levelups
+        // rabattieren, siehe config/knowledge.php). Nur Lv4/5 tragen einen Wert,
+        // Lv1-3 bleiben reine Kenntnis-Gates. Platzhalter-Größenordnung angelehnt
+        // an die Kurven-Enden der Kenntnis-Domänen (Lv4=3, Lv5=2 Prozentpunkte
+        // dort) — eigenständig gewählt, da hier nur 2 statt 5 Stufen zur
+        // Verfügung stehen. Zahlen-Kalibrierung nach Playtest (ADR 0004).
+        'ap_cost_reduction_per_lv' => [4 => 3, 5 => 2],   // Σ5% bei Lv5
     ],
 
     // ── Fleet ─────────────────────────────────────────────────────────────────

--- a/config/buildings.php
+++ b/config/buildings.php
@@ -157,18 +157,21 @@ return [
         // Gedeckelt auf 5 (2026-08-25) — Ausnahme von der max.-3-Regel: Lv1-3
         // bleiben Kenntnis-Freischalt-Gates (unverändert, siehe researches-
         // Migrationen), Lv4/5 bekommen einen Domänen-Effizienzbonus "Wissen"
-        // (separater Folge-Plan, noch nicht implementiert — Level-Deckel wird
-        // hier vorab gesetzt, damit er nicht vergessen wird).
+        // (implementiert via ProjectBonusService::effectiveKnowledgeApForLevelup(),
+        // siehe knowledge_ap_cost_reduction_per_lv unten).
         'max_level' => 5,
         // Domänen-Effizienzbonus "Wissen" (Design-Spec 2026-08-23) — senkt die
         // AP-Kosten für Kenntnis-Levelups, analog zu den ap_cost_reduction_per_lv-
         // Effekten von construction/cartography/trade (die Gebäude-Levelups
-        // rabattieren, siehe config/knowledge.php). Nur Lv4/5 tragen einen Wert,
+        // rabattieren, siehe config/knowledge.php) — eigener Config-Key, da beide
+        // Kurven im selben Namensraum sonst kollidieren würden (invertierte
+        // Semantik: hier rabattiert Gebäude-Level Kenntnis-Kosten, dort
+        // rabattiert Kenntnis-Level Gebäude-Kosten). Nur Lv4/5 tragen einen Wert,
         // Lv1-3 bleiben reine Kenntnis-Gates. Platzhalter-Größenordnung angelehnt
         // an die Kurven-Enden der Kenntnis-Domänen (Lv4=3, Lv5=2 Prozentpunkte
         // dort) — eigenständig gewählt, da hier nur 2 statt 5 Stufen zur
         // Verfügung stehen. Zahlen-Kalibrierung nach Playtest (ADR 0004).
-        'ap_cost_reduction_per_lv' => [4 => 3, 5 => 2],   // Σ5% bei Lv5
+        'knowledge_ap_cost_reduction_per_lv' => [4 => 3, 5 => 2],   // Σ5% bei Lv5
     ],
 
     // ── Fleet ─────────────────────────────────────────────────────────────────

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -778,7 +778,7 @@ Ein Level-Up ist zusätzlich gerechtfertigt, wenn die Stufe **etwas Bestimmtes f
 | **Wohnhabitat** | Instanz | 6 | Unverändert. |
 | **Agrardom** | **Instanz** | offen | Mehrere Kuppeln; Nahrungsproduktion skaliert natürlich mit der Anzahl. Umstellung von Level auf Instanz. |
 | **Hangar** | **Instanz + Level** | Instanzen offen, Lv3 | Der einzige Fall, der beide Achsen braucht — siehe unten. |
-| **Analytik-Labor** | Level | Lv3+ | Die Level **sind** die Kenntnis-Stufen (`cartography` Lv1, `geology`/`trade` Lv2, `defense` Lv3). Ohne sie bricht die Staffelung weg. |
+| **Analytik-Labor** | Level | Lv3+ | Lv1-3 **sind** die Kenntnis-Stufen (`cartography` Lv1, `geology`/`trade` Lv2, `defense` Lv3) — ohne sie bricht die Staffelung weg. Lv4/5 haben zusätzlich einen eigenen Effekt (Kenntnis-Kosten-Rabatt, s.o.), keine reinen Gate-Stufen mehr. |
 | **Uplink-Station** | Level | Lv3 | §4 nennt sie „das einzige Kommunikationsgebäude der Kolonie". Eine zweite Funkanlage verdoppelt keine Reichweite. |
 | **Sicherheits-Hub** | Level | Lv3 | Eine pro Kolonie. |
 | **Handelsposten** | Level | Lv3 | Eine pro Kolonie. |
@@ -1761,7 +1761,9 @@ Boni senken die **AP-Kosten von Projekten** und verkürzen damit die Bauzeit in 
 
 Mehrere unabhängige Quellen tragen zu gestaffelten Kostenreduktionen bei: Berater-Ränge, Kenntnis-Level nach Domäne, und Koloniereife (CC-Level). Exakte Boni und Maxima: siehe `config/game.php` → `project_cost_bonus`.
 
-Domänen-Kenntnis-Zuordnung: Bau ← `construction`, Navigation ← `cartography`, Wirtschaft ← `trade`. Für die Domäne **Wissen** gibt es keine passende Kenntnis — dort stattdessen **Analytik-Labor-Level-Boni** (max Laborausbau Lv5). Diese asymmetrische Bindung gibt dem Laborausbau endlich einen eigenen mechanischen Effekt (heute hat er außer dem Kenntnis-Gate keinen).
+Domänen-Kenntnis-Zuordnung: Bau ← `construction`, Navigation ← `cartography`, Wirtschaft ← `trade`. Für die Domäne **Wissen** gibt es keine passende Kenntnis — ein früher Entwurf sah hier stattdessen Analytik-Labor-Level-Boni auf denselben Gebäude-Rabatt-Pool vor; das wurde durch eine eigenständige Mechanik ersetzt (siehe unten, „Analytik-Labor Lv4/5"): Analytik-Labor-Level senken stattdessen die AP-Kosten von **Kenntnis-Levelups** selbst, ein separater Pool, kein vierter Beitrag zu diesem hier beschriebenen Gebäude-Rabatt.
+
+**Analytik-Labor Lv4/5 (Design-Spec 2026-08-23, umgesetzt 2026-08-27):** Gibt dem Laborausbau über die reinen Kenntnis-Gates (Lv1-3) hinaus einen eigenen mechanischen Effekt — senkt die AP-Kosten für Kenntnis-Levelups, additiv, unabhängig vom Gebäude-Rabatt-Pool oben. Rührt an nichts, was pro Run gezogen wird (§10 Roguelike-Variabilität bleibt unangetastet) — reine Effizienzsteigerung auf bereits freigeschaltete Kenntnisse. Exakte Werte: `config/buildings.php` → `sciencelab.ap_cost_reduction_per_lv`.
 
 Ein **Mindest-Kostenanteil** (`project_min_cost_factor`) verhindert, dass Projekte auf null fallen — das ist eine Leitplanke für spätere Bonusquellen (Events, Missionsbelohnungen, Run-Modifier), keine aktive Regel zum Start. Wichtig, das so zu lesen, damit später niemand gegen einen Deckel kalibriert, der gar nicht wirkt.
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -778,7 +778,7 @@ Ein Level-Up ist zusätzlich gerechtfertigt, wenn die Stufe **etwas Bestimmtes f
 | **Wohnhabitat** | Instanz | 6 | Unverändert. |
 | **Agrardom** | **Instanz** | offen | Mehrere Kuppeln; Nahrungsproduktion skaliert natürlich mit der Anzahl. Umstellung von Level auf Instanz. |
 | **Hangar** | **Instanz + Level** | Instanzen offen, Lv3 | Der einzige Fall, der beide Achsen braucht — siehe unten. |
-| **Analytik-Labor** | Level | Lv3+ | Lv1-3 **sind** die Kenntnis-Stufen (`cartography` Lv1, `geology`/`trade` Lv2, `defense` Lv3) — ohne sie bricht die Staffelung weg. Lv4/5 haben zusätzlich einen eigenen Effekt (Kenntnis-Kosten-Rabatt, s.o.), keine reinen Gate-Stufen mehr. |
+| **Analytik-Labor** | Level | Lv3+ | Lv1-3 **sind** die Kenntnis-Stufen (`cartography` Lv1, `geology`/`trade` Lv2, `defense` Lv3) — ohne sie bricht die Staffelung weg. Lv4/5 haben zusätzlich einen eigenen Effekt (Kenntnis-Kosten-Rabatt, §13.3), keine reinen Gate-Stufen mehr. |
 | **Uplink-Station** | Level | Lv3 | §4 nennt sie „das einzige Kommunikationsgebäude der Kolonie". Eine zweite Funkanlage verdoppelt keine Reichweite. |
 | **Sicherheits-Hub** | Level | Lv3 | Eine pro Kolonie. |
 | **Handelsposten** | Level | Lv3 | Eine pro Kolonie. |
@@ -1763,7 +1763,7 @@ Mehrere unabhängige Quellen tragen zu gestaffelten Kostenreduktionen bei: Berat
 
 Domänen-Kenntnis-Zuordnung: Bau ← `construction`, Navigation ← `cartography`, Wirtschaft ← `trade`. Für die Domäne **Wissen** gibt es keine passende Kenntnis — ein früher Entwurf sah hier stattdessen Analytik-Labor-Level-Boni auf denselben Gebäude-Rabatt-Pool vor; das wurde durch eine eigenständige Mechanik ersetzt (siehe unten, „Analytik-Labor Lv4/5"): Analytik-Labor-Level senken stattdessen die AP-Kosten von **Kenntnis-Levelups** selbst, ein separater Pool, kein vierter Beitrag zu diesem hier beschriebenen Gebäude-Rabatt.
 
-**Analytik-Labor Lv4/5 (Design-Spec 2026-08-23, umgesetzt 2026-08-27):** Gibt dem Laborausbau über die reinen Kenntnis-Gates (Lv1-3) hinaus einen eigenen mechanischen Effekt — senkt die AP-Kosten für Kenntnis-Levelups, additiv, unabhängig vom Gebäude-Rabatt-Pool oben. Rührt an nichts, was pro Run gezogen wird (§10 Roguelike-Variabilität bleibt unangetastet) — reine Effizienzsteigerung auf bereits freigeschaltete Kenntnisse. Exakte Werte: `config/buildings.php` → `sciencelab.ap_cost_reduction_per_lv`.
+**Analytik-Labor Lv4/5 (Design-Spec 2026-08-23, umgesetzt 2026-08-27):** Gibt dem Laborausbau über die reinen Kenntnis-Gates (Lv1-3) hinaus einen eigenen mechanischen Effekt — senkt die AP-Kosten für Kenntnis-Levelups, additiv, unabhängig vom Gebäude-Rabatt-Pool oben. Rührt an nichts, was pro Run gezogen wird (§10 Roguelike-Variabilität bleibt unangetastet) — reine Effizienzsteigerung auf bereits freigeschaltete Kenntnisse. Exakte Werte: `config/buildings.php` → `sciencelab.knowledge_ap_cost_reduction_per_lv`.
 
 Ein **Mindest-Kostenanteil** (`project_min_cost_factor`) verhindert, dass Projekte auf null fallen — das ist eine Leitplanke für spätere Bonusquellen (Events, Missionsbelohnungen, Run-Modifier), keine aktive Regel zum Start. Wichtig, das so zu lesen, damit später niemand gegen einen Deckel kalibriert, der gar nicht wirkt.
 

--- a/tests/Feature/Hangar/HangarMissionResolutionTest.php
+++ b/tests/Feature/Hangar/HangarMissionResolutionTest.php
@@ -244,6 +244,41 @@ class HangarMissionResolutionTest extends TestCase
         $this->assertSame(0, (int) $row->level, 'research_ap reward must not auto-levelup');
     }
 
+    public function test_completion_caps_research_ap_at_discounted_threshold_with_sciencelab_lv5(): void
+    {
+        // Sciencelab Lv5 (building_id 31) discounts knowledge-levelup AP costs via
+        // ProjectBonusService::effectiveKnowledgeApForLevelup() — the cap used here must
+        // match that discounted value, not the raw config/knowledge.php threshold.
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => 31],
+            ['level' => 5, 'status_points' => 20, 'ap_spend' => 0]
+        );
+
+        $rawThreshold = (int) config('knowledge.cartography.levelup_costs.1');
+        $curve = config('buildings.sciencelab.knowledge_ap_cost_reduction_per_lv');
+        $discountPercent = (int) (($curve[4] ?? 0) + ($curve[5] ?? 0));
+        $discountedThreshold = (int) max(
+            ceil($rawThreshold * (float) config('game.project_min_cost_factor', 0.5)),
+            round($rawThreshold * (1 - $discountPercent / 100))
+        );
+        $this->assertLessThan($rawThreshold, $discountedThreshold, 'precondition: Lv5 must actually discount the threshold');
+
+        // Seed 15 ap_spend so the reward's +8 (mission_data_sweep) overshoots both the
+        // raw threshold (20) and the discounted one — proving which value actually caps.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 91],
+            ['level' => 0, 'ap_spend' => 15, 'status_points' => 20]
+        );
+        $this->dispatchFixture('mission_data_sweep', 3, dispatchTick: 20700, target: ['research_id' => 91]);
+
+        Artisan::call('game:tick', ['--run' => 1, '--tick' => 20706]); // return_tick = 20700 + 2×3
+
+        $row = DB::table('colony_researches')
+            ->where('colony_id', self::COLONY_ID)->where('research_id', 91)->first();
+
+        $this->assertSame($discountedThreshold, (int) $row->ap_spend, 'ap_spend must cap at the discounted threshold, not the raw config value');
+    }
+
     public function test_completion_grants_harvester_entitlement_via_salvage(): void
     {
         // mission_harvester_salvage reward: harvester_instance => true (GDD §4c

--- a/tests/Unit/ProjectBonusServiceTest.php
+++ b/tests/Unit/ProjectBonusServiceTest.php
@@ -73,4 +73,66 @@ class ProjectBonusServiceTest extends TestCase
         // 15% discount on base 10: round(10 * 0.85) = round(8.5) = 9, floor = ceil(5) = 5.
         $this->assertSame(9, ProjectBonusService::applyDiscount(10, 15, 0.5));
     }
+
+    // ── Analytik-Labor Domänen-Effizienzbonus "Wissen" (Design-Spec 2026-08-23) ──
+
+    private const SCIENCELAB_ID = 31;
+
+    private function setSciencelabLevel(int $level): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::SCIENCELAB_ID],
+            ['level' => $level, 'status_points' => 20, 'ap_spend' => 0]
+        );
+    }
+
+    public function test_knowledge_discount_is_zero_below_level_4(): void
+    {
+        $this->setSciencelabLevel(3);
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(0, $service->knowledgeApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_knowledge_discount_at_level_4(): void
+    {
+        $this->setSciencelabLevel(4);
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $expected = (int) (config('buildings.sciencelab.ap_cost_reduction_per_lv')[4] ?? 0);
+        $this->assertGreaterThan(0, $expected, 'precondition: config must define a Lv4 discount');
+        $this->assertSame($expected, $service->knowledgeApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_knowledge_discount_at_level_5_is_cumulative(): void
+    {
+        $this->setSciencelabLevel(5);
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $curve = config('buildings.sciencelab.ap_cost_reduction_per_lv');
+        $expected = (int) (($curve[4] ?? 0) + ($curve[5] ?? 0));
+        $this->assertSame($expected, $service->knowledgeApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_effective_knowledge_ap_for_levelup_applies_discount(): void
+    {
+        $this->setSciencelabLevel(5);
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $discountPercent = $service->knowledgeApDiscountPercent(self::COLONY_ID);
+        $expected = ProjectBonusService::applyDiscount(100, $discountPercent, (float) config('game.project_min_cost_factor', 0.5));
+        $this->assertSame($expected, $service->effectiveKnowledgeApForLevelup(self::COLONY_ID, 100));
+    }
+
+    public function test_knowledge_discount_does_not_affect_building_discount_pool(): void
+    {
+        // Die beiden Pools sind unabhängig — Analytik-Labor-Level darf den
+        // bestehenden Gebäude-Rabatt (construction/cartography/trade) nicht
+        // beeinflussen, und umgekehrt.
+        $this->setSciencelabLevel(5);
+        $this->setKnowledgeLevel(90, 0); // construction unbelegt
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(0, $service->buildingApDiscountPercent(self::COLONY_ID));
+    }
 }

--- a/tests/Unit/ProjectBonusServiceTest.php
+++ b/tests/Unit/ProjectBonusServiceTest.php
@@ -99,7 +99,7 @@ class ProjectBonusServiceTest extends TestCase
         $this->setSciencelabLevel(4);
         $service = $this->app->make(ProjectBonusService::class);
 
-        $expected = (int) (config('buildings.sciencelab.ap_cost_reduction_per_lv')[4] ?? 0);
+        $expected = (int) (config('buildings.sciencelab.knowledge_ap_cost_reduction_per_lv')[4] ?? 0);
         $this->assertGreaterThan(0, $expected, 'precondition: config must define a Lv4 discount');
         $this->assertSame($expected, $service->knowledgeApDiscountPercent(self::COLONY_ID));
     }
@@ -109,7 +109,7 @@ class ProjectBonusServiceTest extends TestCase
         $this->setSciencelabLevel(5);
         $service = $this->app->make(ProjectBonusService::class);
 
-        $curve = config('buildings.sciencelab.ap_cost_reduction_per_lv');
+        $curve = config('buildings.sciencelab.knowledge_ap_cost_reduction_per_lv');
         $expected = (int) (($curve[4] ?? 0) + ($curve[5] ?? 0));
         $this->assertSame($expected, $service->knowledgeApDiscountPercent(self::COLONY_ID));
     }

--- a/tests/Unit/Techtree/ResearchServiceKnowledgeDiscountTest.php
+++ b/tests/Unit/Techtree/ResearchServiceKnowledgeDiscountTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Techtree;
+
+use App\Services\Techtree\ResearchService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * ResearchService::knowledgeLevelupCost() — Analytik-Labor-Domänen-Effizienzbonus
+ * (Design-Spec 2026-08-23). Vor diesem Plan war knowledgeLevelupCost() der einzige
+ * AP-Kosten-Pfad im Techtree-System ohne jede Rabatt-Anwendung.
+ */
+class ResearchServiceKnowledgeDiscountTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COLONY_ID = 1;
+
+    private const SCIENCELAB_ID = 31;
+
+    // cartography (id=91): required_building_id=31 (sciencelab) Lv1, kein
+    // required_building2_id — sciencelab-Level lässt sich also frei setzen, ohne
+    // ein zweites Gate zu berühren. levelup_costs[1]=20 (config/knowledge.php).
+    private const CARTOGRAPHY_ID = 91;
+
+    private ResearchService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        $this->service = $this->app->make(ResearchService::class);
+    }
+
+    private function setSciencelabLevel(int $level): void
+    {
+        DB::table('colony_buildings')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'building_id' => self::SCIENCELAB_ID],
+            ['level' => $level, 'status_points' => 20, 'ap_spend' => 0]
+        );
+    }
+
+    public function test_knowledge_levelup_cost_is_undiscounted_below_sciencelab_level_4(): void
+    {
+        $this->setSciencelabLevel(3);
+
+        $rawCost = (int) config('knowledge.cartography.levelup_costs.1');
+        $cost = $this->service->knowledgeLevelupCost(self::COLONY_ID, self::CARTOGRAPHY_ID);
+
+        $this->assertSame($rawCost, $cost, 'below Lv4, sciencelab must not discount knowledge levelup costs');
+    }
+
+    public function test_knowledge_levelup_cost_is_discounted_at_sciencelab_level_5(): void
+    {
+        $this->setSciencelabLevel(5);
+
+        $rawCost = (int) config('knowledge.cartography.levelup_costs.1');
+        $curve = config('buildings.sciencelab.ap_cost_reduction_per_lv');
+        $discountPercent = (int) (($curve[4] ?? 0) + ($curve[5] ?? 0));
+        $expected = (int) max(
+            ceil($rawCost * (float) config('game.project_min_cost_factor', 0.5)),
+            round($rawCost * (1 - $discountPercent / 100))
+        );
+
+        $cost = $this->service->knowledgeLevelupCost(self::COLONY_ID, self::CARTOGRAPHY_ID);
+
+        $this->assertLessThan($rawCost, $cost, 'at Lv5, knowledge levelup cost must be discounted below the raw config value');
+        $this->assertSame($expected, $cost);
+    }
+}

--- a/tests/Unit/Techtree/ResearchServiceKnowledgeDiscountTest.php
+++ b/tests/Unit/Techtree/ResearchServiceKnowledgeDiscountTest.php
@@ -58,7 +58,7 @@ class ResearchServiceKnowledgeDiscountTest extends TestCase
         $this->setSciencelabLevel(5);
 
         $rawCost = (int) config('knowledge.cartography.levelup_costs.1');
-        $curve = config('buildings.sciencelab.ap_cost_reduction_per_lv');
+        $curve = config('buildings.sciencelab.knowledge_ap_cost_reduction_per_lv');
         $discountPercent = (int) (($curve[4] ?? 0) + ($curve[5] ?? 0));
         $expected = (int) max(
             ceil($rawCost * (float) config('game.project_min_cost_factor', 0.5)),


### PR DESCRIPTION
## Zusammenfassung

Analytik-Labor (sciencelab) Stufe IV/V bekommen ihre erste echte Spielwirkung: sie senken die AP-Kosten für Kenntnis-Levelups (bisher komplett unrabattiert) — ein neuer, eigenständiger Rabatt-Pool, unabhängig vom bestehenden Gebäude-Rabatt-Pool (construction/cartography/trade).

Teil der 5-Plan-Serie "Kenntnis-Effekte-Redesign" (Owner-Handzeichnung deckte Abweichungen zum Code auf) — Plan 3 von 5.

- Neue `ProjectBonusService::knowledgeApDiscountPercent()`/`effectiveKnowledgeApForLevelup()`
- Verdrahtet in `ResearchService::knowledgeLevelupCost()` **und** `GameTick::grantResearchAp()` (Whole-Branch-Review deckte auf, dass Letzterer den einzigen verbleibenden unrabattierten Pfad darstellte — Fixwave-Commit behebt das mit Regressionstest)
- Config-Kurve `buildings.sciencelab.knowledge_ap_cost_reduction_per_lv` (Platzhalterwerte, ADR 0004 — Kalibrierung nach Playtest)
- GDD §13.3 korrigiert (Richtungs-Widerspruch zwischen Spec und altem Entwurf aufgelöst, Owner-Entscheidung)

## Test-Plan

- [x] `bin/phpunit` — 1050/1050 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Subagent-Driven-Development: 5 Tasks, alle einzeln reviewed+approved
- [x] Whole-Branch-Review (opus): 4 Important + 2 Minor Findings gefunden und in Fixwave-Commit behoben, Scoped-Re-Review bestätigt alle adressiert

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9