### PR TITLE
feat: cartography-Navigation-AP-Rabatt (Plan 4/5, Kenntnis-Effekte)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-30
+
+- Feat: cartography aus dem undifferenzierten Bau-AP-Rabatt-Pool gelöst, bekommt stattdessen einen eigenen Navigation-AP-Rabatt auf Tile-Erkundungskosten (`ColonyTileService::exploreTile()`) und Hangar-Missions-Reisekosten (`HangarService::dispatchShip()`) — vorher wirkte die Kenntnis ununterschieden wie construction/trade auf Gebäude-Levelups, jetzt hat sie einen thematisch eigenen Effekt. Bau-Rabatt-Pool-Maximum sinkt dadurch strukturell von 45% auf 30% (2 statt 3 Kenntnisse) — bewusst nicht kompensiert, Zahlen-Kalibrierung nach Playtest.
+
 ## 2026-08-28
 
 - Feat: Analytik-Labor (sciencelab) Stufe IV/V bekommen ihre erste echte Spielwirkung — Domänen-Effizienzbonus "Wissen", senkt die AP-Kosten für Kenntnis-Levelups (bisher komplett unrabattiert), additiv und unabhängig vom bestehenden Gebäude-Rabatt-Pool (`ProjectBonusService::DOMAIN_KNOWLEDGE_KEYS`, derzeit construction+cartography+trade). Neue `ProjectBonusService::knowledgeApDiscountPercent()`/`effectiveKnowledgeApForLevelup()`, verdrahtet in `ResearchService::knowledgeLevelupCost()` und `GameTick::grantResearchAp()`.

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -608,7 +608,7 @@ class ColonyController extends BaseController
             return $this->fail('max_level_reached');
         }
 
-        // Construction/cartography/trade knowledge additively discounts the AP
+        // Construction/trade knowledge additively discounts the AP
         // threshold (GDD §13.3, docs/superpowers/specs/2026-08-15-knowledge-effects-
         // and-encounters-design.md §2). Level-up Regolith is charged only on the click
         // that completes the level — checked BEFORE spending the AP so a shortfall

--- a/app/Services/ColonyTileService.php
+++ b/app/Services/ColonyTileService.php
@@ -15,6 +15,7 @@ class ColonyTileService
 
     public function __construct(
         private readonly AdvisorService $advisorService,
+        private readonly ProjectBonusService $projectBonusService,
     ) {}
 
     public function getTilesForColony(int $colonyId): Collection
@@ -38,7 +39,8 @@ class ColonyTileService
             return ['ok' => false, 'error' => 'already_explored', 'message' => __('colony.error_already_explored')];
         }
 
-        $apCost = (int) (config('game.colony.explore_cost_per_ring')[$tile->ring] ?? config('game.colony.explore_cost_default', 1));
+        $baseApCost = (int) (config('game.colony.explore_cost_per_ring')[$tile->ring] ?? config('game.colony.explore_cost_default', 1));
+        $apCost = $this->projectBonusService->effectiveNavigationApCost($colonyId, $baseApCost);
 
         if (! config('game.bypass.ap_checks') && $this->advisorService->getAvailableActionPoints($colonyId) < $apCost) {
             return ['ok' => false, 'error' => 'no_nav_ap', 'message' => __('colony.error_no_nav_ap')];

--- a/app/Services/HangarService.php
+++ b/app/Services/HangarService.php
@@ -622,7 +622,7 @@ class HangarService
         $entries = [];
         foreach (config('missions.catalog', []) as $key => $mission) {
             $dist = (int) $mission['sol_distance'];
-            $navApCost = $dist * $navPerSol;
+            $navApCost = $this->projectBonusService->effectiveNavigationApCost($colonyId, $dist * $navPerSol);
             $organikaCost = $this->organikaCostFor($colonyId, $mission);
 
             $availability = 'ok';

--- a/app/Services/HangarService.php
+++ b/app/Services/HangarService.php
@@ -37,6 +37,7 @@ class HangarService
         private readonly TrustService $trustService,
         private readonly AdvisorService $advisorService,
         private readonly HarvesterEntitlementService $harvesterEntitlementService,
+        private readonly ProjectBonusService $projectBonusService,
     ) {}
 
     // ── Read ──────────────────────────────────────────────────────────────────
@@ -459,7 +460,8 @@ class HangarService
             }
 
             $solDistance = (int) $mission['sol_distance'];
-            $navApCost = $solDistance * (int) config('missions.nav_ap_per_sol', 2);
+            $baseNavApCost = $solDistance * (int) config('missions.nav_ap_per_sol', 2);
+            $navApCost = $this->projectBonusService->effectiveNavigationApCost($colonyId, $baseNavApCost);
             $organikaCost = $this->organikaCostFor($colonyId, $mission);
 
             if (! config('game.bypass.ap_checks')

--- a/app/Services/ProjectBonusService.php
+++ b/app/Services/ProjectBonusService.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\DB;
 class ProjectBonusService
 {
     /** research_id values from config/knowledge.php that discount building projects. */
-    private const DOMAIN_KNOWLEDGE_KEYS = ['construction', 'cartography', 'trade'];
+    private const DOMAIN_KNOWLEDGE_KEYS = ['construction', 'trade'];
 
     public function buildingApDiscountPercent(int $colonyId): int
     {
@@ -73,6 +73,33 @@ class ProjectBonusService
         $minCostFactor = (float) config('game.project_min_cost_factor', 0.5);
 
         return self::applyDiscount($baseApForLevelup, $discountPercent, $minCostFactor);
+    }
+
+    /**
+     * Additive AP-cost discount for Navigation actions (currently: tile
+     * exploration, ColonyTileService::exploreTile()), sourced from the
+     * cartography knowledge level — a separate, independent pool from
+     * buildingApDiscountPercent() above. cartography no longer contributes
+     * to the building-project pool (Owner-Entscheidung 2026-08-27).
+     */
+    public function navigationApDiscountPercent(int $colonyId): int
+    {
+        $level = (int) DB::table('colony_researches')
+            ->where('colony_id', $colonyId)
+            ->where('research_id', (int) config('knowledge.cartography.id'))
+            ->value('level');
+
+        $curve = config('knowledge.cartography.nav_ap_reduction_per_lv', []);
+
+        return GameTick::cumulativeCurveYield($curve, $level);
+    }
+
+    public function effectiveNavigationApCost(int $colonyId, int $baseApCost): int
+    {
+        $discountPercent = $this->navigationApDiscountPercent($colonyId);
+        $minCostFactor = (float) config('game.project_min_cost_factor', 0.5);
+
+        return self::applyDiscount($baseApCost, $discountPercent, $minCostFactor);
     }
 
     /** Pure discount math, factored out so the floor logic is testable without DB state. */

--- a/app/Services/ProjectBonusService.php
+++ b/app/Services/ProjectBonusService.php
@@ -8,12 +8,14 @@ use Illuminate\Support\Facades\DB;
 
 /**
  * Additive AP-cost discounts for building projects (GDD §13.3). Currently sums the
- * three "domain knowledge" curves (construction, cartography, trade) — advisor-rank
- * and CC-level bonus sources from the same GDD table are not yet implemented (out of
- * scope for this plan, see docs/superpowers/specs/2026-08-15-knowledge-effects-and-
+ * two "domain knowledge" curves (construction, trade) — advisor-rank and CC-level
+ * bonus sources from the same GDD table are not yet implemented (out of scope for
+ * this plan, see docs/superpowers/specs/2026-08-15-knowledge-effects-and-
  * encounters-design.md §2). Also hosts a second, independent discount pool for
  * Kenntnis-Levelup-AP-Kosten, sourced from the Analytik-Labor (sciencelab) building
- * level — see knowledgeApDiscountPercent() below.
+ * level — see knowledgeApDiscountPercent() below. Since 2026-08-27, cartography no
+ * longer contributes to the building-discount pool above — it has its own separate
+ * Navigation-AP discount pool instead, see effectiveNavigationApCost() below.
  */
 class ProjectBonusService
 {

--- a/config/buildings.php
+++ b/config/buildings.php
@@ -162,7 +162,7 @@ return [
         'max_level' => 5,
         // Domänen-Effizienzbonus "Wissen" (Design-Spec 2026-08-23) — senkt die
         // AP-Kosten für Kenntnis-Levelups, analog zu den ap_cost_reduction_per_lv-
-        // Effekten von construction/cartography/trade (die Gebäude-Levelups
+        // Effekten von construction/trade (die Gebäude-Levelups
         // rabattieren, siehe config/knowledge.php) — eigener Config-Key, da beide
         // Kurven im selben Namensraum sonst kollidieren würden (invertierte
         // Semantik: hier rabattiert Gebäude-Level Kenntnis-Kosten, dort

--- a/config/game.php
+++ b/config/game.php
@@ -76,8 +76,9 @@ return [
     ],
 
     // Lower bound for additive project-AP discounts (§13.3) — prevents bonuses from
-    // pushing ap_for_levelup to 0. Not binding at the current max discount (45%,
-    // construction+cartography+trade fully invested); a guard rail for future bonus
+    // pushing ap_for_levelup to 0. Not binding at the current max discount (30%,
+    // construction+trade fully invested; cartography no longer part of this pool,
+    // it has its own separate Navigation-AP discount); a guard rail for future bonus
     // sources (advisor rank, colony maturity) that are not yet implemented.
     'project_min_cost_factor' => 0.5,
 

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -39,7 +39,7 @@ return [
         'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
         // Bau-AP-Rabatt (GDD §13.3, glockenförmig statt linear — game-designer review
         // 2026-08-15, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md).
-        // Wirkt additiv mit cartography+trade auf ALLE Gebäude-Levelups (Owner-Entscheidung:
+        // Wirkt additiv mit trade auf ALLE Gebäude-Levelups (Owner-Entscheidung:
         // keine Domänentrennung nach Projekttyp, da nur Bau-Projekte existieren).
         'ap_cost_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
     ],
@@ -51,11 +51,9 @@ return [
         'max_status_points' => 20,
         'credits' => 0,
         'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
-        // Bau-AP-Rabatt (GDD §13.3, glockenförmig statt linear — game-designer review
-        // 2026-08-15, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md).
-        // Wirkt additiv mit construction+trade auf ALLE Gebäude-Levelups (Owner-Entscheidung:
-        // keine Domänentrennung nach Projekttyp, da nur Bau-Projekte existieren).
-        'ap_cost_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
+        // Navigation-AP-Rabatt (seit 2026-08-27 kein Mitglied des Bau-Rabatt-Pools mehr).
+        // Rabatt auf Explorationsaktionen, Kurve wird Task 2 finalisieren.
+        'nav_ap_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
     ],
 
     'geology' => [
@@ -94,7 +92,7 @@ return [
         'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
         // Bau-AP-Rabatt (GDD §13.3, glockenförmig statt linear — game-designer review
         // 2026-08-15, docs/superpowers/specs/2026-08-15-knowledge-effects-and-encounters-design.md).
-        // Wirkt additiv mit construction+cartography auf ALLE Gebäude-Levelups (Owner-Entscheidung:
+        // Wirkt additiv mit construction auf ALLE Gebäude-Levelups (Owner-Entscheidung:
         // keine Domänentrennung nach Projekttyp, da nur Bau-Projekte existieren).
         'ap_cost_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
         // Cantina-Angebotsslot-Bonus (Task 4 dieses Plans) — zusätzliche gleichzeitige

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -58,8 +58,13 @@ return [
         // HangarService::dispatchShip() (Missions-Reisekosten) — beides im Code konsistent
         // als "Navigation-AP" behandelte Kostenpunkte (Fehlercodes no_nav_ap/
         // hangar_dispatch_no_nav_ap). Platzhalter-Größenordnung, Zahlen-Kalibrierung nach
-        // Playtest (ADR 0004).
-        'nav_ap_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
+        // Playtest (ADR 0004) — bewusst auf das Doppelte der ursprünglichen Bau-Rabatt-Kurve
+        // skaliert (Ruling 2026-08-30, SDD-Ledger): exploreTile()s Basiskosten sind winzige
+        // Ganzzahlen (1/2/3 AP), eine 15%-Kurve rundet dort bei jedem Level auf den
+        // Ausgangswert zurück (round() in ProjectBonusService::applyDiscount()) — der Rabatt
+        // wäre ein reiner No-Op gewesen. Σ30% erzeugt bei diesen Größenordnungen tatsächlich
+        // einen sichtbaren Effekt (greift den project_min_cost_factor-Floor).
+        'nav_ap_reduction_per_lv' => [1 => 4, 2 => 8, 3 => 8, 4 => 6, 5 => 4],   // Σ30%
     ],
 
     'geology' => [

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -51,8 +51,14 @@ return [
         'max_status_points' => 20,
         'credits' => 0,
         'levelup_costs' => [1 => 20, 2 => 28, 3 => 36, 4 => 44, 5 => 52],
-        // Navigation-AP-Rabatt (seit 2026-08-27 kein Mitglied des Bau-Rabatt-Pools mehr).
-        // Rabatt auf Explorationsaktionen, Kurve wird Task 2 finalisieren.
+        // Navigation-AP-Rabatt (Owner-Entscheidung 2026-08-27) — ersetzt den bisherigen
+        // Bau-AP-Rabatt-Beitrag (der zuvor undifferenziert mit construction/trade in
+        // denselben Pool floss, ohne cartography von den beiden anderen zu unterscheiden).
+        // Wirkt auf ColonyTileService::exploreTile() (Tile-Erkundungskosten) und
+        // HangarService::dispatchShip() (Missions-Reisekosten) — beides im Code konsistent
+        // als "Navigation-AP" behandelte Kostenpunkte (Fehlercodes no_nav_ap/
+        // hangar_dispatch_no_nav_ap). Platzhalter-Größenordnung, Zahlen-Kalibrierung nach
+        // Playtest (ADR 0004).
         'nav_ap_reduction_per_lv' => [1 => 2, 2 => 4, 3 => 4, 4 => 3, 5 => 2],   // Σ15%
     ],
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1471,7 +1471,7 @@ Kenntnis-Effekte werden **automatisch** wirksam, sobald die Kenntnis das nötige
 
 Bereits implementierte Effekte (`config/knowledge.php`):
 
-- `construction`, `cartography`, `trade` senken additiv die AP-Kosten von Gebäude-Levelups (§13.3) — glockenförmig über die Level gestaffelt (`ap_cost_reduction_per_lv`).
+- `construction`, `trade` senken additiv die AP-Kosten von Gebäude-Levelups (§13.3) — glockenförmig über die Level gestaffelt (`ap_cost_reduction_per_lv`). `cartography` senkt stattdessen eigenständig die Navigation-AP-Kosten von Tile-Erkundung und Hangar-Missions-Reisekosten (siehe §13.3).
 - `trade` erhöht zusätzlich die Zahl gleichzeitig aktiver Cantina-Angebote (§12), siehe `bar_offer_boost_per_lv`.
 - `agronomy`, `health`, `defense` wirken auf das Vertrauen (§14), siehe `trust_per_lv`.
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -1761,7 +1761,7 @@ Boni senken die **AP-Kosten von Projekten** und verkürzen damit die Bauzeit in 
 
 Mehrere unabhängige Quellen tragen zu gestaffelten Kostenreduktionen bei: Berater-Ränge, Kenntnis-Level nach Domäne, und Koloniereife (CC-Level). Exakte Boni und Maxima: siehe `config/game.php` → `project_cost_bonus`.
 
-Domänen-Kenntnis-Zuordnung: Bau ← `construction`, Navigation ← `cartography`, Wirtschaft ← `trade`. Für die Domäne **Wissen** gibt es keine passende Kenntnis — ein früher Entwurf sah hier stattdessen Analytik-Labor-Level-Boni auf denselben Gebäude-Rabatt-Pool vor; das wurde durch eine eigenständige Mechanik ersetzt (siehe unten, „Analytik-Labor Lv4/5"): Analytik-Labor-Level senken stattdessen die AP-Kosten von **Kenntnis-Levelups** selbst, ein separater Pool, kein vierter Beitrag zu diesem hier beschriebenen Gebäude-Rabatt.
+Domänen-Kenntnis-Zuordnung (Bau-Projekt-Rabatt-Pool, `ProjectBonusService::buildingApDiscountPercent()`): Bau ← `construction`, Wirtschaft ← `trade`. `cartography` ist seit 2026-08-27 kein Mitglied dieses Pools mehr — die Kenntnis senkt stattdessen eigenständig die Navigation-AP-Kosten von Tile-Erkundung (`ColonyTileService::exploreTile()`) und Hangar-Missions-Reisekosten (`HangarService::dispatchShip()`), beide über `config('knowledge.cartography.nav_ap_reduction_per_lv')`, ein separater Pool. Für die Domäne **Wissen** gibt es keine passende Kenntnis — ein früher Entwurf sah hier stattdessen Analytik-Labor-Level-Boni auf denselben Gebäude-Rabatt-Pool vor; das wurde durch eine eigenständige Mechanik ersetzt (siehe unten, „Analytik-Labor Lv4/5"): Analytik-Labor-Level senken stattdessen die AP-Kosten von **Kenntnis-Levelups** selbst, ein separater Pool, kein vierter Beitrag zu diesem hier beschriebenen Gebäude-Rabatt.
 
 **Analytik-Labor Lv4/5 (Design-Spec 2026-08-23, umgesetzt 2026-08-27):** Gibt dem Laborausbau über die reinen Kenntnis-Gates (Lv1-3) hinaus einen eigenen mechanischen Effekt — senkt die AP-Kosten für Kenntnis-Levelups, additiv, unabhängig vom Gebäude-Rabatt-Pool oben. Rührt an nichts, was pro Run gezogen wird (§10 Roguelike-Variabilität bleibt unangetastet) — reine Effizienzsteigerung auf bereits freigeschaltete Kenntnisse. Exakte Werte: `config/buildings.php` → `sciencelab.knowledge_ap_cost_reduction_per_lv`.
 
@@ -1770,9 +1770,9 @@ Ein **Mindest-Kostenanteil** (`project_min_cost_factor`) verhindert, dass Projek
 **Boni gelten nur für Projekte, nicht für Handlungen.** Dadurch wächst der Handlungsanteil am Pool über den Run relativ an — das späte Spiel verschiebt sich von selbst Richtung Ausführung. Das ist beabsichtigt und trägt den Kipppunkt aus 13.2 mit.
 
 > **Nachtrag 2026-08-15 (Owner-Entscheidung, PlaytestBot-Befund):** Umgesetzt für
-> `construction`/`cartography`/`trade` — glockenförmig statt linear (Σ15% je Kenntnis
-> bei Lv5, Peak Lv2–4), wirkt additiv auf **alle** Gebäude-Levelups (inkl.
-> CommandCenter), nicht nach Projekttyp getrennt, da im aktuellen Spiel nur
+> `construction`/`trade` — `cartography` wurde am 2026-08-27 aus diesem Pool gelöst, siehe oben —
+> glockenförmig statt linear (Σ15% je Kenntnis bei Lv5, Peak Lv2–4), wirkt additiv auf **alle**
+> Gebäude-Levelups (inkl. CommandCenter), nicht nach Projekttyp getrennt, da im aktuellen Spiel nur
 > Bau-Projekte existieren (Navigation/Wirtschaft haben keine passende Projekt-
 > Kategorie). Berater-Rang- und Koloniereife-Bonusquellen aus der Tabelle oben sind
 > weiterhin nicht implementiert. Siehe `app/Services/ProjectBonusService.php`,

--- a/docs/game-reference.md
+++ b/docs/game-reference.md
@@ -104,7 +104,7 @@ Alle levelup via Analytik-Labor. Keine Credits-Kosten (=0). Alle Kurven glockenf
 | Kenntnis | Levelup-AP (Lv1→5) | Σ AP | Trust/Lv | Effekt |
 |---|---|---|---|---|
 | **construction** | 20/28/36/44/52 | 180 AP | 0 | Bau-AP −2/−4/−4/−3/−2 (Σ−15%) |
-| **cartography** | 20/28/36/44/52 | 180 AP | 0 | Bau-AP −2/−4/−4/−3/−2 (Σ−15%) |
+| **cartography** | 20/28/36/44/52 | 180 AP | 0 | Navigation-AP (Tile-Erkundung, Hangar-Missions-Reisekosten) −4/−8/−8/−6/−4% (Σ−30%) |
 | **geology** | 20/28/36/44/52 | 180 AP | 0 | Harvester +3/+3/+2/+2/+2 Rg/Sol; Instabilität −3/−5/−5/−4/−3% |
 | **agronomy** | 20/28/36/44/52 | 180 AP | +1 | Agrardom +1/+2/+2/+1/+1 Or/Sol |
 | **health** | 20/28/36/44/52 | 180 AP | +2 | — |
@@ -182,9 +182,9 @@ Alle levelup via Analytik-Labor. Keine Credits-Kosten (=0). Alle Kurven glockenf
 ### AP-Kosten (Beispiele)
 | Aktion | AP-Typ | Kosten |
 |---|---|---|
-| Gebäude-Levelup | construction | *Individuell; Rabatt via construction/cartography/trade* |
+| Gebäude-Levelup | construction | *Individuell; Rabatt via construction/trade* |
 | Kenntnis-Levelup | research | *20–52 je Ziel-Level* |
-| Feld erkunden | navigation | 1–3 (ringabhängig: Ring 1=1, Ring 2=2, Ring 3=3) |
+| Feld erkunden | navigation | 1–3 (ringabhängig: Ring 1=1, Ring 2=2, Ring 3=3); Rabatt via cartography |
 | Handel annehmen | economy | 1 |
 | Handel verhandeln | economy | 3 (+ risk) |
 

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -568,6 +568,10 @@ function colonyHexView(config) {
         },
 
         // Ring-staggered explore cost (matches ColonyTileService::exploreTile()).
+        // ponytail: this is the raw config cost, not the cartography-discounted actual
+        // cost — same known gap as OnboardingHintService (deferred for the same reason
+        // in this plan); fixing display would require the server to ship effective
+        // per-ring costs instead of the raw config array.
         exploreCostFor(tile) {
             return this.exploreCostPerRing[tile?.ring] ?? this.exploreCostDefault;
         },

--- a/tests/Feature/Colony/ColonyTileExploreCostTest.php
+++ b/tests/Feature/Colony/ColonyTileExploreCostTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\Colony;
 
+use App\Console\Commands\GameTick;
 use App\Services\AdvisorService;
 use App\Services\ColonyTileService;
+use App\Services\ProjectBonusService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -97,5 +99,42 @@ class ColonyTileExploreCostTest extends TestCase
             ->where('colony_id', self::COLONY_ID)
             ->where('q', 2)->where('r', 0)
             ->value('is_explored'));
+    }
+
+    // ── cartography Navigation-AP-Rabatt (Owner-Entscheidung 2026-08-27) ────────
+
+    private function setCartographyLevel(int $level): void
+    {
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 91],
+            ['level' => $level, 'ap_spend' => 0, 'status_points' => 20]
+        );
+    }
+
+    public function test_exploring_ring2_tile_costs_less_with_cartography(): void
+    {
+        $this->setCartographyLevel(5);
+        $this->fogTile(2, 0, 2);
+        $before = $this->navAp();
+
+        $result = $this->app->make(ColonyTileService::class)->exploreTile(self::COLONY_ID, 2, 0);
+
+        $this->assertTrue($result['ok']);
+        $curve = config('knowledge.cartography.nav_ap_reduction_per_lv');
+        $discountPercent = GameTick::cumulativeCurveYield($curve, 5);
+        $expectedCost = ProjectBonusService::applyDiscount(2, $discountPercent, (float) config('game.project_min_cost_factor', 0.5));
+        $this->assertSame($before - $expectedCost, $this->navAp());
+        $this->assertLessThan(2, $expectedCost, 'precondition: discount must actually lower the ring-2 base cost of 2');
+    }
+
+    public function test_exploring_tile_costs_full_price_without_cartography(): void
+    {
+        $this->fogTile(1, -1, 1);
+        $before = $this->navAp();
+
+        $result = $this->app->make(ColonyTileService::class)->exploreTile(self::COLONY_ID, 1, -1);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame($before - 1, $this->navAp(), 'no cartography → unchanged ring-1 base cost of 1');
     }
 }

--- a/tests/Unit/HangarServiceTest.php
+++ b/tests/Unit/HangarServiceTest.php
@@ -56,8 +56,11 @@ namespace Tests\Unit;
  *    - test_repair_ship_throws_when_already_at_full_status
  */
 
+use App\Console\Commands\GameTick;
+use App\Services\AdvisorService;
 use App\Services\HangarService;
 use App\Services\HarvesterEntitlementService;
+use App\Services\ProjectBonusService;
 use App\Services\TickService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -775,5 +778,44 @@ class HangarServiceTest extends TestCase
         $this->expectException(\RuntimeException::class);
 
         $this->hangarService->repairShip(self::COLONY_ID, 1);
+    }
+
+    // ── cartography Navigation-AP-Rabatt (Owner-Entscheidung 2026-08-27) ────────
+
+    public function test_dispatch_ship_costs_less_nav_ap_with_cartography(): void
+    {
+        config(['game.bypass.ap_checks' => false]);
+        $this->insertHangar(1);
+        $this->assignShip(1, self::SHIP_DRONE, 'docked');
+        $this->setKnowledgeLevel('cartography', 5);
+
+        $advisorService = $this->app->make(AdvisorService::class);
+        $before = $advisorService->getAvailableActionPoints(self::COLONY_ID);
+
+        // mission_courier_run: sol_distance=1 (siehe test_dispatch_ship_sets_dispatched_state_and_creates_mission).
+        $this->hangarService->dispatchShip(self::COLONY_ID, 1, 'mission_courier_run');
+
+        $baseNavApCost = 1 * (int) config('missions.nav_ap_per_sol', 2);
+        $curve = config('knowledge.cartography.nav_ap_reduction_per_lv');
+        $discountPercent = GameTick::cumulativeCurveYield($curve, 5);
+        $expectedCost = ProjectBonusService::applyDiscount($baseNavApCost, $discountPercent, (float) config('game.project_min_cost_factor', 0.5));
+
+        $this->assertLessThan($baseNavApCost, $expectedCost, 'precondition: discount must actually lower the base nav AP cost');
+        $this->assertSame($before - $expectedCost, $advisorService->getAvailableActionPoints(self::COLONY_ID));
+    }
+
+    public function test_dispatch_ship_costs_full_nav_ap_without_cartography(): void
+    {
+        config(['game.bypass.ap_checks' => false]);
+        $this->insertHangar(1);
+        $this->assignShip(1, self::SHIP_DRONE, 'docked');
+
+        $advisorService = $this->app->make(AdvisorService::class);
+        $before = $advisorService->getAvailableActionPoints(self::COLONY_ID);
+
+        $this->hangarService->dispatchShip(self::COLONY_ID, 1, 'mission_courier_run');
+
+        $baseNavApCost = 1 * (int) config('missions.nav_ap_per_sol', 2);
+        $this->assertSame($before - $baseNavApCost, $advisorService->getAvailableActionPoints(self::COLONY_ID), 'no cartography → unchanged base nav AP cost');
     }
 }

--- a/tests/Unit/HangarServiceTest.php
+++ b/tests/Unit/HangarServiceTest.php
@@ -818,4 +818,32 @@ class HangarServiceTest extends TestCase
         $baseNavApCost = 1 * (int) config('missions.nav_ap_per_sol', 2);
         $this->assertSame($before - $baseNavApCost, $advisorService->getAvailableActionPoints(self::COLONY_ID), 'no cartography → unchanged base nav AP cost');
     }
+
+    /**
+     * Regression: getMissionCatalogFor() is the read/preview sibling of dispatchShip()
+     * and must report the same discounted nav AP cost, otherwise the UI shows a wrong
+     * chip and can falsely disable missions the player could actually afford.
+     */
+    public function test_get_mission_catalog_for_reports_same_nav_ap_as_dispatch_ship_charges(): void
+    {
+        config(['game.bypass.ap_checks' => false]);
+        $this->insertHangar(1);
+        $this->assignShip(1, self::SHIP_DRONE, 'docked');
+        $this->setKnowledgeLevel('cartography', 5);
+
+        $advisorService = $this->app->make(AdvisorService::class);
+        $before = $advisorService->getAvailableActionPoints(self::COLONY_ID);
+
+        $catalog = $this->hangarService->getMissionCatalogFor(self::COLONY_ID);
+        $entry = collect($catalog)->firstWhere('key', 'mission_courier_run');
+        $this->assertNotNull($entry);
+
+        $baseNavApCost = 1 * (int) config('missions.nav_ap_per_sol', 2);
+        $this->assertLessThan($baseNavApCost, $entry['nav_ap'], 'precondition: catalog must reflect the cartography discount');
+
+        $this->hangarService->dispatchShip(self::COLONY_ID, 1, 'mission_courier_run');
+        $actualCharged = $before - $advisorService->getAvailableActionPoints(self::COLONY_ID);
+
+        $this->assertSame($actualCharged, $entry['nav_ap'], 'catalog nav_ap must match what dispatchShip() actually charges');
+    }
 }

--- a/tests/Unit/ProjectBonusServiceTest.php
+++ b/tests/Unit/ProjectBonusServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Console\Commands\GameTick;
 use App\Services\ProjectBonusService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -35,15 +36,23 @@ class ProjectBonusServiceTest extends TestCase
         $this->assertSame(0, $service->buildingApDiscountPercent(self::COLONY_ID));
     }
 
-    public function test_discount_sums_all_three_domains_additively(): void
+    public function test_discount_sums_construction_and_trade_additively(): void
     {
-        // construction id=90, cartography id=91, trade id=95 (config/knowledge.php)
+        // construction id=90, trade id=95 (config/knowledge.php) — cartography (id=91)
+        // ist NICHT mehr Teil dieses Pools (siehe navigationApDiscountPercent() unten).
         $this->setKnowledgeLevel(90, 3);   // cumulative [2,4,4] = 10
-        $this->setKnowledgeLevel(91, 1);   // cumulative [2] = 2
         $this->setKnowledgeLevel(95, 5);   // cumulative [2,4,4,3,2] = 15
         $service = $this->app->make(ProjectBonusService::class);
 
-        $this->assertSame(27, $service->buildingApDiscountPercent(self::COLONY_ID));
+        $this->assertSame(25, $service->buildingApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_cartography_no_longer_contributes_to_building_discount(): void
+    {
+        $this->setKnowledgeLevel(91, 5);   // cartography Lv5 — voll investiert
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(0, $service->buildingApDiscountPercent(self::COLONY_ID), 'cartography must no longer feed the building-project discount pool');
     }
 
     public function test_effective_ap_for_levelup_applies_discount(): void
@@ -134,5 +143,35 @@ class ProjectBonusServiceTest extends TestCase
         $service = $this->app->make(ProjectBonusService::class);
 
         $this->assertSame(0, $service->buildingApDiscountPercent(self::COLONY_ID));
+    }
+
+    // ── cartography Navigation-AP-Rabatt (Owner-Entscheidung 2026-08-27) ────────
+
+    public function test_navigation_discount_is_zero_with_no_cartography(): void
+    {
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(0, $service->navigationApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_navigation_discount_scales_with_cartography_level(): void
+    {
+        $this->setKnowledgeLevel(91, 3);
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $curve = config('knowledge.cartography.nav_ap_reduction_per_lv');
+        $expected = GameTick::cumulativeCurveYield($curve, 3);
+        $this->assertGreaterThan(0, $expected, 'precondition: config must define a non-zero curve up to Lv3');
+        $this->assertSame($expected, $service->navigationApDiscountPercent(self::COLONY_ID));
+    }
+
+    public function test_effective_navigation_ap_cost_applies_discount(): void
+    {
+        $this->setKnowledgeLevel(91, 5);
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $discountPercent = $service->navigationApDiscountPercent(self::COLONY_ID);
+        $expected = ProjectBonusService::applyDiscount(10, $discountPercent, (float) config('game.project_min_cost_factor', 0.5));
+        $this->assertSame($expected, $service->effectiveNavigationApCost(self::COLONY_ID, 10));
     }
 }

--- a/tests/Unit/ProjectBonusServiceTest.php
+++ b/tests/Unit/ProjectBonusServiceTest.php
@@ -136,7 +136,7 @@ class ProjectBonusServiceTest extends TestCase
     public function test_knowledge_discount_does_not_affect_building_discount_pool(): void
     {
         // Die beiden Pools sind unabhängig — Analytik-Labor-Level darf den
-        // bestehenden Gebäude-Rabatt (construction/cartography/trade) nicht
+        // bestehenden Gebäude-Rabatt (construction/trade) nicht
         // beeinflussen, und umgekehrt.
         $this->setSciencelabLevel(5);
         $this->setKnowledgeLevel(90, 0); // construction unbelegt
@@ -172,6 +172,8 @@ class ProjectBonusServiceTest extends TestCase
 
         $discountPercent = $service->navigationApDiscountPercent(self::COLONY_ID);
         $expected = ProjectBonusService::applyDiscount(10, $discountPercent, (float) config('game.project_min_cost_factor', 0.5));
+
+        $this->assertLessThan(10, $expected, 'precondition: discount must actually lower the base cost of 10');
         $this->assertSame($expected, $service->effectiveNavigationApCost(self::COLONY_ID, 10));
     }
 }


### PR DESCRIPTION
## Zusammenfassung

`cartography` wird aus dem undifferenzierten Bau-AP-Rabatt-Pool (bisher gemeinsam mit `construction`/`trade`) gelöst und bekommt stattdessen einen eigenen, thematisch passenden Effekt: Navigation-AP-Rabatt auf Tile-Erkundung (`ColonyTileService::exploreTile()`) und Hangar-Missions-Reisekosten (`HangarService::dispatchShip()`).

Teil der 5-Plan-Serie "Kenntnis-Effekte-Redesign" — Plan 4 von 5.

- Neue `ProjectBonusService::navigationApDiscountPercent()`/`effectiveNavigationApCost()`
- Config-Kurve umbenannt: `cartography.ap_cost_reduction_per_lv` → `nav_ap_reduction_per_lv`
- Bau-Rabatt-Pool-Maximum sinkt strukturell von 45% auf 30% (2 statt 3 Kenntnisse) — bewusst nicht kompensiert
- **Kalibrierungs-Ruling während der Umsetzung:** Die ursprüngliche Platzhalter-Kurve (Σ15%) war bei den winzigen Ganzzahl-Basiskosten (1-3 AP) durch Rundung faktisch wirkungslos — auf Σ30% verdoppelt, damit der Effekt real sichtbar wird (weiterhin Platzhalter, Zahlen-Kalibrierung nach Playtest, ADR 0004)
- Whole-Branch-Review fand einen echten Bug: `HangarService::getMissionCatalogFor()` (Anzeige-/Vorschau-Pfad) berechnete weiterhin den unrabattierten Wert — UI zeigte falschen Preis und blockierte fälschlich erschwingliche Missionen. Behoben mit Regressionstest.

**Offener Punkt für dich:** Cartography Lv1 bleibt bei jeder Basiskosten-Größe ein kompletter No-Op (Rundung), Lv1-3 sind für die häufigsten Aktionen (Ring-2-Tile, 1-Sol-Kurierflug) wirkungslos. Das ist Kalibrierung unter ADR 0004 (Platzhalter, kein Code-Bug) — aber ein Playtest-Hinweis wert, bevor es dort überrascht.

## Test-Plan

- [x] `bin/phpunit` — 1059/1059 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Subagent-Driven-Development: 6 Tasks, alle einzeln reviewed+approved (Task 1 brauchte 1 Fix-Runde: Config-Duplikat/veraltete Kommentare)
- [x] Whole-Branch-Review (opus): 1 Critical + 4 Important + 2 Minor Findings gefunden und in Fixwave-Commit behoben, Scoped-Re-Review bestätigt alle adressiert

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9