### PR TITLE
feat: defense-Trust-Vorzeichen-Umkehr (Plan 5/5, Kenntnis-Effekte)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2026-08-30
 
+- Feat: defense-Kenntnis Trust-Effekt von `trust_per_lv=-1` auf `+1` umgekehrt (Owner-Entscheidung 2026-08-27, "Sicherheit schafft Vertrauen") — reine Vorzeichen-Umkehr, gleiche Magnitude. GDD-Begründung angepasst, betroffene Grenzfall-Tests in `TrustServiceTest` auf eine andere Kenntnis-Quelle umgestellt.
 - Feat: cartography aus dem undifferenzierten Bau-AP-Rabatt-Pool gelöst, bekommt stattdessen einen eigenen Navigation-AP-Rabatt auf Tile-Erkundungskosten (`ColonyTileService::exploreTile()`) und Hangar-Missions-Reisekosten (`HangarService::dispatchShip()`) — vorher wirkte die Kenntnis ununterschieden wie construction/trade auf Gebäude-Levelups, jetzt hat sie einen thematisch eigenen Effekt. Bau-Rabatt-Pool-Maximum sinkt dadurch strukturell von 45% auf 30% (2 statt 3 Kenntnisse) — bewusst nicht kompensiert, Zahlen-Kalibrierung nach Playtest.
 
 ## 2026-08-28

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -113,7 +113,11 @@ return [
 
     'defense' => [
         'id' => 96,
-        'trust_per_lv' => -1,      // see GDD §13 — vigilance dampens trust slightly
+        // Vorzeichen umgekehrt (Owner-Entscheidung 2026-08-27, "Sicherheit schafft
+        // Vertrauen" statt "Wachsamkeit dämpft Vertrauen") — reiht defense neben
+        // agronomy (trust_per_lv=1) ein, dieselbe Magnitude wie zuvor, nur positiv.
+        // Zahlen-Kalibrierung nach Playtest (ADR 0004).
+        'trust_per_lv' => 1,
         'decay_rate' => 0,
         'max_status_points' => 20,
         'credits' => 0,

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -2871,11 +2871,11 @@ Forschungen tragen mit einem Pauschalwert pro Level bei (unabhängig von status_
 |--------------|------------|-----------------|
 | agronomy | Agronomie & Kultivierung | +1 |
 | health | Gesundheit & Wohlbefinden | +2 |
-| defense | Verteidigung & Überlebenstaktik | -1 |
+| defense | Verteidigung & Überlebenstaktik | +1 |
 
 Alle anderen Kenntnisse (construction, cartography, geology, trade) haben keinen direkten Vertrauenseffekt — sie sind neutrale Werkzeuge.
 
-**Rationale:** Agronomie und Gesundheit verbessern spürbar das koloniale Wohlbefinden. Verteidigung als Kenntnis verbreitet ein Klima der Wachsamkeit, das die Stimmung leicht dämpft — analoges Signal zu den Korvetten.
+**Rationale:** Agronomie und Gesundheit verbessern spürbar das koloniale Wohlbefinden. **Korrektur (2026-08-27, Owner-Entscheidung):** Verteidigung gibt seit diesem Datum einen POSITIVEN Trust-Beitrag pro Level (`trust_per_lv=+1`, vorher `-1`) — "Sicherheit schafft Vertrauen" statt "Wachsamkeit dämpft Vertrauen". Die vorige Begründung (sichtbare Schutzinfrastruktur signalisiert Gefahr) wurde neu bewertet — eine gut ausgebaute, zivile Sicherheitsvorsorge (Sturm-Risiko-Reduktion, das andere `defense`-Effekt) wird jetzt durchgängig positiv gerahmt, ohne Trade-off-Zwang. (Präzedenzfall: `geology` hat ebenfalls zwei Vorteile ohne Vertrauensmalus, `trust_per_lv=0`.)
 
 ### Einflussfaktoren: Relaisvergütung
 

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -2875,7 +2875,7 @@ Forschungen tragen mit einem Pauschalwert pro Level bei (unabhängig von status_
 
 Alle anderen Kenntnisse (construction, cartography, geology, trade) haben keinen direkten Vertrauenseffekt — sie sind neutrale Werkzeuge.
 
-**Rationale:** Agronomie und Gesundheit verbessern spürbar das koloniale Wohlbefinden. **Korrektur (2026-08-27, Owner-Entscheidung):** Verteidigung gibt seit diesem Datum einen POSITIVEN Trust-Beitrag pro Level (`trust_per_lv=+1`, vorher `-1`) — "Sicherheit schafft Vertrauen" statt "Wachsamkeit dämpft Vertrauen". Die vorige Begründung (sichtbare Schutzinfrastruktur signalisiert Gefahr) wurde neu bewertet — eine gut ausgebaute, zivile Sicherheitsvorsorge (Sturm-Risiko-Reduktion, das andere `defense`-Effekt) wird jetzt durchgängig positiv gerahmt, ohne Trade-off-Zwang. (Präzedenzfall: `geology` hat ebenfalls zwei Vorteile ohne Vertrauensmalus, `trust_per_lv=0`.)
+**Rationale:** Agronomie und Gesundheit verbessern spürbar das koloniale Wohlbefinden. Verteidigung als Kenntnis schafft Sicherheit und stärkt dadurch das Vertrauen der Kolonisten — "Sicherheit schafft Vertrauen". Eine gut ausgebaute, zivile Sicherheitsvorsorge (Sturm-Risiko-Reduktion, der andere `defense`-Effekt) wird durchgängig positiv gerahmt, ohne Trade-off-Zwang. (Präzedenzfall: `geology` hat ebenfalls zwei Vorteile ohne Vertrauensmalus.)
 
 ### Einflussfaktoren: Relaisvergütung
 

--- a/docs/game-reference.md
+++ b/docs/game-reference.md
@@ -109,7 +109,7 @@ Alle levelup via Analytik-Labor. Keine Credits-Kosten (=0). Alle Kurven glockenf
 | **agronomy** | 20/28/36/44/52 | 180 AP | +1 | Agrardom +1/+2/+2/+1/+1 Or/Sol |
 | **health** | 20/28/36/44/52 | 180 AP | +2 | — |
 | **trade** | 20/28/36/44/52 | 180 AP | 0 | Bau-AP −2/−4/−4/−3/−2 (Σ−15%); Bar-Slots +0/+1/+1/+0/+0 |
-| **defense** | 20/28/36/44/52 | 180 AP | −1 | Sturm-Risiko −3/−5/−5/−4/−3% |
+| **defense** | 20/28/36/44/52 | 180 AP | +1 | Sturm-Risiko −3/−5/−5/−4/−3% |
 
 > **CC-Level Gate**: Lv4 & Lv5 knowledge erfordern CC Lv4 bzw. Lv5
 > **Supply-Cap Bonus**: alle Kenntnisse +3/+5/+5/+4/+3 = 20 max pro Kenntnis

--- a/tests/Feature/TrustServiceTest.php
+++ b/tests/Feature/TrustServiceTest.php
@@ -38,7 +38,7 @@ namespace Tests\Feature;
  *
  * calculateTrust() — research contribution:
  *   - A positive-trust research (health, id=94) adds level × 2
- *   - A negative-trust research (defense, id=96) subtracts level × 1
+ *   - A positive-trust research (defense, id=96) adds level × 1
  *
  * calculateTrust() — ship contribution:
  *   - A positive-trust ship (frachter, id=47) adds level × 1
@@ -54,6 +54,8 @@ namespace Tests\Feature;
  * calculateTrust() — global clamp:
  *   - Result is clamped to +100 even when raw sum exceeds 100
  *   - Result is clamped to -100 even when raw sum exceeds -100
+ *   - Both clamp-boundary tests use health (id=94) with a negative level for
+ *     the negative-trust scenario, since defense can no longer go negative
  *
  * calculateAndStore():
  *   - Persists the calculated trust in colony_resources (resource_id=12)

--- a/tests/Feature/TrustServiceTest.php
+++ b/tests/Feature/TrustServiceTest.php
@@ -400,9 +400,9 @@ class TrustServiceTest extends TestCase
         $this->assertSame(6, $trust);
     }
 
-    public function test_calculate_trust_negative_research_contribution(): void
+    public function test_calculate_trust_positive_defense_contribution(): void
     {
-        // defense (id=96): -1 per level; level=10 → -10
+        // defense (id=96): +1 per level (Owner-Entscheidung 2026-08-27); level=10 → +10
         DB::table('colony_researches')->insert([
             'colony_id' => $this->colonyId,
             'research_id' => 96,
@@ -413,7 +413,7 @@ class TrustServiceTest extends TestCase
 
         $trust = $this->service->calculateTrust($this->colonyId, $this->tick);
 
-        $this->assertSame(-10, $trust);
+        $this->assertSame(10, $trust);
     }
 
     public function test_calculate_trust_research_not_in_config_is_ignored(): void
@@ -590,11 +590,16 @@ class TrustServiceTest extends TestCase
 
     public function test_calculate_trust_is_clamped_to_negative100(): void
     {
-        // defense (id=96): -1/level; level=200 → raw -200, clamped to -100
+        // health (id=94): +2/level; level=-100 → raw -200, clamped to -100.
+        // Negatives Level ist kein erreichbarer Spielzustand — reiner
+        // Formel-Grenzfall-Test der Clamp-Logik selbst, unabhängig von einer
+        // bestimmten Kenntnis. Ersetzt den vorigen defense-basierten Aufbau
+        // (defense ist seit 2026-08-27 positiv, kann diesen Grenzfall nicht
+        // mehr erzeugen).
         DB::table('colony_researches')->insert([
             'colony_id' => $this->colonyId,
-            'research_id' => 96,
-            'level' => 200,
+            'research_id' => 94,
+            'level' => -100,
             'status_points' => 10,
             'ap_spend' => 0,
         ]);
@@ -661,11 +666,14 @@ class TrustServiceTest extends TestCase
 
     public function test_calculate_and_store_returns_clamped_value(): void
     {
-        // defense (id=96): -1/level; level=200 → raw -200, clamped to -100
+        // health (id=94): +2/level; level=-100 → raw -200, clamped to -100.
+        // Siehe test_calculate_trust_is_clamped_to_negative100() für die
+        // Begründung, warum health statt defense (defense ist seit
+        // 2026-08-27 positiv).
         DB::table('colony_researches')->insert([
             'colony_id' => $this->colonyId,
-            'research_id' => 96,
-            'level' => 200,
+            'research_id' => 94,
+            'level' => -100,
             'status_points' => 10,
             'ap_spend' => 0,
         ]);


### PR DESCRIPTION
## Zusammenfassung

`defense`-Kenntnis gibt einen positiven statt negativen Trust-Effekt pro Level — Owner-Entscheidung ("Sicherheit schafft Vertrauen" statt "Wachsamkeit dämpft Vertrauen").

Teil der 5-Plan-Serie "Kenntnis-Effekte-Redesign" — Plan 5 von 5 (letzter Plan der Serie).

- Reine Config-Wertänderung: `defense.trust_per_lv` von `-1` auf `+1` (gleiche Magnitude, nur Vorzeichen)
- `TrustService::researchContribution()` unverändert (liest den Wert bereits generisch)
- 3 betroffene Tests umgestellt: einer umbenannt+Vorzeichen gedreht, zwei Clamp-Grenzfall-Tests auf `health` als Quelle umgestellt (defense kann jetzt keine großen negativen Werte mehr erzeugen)
- GDD §14 korrigiert (Korvetten-Begründung in separatem, unberührtem Abschnitt bleibt gültig — verifiziert)
- Whole-Branch-Review fand 2 vergessene Stellen (game-reference.md, Test-Docblock) + 1 GDD-Stil-Punkt (Korrektur-Block statt Live-Edit, gegen Owner-Konvention) — alle behoben

## Test-Plan

- [x] `bin/phpunit` — 1059/1059 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Subagent-Driven-Development: 3 Tasks, alle einzeln reviewed+approved
- [x] Whole-Branch-Review (opus): 2 Important + 1 Minor Findings gefunden und in Fixwave-Commit behoben, Scoped-Re-Review bestätigt alle adressiert

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9