### PR TITLE
docs: Merge-Checkliste + Agenten-Definitionen um Rabatt-Wiring-Lehren ergänzen

### DIFF
--- a/.claude/agents/backend-coder.md
+++ b/.claude/agents/backend-coder.md
@@ -64,6 +64,9 @@ Schema-Änderungen und Migrations gehören zu **db-migration-agent** — wenn Co
 ## Test-Driven Development — verbindlich
 Vor jedem neuen Controller-Endpoint oder jeder Service-Methode mit Verhalten: erst einen Feature-/Unit-Test schreiben (`tests/Feature/...`), rot laufen lassen, dann implementieren bis grün. Kein Endpoint ohne vorher existierenden Test. Ausnahme nur bei reinem Routing/Wiring ohne eigene Logik oder explizitem Owner-Spike. Details: CLAUDE.md → „Test-Driven Development (TDD) — verbindlich".
 
+## Beim Verdrahten eines Rabatts/Effekts auf einen bestehenden Kostenwert
+Vor der Implementierung grep nach ALLEN Lesestellen des betroffenen Rohwerts (`config('...')`-Key oder Konstante) — insbesondere Controller-/Service-Methoden, die denselben Kostenwert nur zur ANZEIGE oder Verfügbarkeitsprüfung lesen (z.B. ein Katalog-/Vorschau-Endpoint), nicht nur die eine, die den Wert tatsächlich abzieht. Beide müssen denselben rabattierten Wert verwenden — sonst zeigt das UI einen falschen Preis und blockiert ggf. fälschlich erschwingliche Aktionen (realer Bug, PR #283, 2026-08-30).
+
 ## Coding-Standards
 - PSR-12 strikt einhalten
 - Dependency Injection — keine statischen Calls oder globaler State außer idiomatischen Facades

--- a/.claude/agents/game-developer.md
+++ b/.claude/agents/game-developer.md
@@ -61,6 +61,9 @@ Vor JEDER neuen Methode/Mechanik mit Verhalten: erst den PHPUnit-Test schreiben,
 - Alle Balance-Werte in `config/game.php` — keine Zahlen hartkodieren
 - Vollständige PHP-8.2-Typsignaturen auf jeder public-Methode
 
+## Beim Verdrahten eines Rabatts/Effekts auf einen bestehenden Kostenwert
+Vor der Implementierung grep nach ALLEN Lesestellen des betroffenen Rohwerts (`config('...')`-Key oder Konstante) — nicht nur der einen offensichtlich benannten Konsumenten-Methode. Ein Anzeige-/Vorschau-Pfad (z.B. eine `getXCatalogFor()`-Methode fürs UI) ist genauso ein Konsument wie der tatsächliche Ausführungs-/Abzugs-Pfad — beide müssen denselben rabattierten Wert verwenden, sonst zeigt das UI einen falschen Preis und blockiert ggf. fälschlich erschwingliche Aktionen (realer Bug, PR #283, 2026-08-30). Bei `ProjectBonusService::applyDiscount()`-basierten Rabatten zusätzlich prüfen: rundet die Kurve bei kleinen Ganzzahl-Basiskosten (unter ~10) tatsächlich sichtbar herunter, oder rundet `round()` bei jedem Level auf den Ausgangswert zurück (No-Op)?
+
 ### DB-Transaktions-Muster
 ```php
 DB::transaction(function () use ($colony, $amount): void {

--- a/.claude/agents/qa-tester.md
+++ b/.claude/agents/qa-tester.md
@@ -83,6 +83,14 @@ bin/phpunit --filter test_explore_tile_success    # single test method
 - [ ] Alle DB-Schreibzugriffe transaktional?
 - [ ] CSRF auf zustandsändernden Endpoints geprüft?
 
+## Rabatt-/Kosten-Wiring-Checkliste (bei jeder Kenntnis-/Rabatt-Änderung auf einen bestehenden Kostenwert)
+
+Bei der Kenntnis-Effekte-Serie (2026-08-30, PR #283) blieb ein Anzeige-/Vorschau-Pfad unrabattiert, während der Ausführungs-Pfad korrekt war — UI zeigte falschen Preis UND blockierte fälschlich erschwingliche Aktionen. Keine Task-Review hat es gefangen (jede sah nur ihre eigene Datei), erst die Whole-Branch-Review.
+
+- [ ] Grep nach ALLEN Lesern des betroffenen Rohwerts/Config-Keys — nicht nur den einen offensichtlich benannten Konsumenten. Ein Anzeige-/Vorschau-Pfad (z.B. `getXCatalogFor()`, ein Preis-Chip im UI) ist genauso ein Konsument wie der Ausführungs-/Abzugs-Pfad.
+- [ ] Bei kleinen Ganzzahl-Basiskosten (unter ~10): rechnet die Rabatt-Prozentkurve gegen `ProjectBonusService::applyDiscount()`s `round()`-Formel tatsächlich einen sichtbaren Effekt aus, oder rundet sie bei jedem Level auf den Ausgangswert zurück (No-Op)? Von Hand nachrechnen, nicht annehmen.
+- [ ] Wenn Config-Werte geändert werden, die in `docs/game-reference.md` gelistet sind: dort mitziehen (wird nicht automatisch geprüft, siehe CLAUDE.md-Merge-Checkliste).
+
 ## Output-Format
 Vollständige PHPUnit-Test-Klassen liefern, direkt ausführbar. Kurzer Kommentar oben mit abgedeckten Szenarien.
 ## Code-Style (Linter — Pflicht)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,5 +167,6 @@ Vor `mcp__github__merge_pull_request` immer prüfen:
 
 1. **CHANGELOG** — Eintrag für heute (`## YYYY-MM-DD`) vorhanden?
 2. **PR-Beschreibung** — spiegelt alle Commits seit dem letzten Merge wider?
+3. **`docs/game-reference.md`** — falls der PR Config-Werte ändert, die dort gelistet sind (Kenntnis-/Gebäude-Kurven, Kosten, o.ä.): Tabelle aktuell? Wiederholt in mehreren PRs übersehen (Kenntnis-Effekte-Serie, 2026-08-30) — dieses Dokument wird nicht automatisch geprüft, nur manuell nach Balance-Pässen (ADR 0004).
 
-Der Pre-Merge-Hook (`.claude/hooks/pre-merge-check.sh`) blockiert automatisch wenn CHANGELOG fehlt. PR-Beschreibung muss manuell geprüft/aktualisiert werden.
+Der Pre-Merge-Hook (`.claude/hooks/pre-merge-check.sh`) blockiert automatisch wenn CHANGELOG fehlt. PR-Beschreibung und `docs/game-reference.md` müssen manuell geprüft/aktualisiert werden.


### PR DESCRIPTION
## Zusammenfassung

Reine Prozess-/Dokumentationsänderung, kein Code-Pfad betroffen. Aus der Kenntnis-Effekte-Serie (insb. PR #283, cartography-Plan) zwei wiederkehrende Fallen destilliert und dauerhaft verankert:

- `CLAUDE.md`: Merge-Checkliste um `docs/game-reference.md`-Prüfung ergänzt (wiederholt in mehreren PRs übersehen)
- `.claude/agents/game-developer.md`, `backend-coder.md`, `qa-tester.md`: Checkliste beim Verdrahten eines Rabatts auf einen bestehenden Kostenwert — Lese-/Vorschau-Pfad nicht vergessen (echter Bug in PR #283: `getMissionCatalogFor()` blieb unrabattiert, UI zeigte falschen Preis + blockierte fälschlich erschwingliche Missionen), sowie `round()`-Rundungsfalle bei kleinen Ganzzahl-Basiskosten.

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9