### PR TITLE
feat: trade-Kenntnis-Preis-Bonus (Plan 7/7, Kenntnis-Effekte, letzter Plan der Serie)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-31
+
+- Feat: trade-Kenntnis bekommt einen eigenen Preis-Bonus auf allen 3 Handelskanälen (Cantina, Reisender Händler, Nexus/Corporate Contact), additiv zum bestehenden Handelsposten-Kanal-Rabatt (Plan 7 der Kenntnis-Effekte-Redesign-Serie, Owner-Entscheidung 2026-08-27). Neuer `ProjectBonusService::tradePriceBonusPercent()`, Config `knowledge.trade.trade_price_bonus_per_lv`.
+
 ## 2026-08-30
 
 - Feat: defense-Kenntnis Trust-Effekt von `trust_per_lv=-1` auf `+1` umgekehrt (Owner-Entscheidung 2026-08-27, "Sicherheit schafft Vertrauen") — reine Vorzeichen-Umkehr, gleiche Magnitude. GDD-Begründung angepasst, betroffene Grenzfall-Tests in `TrustServiceTest` auf eine andere Kenntnis-Quelle umgestellt.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -55,6 +55,7 @@ class AppServiceProvider extends ServiceProvider
             $app->make(BarService::class),
             $app->make(ResourcesService::class),
             $app->make(TradingPostService::class),
+            $app->make(ProjectBonusService::class),
         ));
         $this->app->bind(ResourcesService::class, ResourcesService::class);
         $this->app->bind(TrustService::class, fn ($app) => new TrustService(

--- a/app/Services/BarService.php
+++ b/app/Services/BarService.php
@@ -22,6 +22,7 @@ class BarService
         private readonly ResourcesService $resourcesService,
         private readonly AdvisorService $advisorService,
         private readonly TradingPostService $tradingPostService,
+        private readonly ProjectBonusService $projectBonusService,
     ) {}
 
     public function generateOffersForColony(int $colonyId, int $tick): void
@@ -170,7 +171,8 @@ class BarService
         $giveAmount = $offer->give_amount;
         $getAmount = $offer->get_amount;
         if (! $offer->is_negotiated) {
-            $discount = $this->tradingPostService->discountFor($colonyId, 'bar');
+            $discount = $this->tradingPostService->discountFor($colonyId, 'bar')
+                + $this->projectBonusService->tradePriceBonusPercent($colonyId) / 100;
             if ($discount > 0.0) {
                 $isCreditsOffer = $offer->give_resource_id === self::RES_CREDITS;
                 $giveAmount = $isCreditsOffer

--- a/app/Services/BarService.php
+++ b/app/Services/BarService.php
@@ -168,20 +168,26 @@ class BarService
         // Affordability-Check, damit dieser gegen den tatsächlich fälligen
         // Betrag läuft (Whole-Branch-Review-Fund 2026-08-27 — derselbe Bug,
         // der in MerchantService::buyItem() bereits behoben wurde).
+        //
+        // Der trade-Kenntnis-Preisbonus ist davon unabhängig — eine dritte,
+        // eigenständige Rabattquelle (additiv, wie construction+cartography+trade
+        // im Building-Discount-Pool) — und gilt daher AUCH für verhandelte
+        // Angebote (Whole-Branch-Review-Fund 2026-08-30: durfte nicht von der
+        // is_negotiated-Guard mit ausgeschlossen werden).
         $giveAmount = $offer->give_amount;
         $getAmount = $offer->get_amount;
+        $discount = $this->projectBonusService->tradePriceBonusPercent($colonyId) / 100;
         if (! $offer->is_negotiated) {
-            $discount = $this->tradingPostService->discountFor($colonyId, 'bar')
-                + $this->projectBonusService->tradePriceBonusPercent($colonyId) / 100;
-            if ($discount > 0.0) {
-                $isCreditsOffer = $offer->give_resource_id === self::RES_CREDITS;
-                $giveAmount = $isCreditsOffer
-                    ? (int) max(1, round($offer->give_amount * (1 - $discount)))
-                    : $offer->give_amount;
-                $getAmount = $isCreditsOffer
-                    ? $offer->get_amount
-                    : (int) max(1, round($offer->get_amount * (1 + $discount)));
-            }
+            $discount += $this->tradingPostService->discountFor($colonyId, 'bar');
+        }
+        if ($discount > 0.0) {
+            $isCreditsOffer = $offer->give_resource_id === self::RES_CREDITS;
+            $giveAmount = $isCreditsOffer
+                ? (int) max(1, round($offer->give_amount * (1 - $discount)))
+                : $offer->give_amount;
+            $getAmount = $isCreditsOffer
+                ? $offer->get_amount
+                : (int) max(1, round($offer->get_amount * (1 + $discount)));
         }
 
         // Check player can afford the give side

--- a/app/Services/CorporateContactService.php
+++ b/app/Services/CorporateContactService.php
@@ -26,6 +26,7 @@ class CorporateContactService
     public function __construct(
         private readonly HarvesterEntitlementService $harvesterEntitlementService,
         private readonly TradingPostService $tradingPostService,
+        private readonly ProjectBonusService $projectBonusService,
     ) {}
 
     /**
@@ -53,7 +54,8 @@ class CorporateContactService
 
         // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — Stufe 3 schaltet
         // den Nexus/Corporate-Contact-Kanal frei.
-        $discount = $this->tradingPostService->discountFor($colonyId, 'corporate_contact');
+        $discount = $this->tradingPostService->discountFor($colonyId, 'corporate_contact')
+            + $this->projectBonusService->tradePriceBonusPercent($colonyId) / 100;
         if ($discount > 0.0) {
             $price = (int) max(1, round($price * (1 - $discount)));
         }

--- a/app/Services/MerchantService.php
+++ b/app/Services/MerchantService.php
@@ -44,6 +44,7 @@ class MerchantService
         private readonly BarService $barService,
         private readonly ResourcesService $resourcesService,
         private readonly TradingPostService $tradingPostService,
+        private readonly ProjectBonusService $projectBonusService,
     ) {}
 
     public function getActiveVisit(int $colonyId, int $currentTick): ?object
@@ -311,7 +312,8 @@ class MerchantService
         // Handelsposten-Kanal-Rabatt (Design-Spec 2026-08-23) — Stufe 2 schaltet
         // den Reisender-Händler-Kanal frei. Vor dem Credits-Check berechnet, damit
         // die Affordability-Prüfung gegen den tatsächlich fälligen Betrag läuft.
-        $discount = $this->tradingPostService->discountFor($colonyId, 'merchant');
+        $discount = $this->tradingPostService->discountFor($colonyId, 'merchant')
+            + $this->projectBonusService->tradePriceBonusPercent($colonyId) / 100;
         $chargedCredits = $discount > 0.0
             ? (int) max(1, round($item->cost_credits * (1 - $discount)))
             : $item->cost_credits;

--- a/app/Services/ProjectBonusService.php
+++ b/app/Services/ProjectBonusService.php
@@ -104,6 +104,24 @@ class ProjectBonusService
         return self::applyDiscount($baseApCost, $discountPercent, $minCostFactor);
     }
 
+    /**
+     * Additive percent bonus applied to the sell price on all 3 trade channels
+     * (TradingPostService), sourced from the trade knowledge level — additive
+     * to the existing TradingPostService per-channel discount, not a replacement
+     * (Owner-Entscheidung 2026-08-27).
+     */
+    public function tradePriceBonusPercent(int $colonyId): int
+    {
+        $level = (int) DB::table('colony_researches')
+            ->where('colony_id', $colonyId)
+            ->where('research_id', (int) config('knowledge.trade.id'))
+            ->value('level');
+
+        $curve = config('knowledge.trade.trade_price_bonus_per_lv', []);
+
+        return GameTick::cumulativeCurveYield($curve, $level);
+    }
+
     /** Pure discount math, factored out so the floor logic is testable without DB state. */
     public static function applyDiscount(int $base, int $discountPercent, float $minCostFactor): int
     {

--- a/app/Services/ProjectBonusService.php
+++ b/app/Services/ProjectBonusService.php
@@ -7,15 +7,17 @@ use App\Enums\BuildingId;
 use Illuminate\Support\Facades\DB;
 
 /**
- * Additive AP-cost discounts for building projects (GDD §13.3). Currently sums the
- * two "domain knowledge" curves (construction, trade) — advisor-rank and CC-level
- * bonus sources from the same GDD table are not yet implemented (out of scope for
- * this plan, see docs/superpowers/specs/2026-08-15-knowledge-effects-and-
- * encounters-design.md §2). Also hosts a second, independent discount pool for
- * Kenntnis-Levelup-AP-Kosten, sourced from the Analytik-Labor (sciencelab) building
- * level — see knowledgeApDiscountPercent() below. Since 2026-08-27, cartography no
- * longer contributes to the building-discount pool above — it has its own separate
- * Navigation-AP discount pool instead, see effectiveNavigationApCost() below.
+ * Hosts several independent AP-cost discount and price-bonus pools (GDD §13.3),
+ * each sourced from its own knowledge/building level and combined additively
+ * within its own pool only — no cross-pool stacking:
+ *   - building-project AP discount, summed across the construction and trade
+ *     knowledge curves (buildingApDiscountPercent());
+ *   - knowledge-levelup AP discount, sourced from the Analytik-Labor
+ *     (sciencelab) building level (knowledgeApDiscountPercent());
+ *   - navigation-AP discount for exploration and hangar mission actions,
+ *     sourced from the cartography knowledge level (navigationApDiscountPercent());
+ *   - trade-price bonus across all 3 trade channels, sourced from the trade
+ *     knowledge level (tradePriceBonusPercent()).
  */
 class ProjectBonusService
 {
@@ -78,11 +80,11 @@ class ProjectBonusService
     }
 
     /**
-     * Additive AP-cost discount for Navigation actions (currently: tile
-     * exploration, ColonyTileService::exploreTile()), sourced from the
-     * cartography knowledge level — a separate, independent pool from
-     * buildingApDiscountPercent() above. cartography no longer contributes
-     * to the building-project pool (Owner-Entscheidung 2026-08-27).
+     * Additive AP-cost discount for Navigation actions — tile exploration
+     * (ColonyTileService::exploreTile()) and hangar missions
+     * (HangarService::dispatchShip(), HangarService::getMissionCatalogFor()) —
+     * sourced from the cartography knowledge level, a separate, independent
+     * pool from buildingApDiscountPercent() above.
      */
     public function navigationApDiscountPercent(int $colonyId): int
     {
@@ -105,10 +107,10 @@ class ProjectBonusService
     }
 
     /**
-     * Additive percent bonus applied to the sell price on all 3 trade channels
-     * (TradingPostService), sourced from the trade knowledge level — additive
-     * to the existing TradingPostService per-channel discount, not a replacement
-     * (Owner-Entscheidung 2026-08-27).
+     * Additive percent bonus applied to the price a player pays across all 3
+     * trade channels (BarService, MerchantService, CorporateContactService),
+     * sourced from the trade knowledge level — additive to the existing
+     * TradingPostService per-channel discount, not a replacement.
      */
     public function tradePriceBonusPercent(int $colonyId): int
     {

--- a/config/knowledge.php
+++ b/config/knowledge.php
@@ -109,6 +109,11 @@ return [
         // Cantina-Angebotsslot-Bonus (Task 4 dieses Plans) — zusätzliche gleichzeitige
         // Bar-Angebote bei höherem trade-Level.
         'bar_offer_boost_per_lv' => [1 => 0, 2 => 1, 3 => 1, 4 => 0, 5 => 0],   // Σ2 Slots
+        // Additiver Preis-Bonus auf ALLE 3 Handelskanäle, zusätzlich zum bestehenden
+        // TradingPostService-Kanalrabatt — additives Stacking mehrerer Quellen ist
+        // etablierte Projekt-Konvention (siehe construction+cartography+trade auf dem
+        // Gebäude-AP-Rabatt-Pool). Owner-Entscheidung 2026-08-27, Platzhalter-Größe (ADR 0004).
+        'trade_price_bonus_per_lv' => [1 => 2, 2 => 3, 3 => 3, 4 => 2, 5 => 2],
     ],
 
     'defense' => [

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -468,6 +468,8 @@ Jede Ausbaustufe schaltet einen zusätzlichen Handelskanal für einen Preisrabat
 > **TODO Balance/Design:** Der passive, bereits bei der Angebots-Generierung eingerechnete Konsul-Rang-Rabatt (`trader_discount`, siehe `BarService::generateOffersForColony()`) ist von diesem Ausschluss NICHT erfasst und stackt aktuell multiplikativ mit dem Handelsposten-Rabatt (z.B. Rang-3-Konsul 30% + Handelsposten-Stufe-I 12% = kombiniert 38,4%). Ob das gewollt ist, wurde noch nicht bewertet — Whole-Branch-Review-Fund 2026-08-27, offene Design-Frage für den nächsten Balance-Pass.
 Exakter Rabattsatz: `config/buildings.php` → `merchant_price_bonus`.
 
+**Zusätzlich — Kenntnis-Preisbonus:** Die `trade`-Kenntnis liefert unabhängig vom Handelsposten einen eigenen Preis-Bonus auf allen drei Handelskanälen (Cantina-Angebote, Reisender Händler, Nexus/Corporate Contact). Beide Quellen stacken additiv, ohne Konkurrenz oder Ausschluss — dasselbe Muster wie beim Bau-AP-Rabatt-Pool, den `construction` und `trade` gemeinsam speisen (§13.3). Exakte Werte: `config/knowledge.php` → `trade.trade_price_bonus_per_lv`.
+
 > **TODO Balance:** Baukosten und Decay nach erstem Playtest festlegen (siehe `config/buildings.php`).
 
 ---

--- a/docs/game-reference.md
+++ b/docs/game-reference.md
@@ -108,7 +108,7 @@ Alle levelup via Analytik-Labor. Keine Credits-Kosten (=0). Alle Kurven glockenf
 | **geology** | 20/28/36/44/52 | 180 AP | 0 | Harvester +3/+3/+2/+2/+2 Rg/Sol; Instabilität −3/−5/−5/−4/−3% |
 | **agronomy** | 20/28/36/44/52 | 180 AP | +1 | Agrardom +1/+2/+2/+1/+1 Or/Sol |
 | **health** | 20/28/36/44/52 | 180 AP | +2 | Seuchenausbruch-Risiko −3/−5/−5/−4/−3% |
-| **trade** | 20/28/36/44/52 | 180 AP | 0 | Bau-AP −2/−4/−4/−3/−2 (Σ−15%); Bar-Slots +0/+1/+1/+0/+0 |
+| **trade** | 20/28/36/44/52 | 180 AP | 0 | Bau-AP −2/−4/−4/−3/−2 (Σ−15%); Bar-Slots +0/+1/+1/+0/+0; Handelspreis-Bonus +2/+3/+3/+2/+2% (Σ12%) |
 | **defense** | 20/28/36/44/52 | 180 AP | +1 | Sturm-Risiko −3/−5/−5/−4/−3% |
 
 > **CC-Level Gate**: Lv4 & Lv5 knowledge erfordern CC Lv4 bzw. Lv5

--- a/tests/Feature/Bar/BarServiceTest.php
+++ b/tests/Feature/Bar/BarServiceTest.php
@@ -1356,6 +1356,40 @@ class BarServiceTest extends TestCase
         $this->assertSame(450 - $expectedGive, $this->getCredits());
     }
 
+    public function test_accept_offer_applies_trade_price_bonus_even_without_trading_post_channel(): void
+    {
+        // GDD/Owner-Entscheidung 2026-08-27: trade-Kenntnis-Preisbonus ist additiv
+        // zum Handelsposten-Kanal-Rabatt, nicht davon abhängig — muss also auch
+        // greifen, wenn der Handelsposten-Kanal selbst gar nicht freigeschaltet ist.
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(0); // unter dem 'bar'-Kanal-Schwellenwert → 0% Handelsposten-Rabatt
+
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $giveAmount = 500;
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => 20,
+            'expires_tick' => 20,
+        ]);
+
+        $result = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 10);
+
+        $this->assertTrue($result['ok']);
+        $expectedGive = (int) max(1, round($giveAmount * (1 - 0.08))); // trade Lv3 cumulative curve = 8%
+        $this->assertSame($expectedGive, $result['give_amount'], 'trade knowledge price bonus must apply even without a trading post channel discount');
+        $this->assertSame(1000 - $expectedGive, $this->getCredits());
+    }
+
     /**
      * Covers the previously-untested non-credits branch of the trading post
      * discount: when the give side is a colony resource (not credits), the

--- a/tests/Feature/Bar/BarServiceTest.php
+++ b/tests/Feature/Bar/BarServiceTest.php
@@ -1316,6 +1316,51 @@ class BarServiceTest extends TestCase
     }
 
     /**
+     * Whole-Branch-Review-Fund 2026-08-30: the is_negotiated guard exists solely to
+     * keep the TradingPostService channel discount from stacking with the Konsul
+     * negotiation bonus (see test above) — it must NOT also suppress the trade
+     * knowledge price bonus, a categorically independent third source.
+     */
+    public function test_accept_offer_applies_trade_price_bonus_to_a_negotiated_offer(): void
+    {
+        $this->clearBarOffers();
+        $this->mockTick(10);
+        $this->setTradingPostLevel(1);
+        $this->assignTrader(3); // rank 3 Konsul
+
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => (int) config('knowledge.trade.id')],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $giveAmount = 500;
+        $this->setCredits(1000);
+        $this->setColonyResource(self::RES_REGOLITH, 0);
+
+        $offerId = $this->insertOffer([
+            'give_resource_id' => self::RES_CREDITS,
+            'give_amount' => $giveAmount,
+            'get_resource_id' => self::RES_REGOLITH,
+            'get_amount' => 20,
+            'expires_tick' => 20,
+        ]);
+
+        config(['game.bypass.ap_checks' => true]);
+        $negotiateResult = $this->barService->negotiateOffer(self::COLONY_ID, $offerId, self::USER_ID, 11);
+        $this->assertTrue($negotiateResult['ok']);
+        $this->assertTrue($negotiateResult['success'] ?? false, 'negotiate must succeed for this assertion to be meaningful — check negotiate_success_chance fixture for rank 3');
+
+        $negotiatedGiveAmount = (int) DB::table('bar_offers')->where('id', $offerId)->value('give_amount');
+        $expectedGive = (int) max(1, round($negotiatedGiveAmount * (1 - 0.08))); // trade Lv3 cumulative curve = 8%
+
+        $acceptResult = $this->barService->acceptOffer(self::COLONY_ID, $offerId, self::USER_ID, 11);
+
+        $this->assertTrue($acceptResult['ok'] ?? false);
+        $this->assertLessThan($negotiatedGiveAmount, $expectedGive, 'fixture assumption: trade bonus must further reduce the already-negotiated amount for this test to be meaningful');
+        $this->assertSame($expectedGive, $acceptResult['give_amount'], 'trade knowledge price bonus must apply on top of a negotiated offer, unlike the trading post channel discount');
+    }
+
+    /**
      * Whole-Branch-Review-Fund 2026-08-27: the affordability check must run against
      * the DISCOUNTED price, not the offer's full give_amount — otherwise a player
      * who can afford the discounted price but not the full price is wrongly
@@ -1366,7 +1411,7 @@ class BarServiceTest extends TestCase
         $this->setTradingPostLevel(0); // unter dem 'bar'-Kanal-Schwellenwert → 0% Handelsposten-Rabatt
 
         DB::table('colony_researches')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['colony_id' => self::COLONY_ID, 'research_id' => (int) config('knowledge.trade.id')],
             ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
         );
 

--- a/tests/Feature/Colony/CorporateContactServiceTest.php
+++ b/tests/Feature/Colony/CorporateContactServiceTest.php
@@ -211,4 +211,22 @@ class CorporateContactServiceTest extends TestCase
         $this->assertNotNull($offer);
         $this->assertSame(495, $offer['price'], 'below the level-3 threshold, price must equal the documented undiscounted roll (495 Cr at OFFER_HIT_TICK)');
     }
+
+    public function test_active_offer_price_applies_trade_price_bonus_even_below_trading_post_threshold(): void
+    {
+        // GDD/Owner-Entscheidung 2026-08-27: trade-Kenntnis-Preisbonus ist additiv
+        // zum Handelsposten-Kanal-Rabatt, nicht davon abhängig.
+        $this->setTradingPostLevel(2); // unter dem 'corporate_contact'-Schwellenwert (3) → 0% Handelsposten-Rabatt
+
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $offer = $this->service->getActiveOffer(self::COLONY_ID, self::USER_ID, self::OFFER_HIT_TICK);
+
+        $this->assertNotNull($offer);
+        $expectedPrice = (int) max(1, round(495 * (1 - 0.08))); // trade Lv3 cumulative curve = 8%
+        $this->assertSame($expectedPrice, $offer['price'], 'trade knowledge price bonus must apply even without a trading post channel discount');
+    }
 }

--- a/tests/Feature/Colony/CorporateContactServiceTest.php
+++ b/tests/Feature/Colony/CorporateContactServiceTest.php
@@ -219,7 +219,7 @@ class CorporateContactServiceTest extends TestCase
         $this->setTradingPostLevel(2); // unter dem 'corporate_contact'-Schwellenwert (3) → 0% Handelsposten-Rabatt
 
         DB::table('colony_researches')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['colony_id' => self::COLONY_ID, 'research_id' => (int) config('knowledge.trade.id')],
             ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
         );
 

--- a/tests/Feature/MerchantServiceTest.php
+++ b/tests/Feature/MerchantServiceTest.php
@@ -862,7 +862,7 @@ class MerchantServiceTest extends TestCase
         $this->setTradingPostLevel(null);
 
         DB::table('colony_researches')->updateOrInsert(
-            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['colony_id' => self::COLONY_ID, 'research_id' => (int) config('knowledge.trade.id')],
             ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
         );
 

--- a/tests/Feature/MerchantServiceTest.php
+++ b/tests/Feature/MerchantServiceTest.php
@@ -854,6 +854,35 @@ class MerchantServiceTest extends TestCase
         $this->assertSame(300 - $expectedCharge, $this->getCredits());
     }
 
+    public function test_buy_item_applies_trade_price_bonus_even_without_trading_post_channel(): void
+    {
+        // GDD/Owner-Entscheidung 2026-08-27: trade-Kenntnis-Preisbonus ist additiv
+        // zum Handelsposten-Kanal-Rabatt, nicht davon abhängig.
+        $this->mockTick(20);
+        $this->setTradingPostLevel(null);
+
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => self::COLONY_ID, 'research_id' => 95],
+            ['level' => 3, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $visitId = $this->insertVisit(['tick_start' => 20, 'tick_end' => 21]);
+        $itemId = $this->insertItem($visitId, [
+            'item_type' => 'trust_boost',
+            'payload' => json_encode(['trust_amount' => 15]),
+            'cost_credits' => 100,
+        ]);
+        $this->setCredits(300);
+        $this->setColonyResource(self::TRUST_RESOURCE_ID, 50);
+
+        $result = $this->service->buyItem($itemId, self::COLONY_ID, self::USER_ID);
+
+        $this->assertTrue($result['ok']);
+        $expectedCharge = (int) max(1, round(100 * (1 - 0.08))); // trade Lv3 cumulative curve = 8%
+        $this->assertSame(300 - $expectedCharge, $result['credits'], 'trade knowledge price bonus must apply even without a trading post channel discount');
+        $this->assertSame(300 - $expectedCharge, $this->getCredits());
+    }
+
     public function test_buy_item_has_no_discount_without_trading_post(): void
     {
         $this->mockTick(20);

--- a/tests/Unit/ProjectBonusServiceTest.php
+++ b/tests/Unit/ProjectBonusServiceTest.php
@@ -176,4 +176,25 @@ class ProjectBonusServiceTest extends TestCase
         $this->assertLessThan(10, $expected, 'precondition: discount must actually lower the base cost of 10');
         $this->assertSame($expected, $service->effectiveNavigationApCost(self::COLONY_ID, 10));
     }
+
+    // ── trade Handelspreis-Bonus (Owner-Entscheidung 2026-08-27) ────────────────
+
+    private const TRADE_RESEARCH_ID = 95;
+
+    public function test_trade_price_bonus_percent_sums_curve_up_to_level(): void
+    {
+        $this->assertSame((int) config('knowledge.trade.id'), self::TRADE_RESEARCH_ID, 'precondition: config/knowledge.php trade.id must match the test constant');
+        $this->setKnowledgeLevel(self::TRADE_RESEARCH_ID, 3);
+        $service = $this->app->make(ProjectBonusService::class);
+
+        // curve [1=>2,2=>3,3=>3,...] summed to level 3 = 8
+        $this->assertSame(8, $service->tradePriceBonusPercent(self::COLONY_ID));
+    }
+
+    public function test_trade_price_bonus_percent_is_zero_with_no_trade_knowledge(): void
+    {
+        $service = $this->app->make(ProjectBonusService::class);
+
+        $this->assertSame(0, $service->tradePriceBonusPercent(self::COLONY_ID));
+    }
 }


### PR DESCRIPTION
## Zusammenfassung

`trade`-Kenntnis bekommt einen eigenen, additiven Preis-Bonus auf allen 3 Handelskanälen (Cantina/Bar, Reisender Händler, Corporate Contact) — zusätzlich zum bestehenden Handelsposten-Kanal-Rabatt, kein Konflikt.

**Letzter Plan der 5-Plan-Serie "Kenntnis-Effekte-Redesign"** (sciencelab #282, cartography #283, defense #284, health #285, trade — dieser PR).

- Neue Kurve `config('knowledge.trade.trade_price_bonus_per_lv')` (Σ12%)
- Neue `ProjectBonusService::tradePriceBonusPercent()`
- Verdrahtet additiv in `BarService::acceptOffer()`, `MerchantService::buyItem()`, `CorporateContactService::getActiveOffer()`
- Implementer fand und korrigierte einen echten Plan-Fehler: der Plan behauptete pauschal, keine `AppServiceProvider`-Änderung sei nötig — `MerchantService` hat aber tatsächlich eine explizite Factory-Bindung, die den neuen Parameter brauchte
- Whole-Branch-Review fand einen echten Bug: der trade-Bonus landete fälschlich innerhalb der `is_negotiated`-Ausnahme (die eigentlich nur den Handelsposten-Kanalrabatt vom Konsul-Verhandlungsbonus trennen soll) — behoben, negotiated Angebote bekommen jetzt korrekt auch den Kenntnis-Bonus
- Series-Closing-Cleanup: `ProjectBonusService`s Klassen-Docblock (über 4 Pläne akkumuliert) auf sauberen, aktuellen Stand gebracht

**Bekannter, bewusst nicht behobener Punkt (pre-existing, kein Regressions-Bug dieses Branches):** Bar-/Merchant-Angebotslisten zeigen weiterhin den unrabattierten Preis an (Rabatt erst beim Kauf sichtbar) — dieser Branch verdoppelt die maximale Anzeige-Abweichung von 12% auf 24%, spielerfreundliche Richtung (Anzeigepreis ≥ tatsächlicher Preis). Folge-Ticket empfohlen.

## Test-Plan

- [x] `bin/phpunit` — 1067/1067 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Subagent-Driven-Development: 4 Tasks, alle einzeln reviewed+approved
- [x] Whole-Branch-Review (opus): 1 Important (echter Bug) + 4 Minor Findings gefunden und in Fixwave-Commit behoben, Scoped-Re-Review bestätigt alle adressiert

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9