### PR TITLE
docs: CHANGELOG-Eintrag für PR #288 nachtragen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-08-31
 
 - Feat: trade-Kenntnis bekommt einen eigenen Preis-Bonus auf allen 3 Handelskanälen (Cantina, Reisender Händler, Nexus/Corporate Contact), additiv zum bestehenden Handelsposten-Kanal-Rabatt (Plan 7 der Kenntnis-Effekte-Redesign-Serie, Owner-Entscheidung 2026-08-27). Neuer `ProjectBonusService::tradePriceBonusPercent()`, Config `knowledge.trade.trade_price_bonus_per_lv`.
+- Docs: Post-Merge-Abgleich der Kenntnis-Effekte-Serie gegen GDD/game-reference.md — sciencelab-Effekt in game-reference.md nachgetragen (fehlte komplett), ungenauer Präzedenzfall im health-Paragraph (GDD §9) korrigiert.
 
 ## 2026-08-30
 


### PR DESCRIPTION
CHANGELOG-Eintrag für PR #288 (GDD/game-reference.md-Nachträge) versehentlich beim schnellen Fix übersehen — beim direkten `gh pr merge` per Bash-Tool wird der Claude-Code-seitige Pre-Merge-Hook nicht ausgelöst (der greift nur bei `mcp__github__merge_pull_request`), daher kein automatischer Block.

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9