### PR TITLE
fix: hint_build_priority nennt fehlende CC-Lv2-Voraussetzung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-31
 
+- Fix: `hint_build_priority`-Onboarding-Hint behauptete fälschlich, mehrere Gebäude seien "gerade baubar", obwohl Cantina/Analytik-Labor/Hangar ohne Kommandozentrale Lv2 gar nicht platzierbar sind — Wortlaut korrigiert (Owner-Playtest-Fund).
+
 - Feat: trade-Kenntnis bekommt einen eigenen Preis-Bonus auf allen 3 Handelskanälen (Cantina, Reisender Händler, Nexus/Corporate Contact), additiv zum bestehenden Handelsposten-Kanal-Rabatt (Plan 7 der Kenntnis-Effekte-Redesign-Serie, Owner-Entscheidung 2026-08-27). Neuer `ProjectBonusService::tradePriceBonusPercent()`, Config `knowledge.trade.trade_price_bonus_per_lv`.
 - Docs: Post-Merge-Abgleich der Kenntnis-Effekte-Serie gegen GDD/game-reference.md — sciencelab-Effekt in game-reference.md nachgetragen (fehlte komplett), ungenauer Präzedenzfall im health-Paragraph (GDD §9) korrigiert.
 

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -94,7 +94,7 @@ return [
     'onboarding_hint_advisor_slot2' => 'Berater-Slot 2 ist offen und das dafür nötige Gebäude steht — im Berater-Screen den passenden Berater einstellen.',
     'onboarding_hint_4' => 'Noch keine Kenntnis auf Level 1 — im Techtree Forschungs-AP einer Kenntnis zuweisen. Ergebnisse kommen Sol für Sol.',
     'onboarding_hint_5' => 'Die Stimmung in der Kolonie kippt — Vertrauen stabilisieren: Zivilgebäude bauen oder reparieren, bevor es weiter fällt.',
-    'onboarding_hint_build_priority' => 'Mehrere Gebäude sind gerade baubar, aber die Ressourcen reichen nicht für alle auf einmal — erst eines wählen und fertigstellen. Der Rest kommt, wenn die Kolonie stabiler steht.',
+    'onboarding_hint_build_priority' => 'Cantina, Analytik-Labor und Hangar stehen zur Wahl — aber nicht gleichzeitig: alle drei brauchen zusätzlich Kommandozentrale Lv2, und die Ressourcen reichen ohnehin nicht für alle auf einmal. Schon jetzt überlegen, welches zuerst drankommt.',
     'onboarding_hint_6' => 'Keine Cantina gebaut — Händler und Gäste legen nicht an. Tauschangebote und Einmal-Items passieren die Kolonie einfach.',
     'onboarding_hint_agrardome' => 'Erstes Bauprojekt der Kolonie: der Agrardom. Ohne ihn bleibt CC Level 2 gesperrt und Organika gleich null — heute platzieren, restliche Bau-AP hineinstecken. Investierte Bau-AP bleiben über Sol-Grenzen erhalten, auch wenn ein Sol nicht reicht.',
     'onboarding_hint_analytik' => 'Kein Analytik-Labor — Forschungs-AP können nirgendwo landen. Die Kolonie bleibt wissenschaftlich auf der Stelle.',


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund (Sol 2): `hint_build_priority` behauptet "Mehrere Gebäude sind gerade baubar", obwohl keines der drei Pfadgebäude (Cantina/Analytik-Labor/Hangar) ohne Kommandozentrale Lv2 überhaupt platzierbar ist (`required_building_level=2` in der `buildings`-Tabelle, serverseitig durchgesetzt in `ColonyController`s Buildable-Filter).

Root Cause: `OnboardingHintService::pathChoiceOpen()` gibt im Zweig "noch kein Pfadgebäude platziert" unabhängig vom CC-Level `true` zurück — der Hint feuert also schon vor Erreichen von CC Lv2.

**Bewusst reine Wortlaut-Korrektur, keine Logikänderung:** die bestehende Testsuite hat `test_build_priority_hint_fires_when_two_buildings_eligible` — dieser Test setzt exakt das Sol-2/CC-Lv1-Szenario als gültigen Feuer-Zeitpunkt für die Hint-Auswahl selbst voraus (Rang/Priorität gegenüber anderen Hints). Eine Logikänderung hätte diese Design-Entscheidung angetastet, ohne dass klar ist, ob sie beabsichtigt war (das Nudging könnte absichtlich vorausschauend sein: "überlege schon jetzt, welches zuerst drankommt", auch bevor CC Lv2 erreicht ist). Der Wortlaut ist jetzt unabhängig vom tatsächlichen CC-Level korrekt.

## Test-Plan

- [x] `bin/phpunit --filter OnboardingHintServiceTest` — 68/68 grün, unverändert
- [x] Kein Test hängt am exakten Wortlaut (nur am `text_key`)

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9