### PR TITLE
fix: AP-Chip in Resourcebar nach Berater-Anstellung/-Entlassung live syncen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-31
 
+- Fix: AP-Chip in der Resourcebar aktualisierte sich nach Berater-Anstellung/-Entlassung nicht live — `AdvisorController::hire()`/`fire()` liefern jetzt `apAvailable` im JSON-Response, `advisors.js` patcht den `#resbar-ap`-Chip analog zum bestehenden Credits-Chip-Sync (Owner-Playtest-Fund: Hint zeigte "Forschungs-AP übrig", Header noch "AP 0").
+
 - Fix: `hint_build_priority`-Onboarding-Hint behauptete fälschlich, mehrere Gebäude seien "gerade baubar", obwohl Cantina/Analytik-Labor/Hangar ohne Kommandozentrale Lv2 gar nicht platzierbar sind — Wortlaut korrigiert (Owner-Playtest-Fund).
 
 - Feat: trade-Kenntnis bekommt einen eigenen Preis-Bonus auf allen 3 Handelskanälen (Cantina, Reisender Händler, Nexus/Corporate Contact), additiv zum bestehenden Handelsposten-Kanal-Rabatt (Plan 7 der Kenntnis-Effekte-Redesign-Serie, Owner-Entscheidung 2026-08-27). Neuer `ProjectBonusService::tradePriceBonusPercent()`, Config `knowledge.trade.trade_price_bonus_per_lv`.

--- a/app/Http/Controllers/Techtree/AdvisorController.php
+++ b/app/Http/Controllers/Techtree/AdvisorController.php
@@ -372,6 +372,7 @@ class AdvisorController extends BaseController
                 'slots' => $this->buildSlots($advisors, $slotInfo, $currentTick, $colonyId),
                 'slotInfo' => $slotInfo,
                 'credits' => (int) ($this->resourcesService->getUserResources(['user_id' => $userId])->first()->credits ?? 0),
+                'apAvailable' => $this->advisorService->getAvailableActionPoints($colonyId),
                 'activeHint' => $this->resolveHint($colonyId),
             ]);
         }
@@ -405,6 +406,7 @@ class AdvisorController extends BaseController
                 'ok' => true,
                 'slots' => $this->buildSlots($advisors, $slotInfo, $currentTick, $colonyId),
                 'slotInfo' => $slotInfo,
+                'apAvailable' => $this->advisorService->getAvailableActionPoints($colonyId),
                 'activeHint' => $this->resolveHint($colonyId),
             ]);
         }

--- a/public/js/advisors.js
+++ b/public/js/advisors.js
@@ -59,6 +59,7 @@ function advisorCarousel(config) {
                 this.slotInfo = res.slotInfo;
                 this.closeDialogs();
                 this.syncCreditsChip(res.credits);
+                this.syncApChip(res.apAvailable);
                 this.syncHint(res);
             } else {
                 this.errorMsg = res.message ?? 'Fehler beim Einstellen.';
@@ -89,6 +90,23 @@ function advisorCarousel(config) {
             setTimeout(() => chip.classList.remove('res-chip--flash'), 600);
         },
 
+        // Single shared AP pool chip (#resbar-ap, GDD §13.1) — hiring/firing an
+        // advisor changes it immediately, but the resourcebar is server-rendered
+        // and won't reflect that until a full reload without this patch (Owner-
+        // Playtest 2026-08-31: "Forschungs-AP übrig" hint fired while the header
+        // still showed the pre-hire AP count).
+        syncApChip(apAvailable) {
+            if (apAvailable === undefined) return;
+            const chip = document.getElementById('resbar-ap');
+            if (!chip) return;
+            const el = chip.querySelector('.res-amount');
+            if (el) el.textContent = apAvailable;
+            chip.classList.remove('ap-chip--flash');
+            void chip.offsetWidth;
+            chip.classList.add('ap-chip--flash');
+            setTimeout(() => chip.classList.remove('ap-chip--flash'), 600);
+        },
+
         async doFire() {
             const url = this.routes.fire.replace('__ID__', this.dialogSlot.advisor.id);
             const res = await this.delete(url);
@@ -96,6 +114,7 @@ function advisorCarousel(config) {
                 this.slots = res.slots;
                 this.slotInfo = res.slotInfo;
                 this.closeDialogs();
+                this.syncApChip(res.apAvailable);
                 this.syncHint(res);
             } else {
                 this.errorMsg = res.error ?? 'Fehler beim Entlassen.';

--- a/tests/Feature/Techtree/AdvisorControllerTest.php
+++ b/tests/Feature/Techtree/AdvisorControllerTest.php
@@ -30,6 +30,7 @@ namespace Tests\Feature\Techtree;
  */
 
 use App\Models\User;
+use App\Services\AdvisorService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -330,6 +331,30 @@ class AdvisorControllerTest extends TestCase
             ->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
 
         $response->assertOk()->assertJson(['ok' => true, 'credits' => 10000 - $hireCost]);
+    }
+
+    public function test_hire_json_returns_ap_available_for_resourcebar_sync(): void
+    {
+        // Regression (Owner-Playtest 2026-08-31): the resourcebar AP chip only
+        // updates reactively via this field (advisors.js patches the DOM with
+        // it, mirroring the existing credits-chip sync) — without it a newly
+        // hired advisor's AP contribution is invisible in the header until a
+        // full page reload, even though onboarding hints (which read the AP
+        // pool fresh server-side) already see it.
+        $this->clearBartAdvisors();
+        $this->ensureCredits($this->userIdBart, 10000);
+        $apBefore = app(AdvisorService::class)->getAvailableActionPoints($this->colonyIdBart);
+
+        $bart = User::find($this->userIdBart);
+
+        $response = $this->actingAs($bart)
+            ->withSession($this->bartSession())
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post(route('advisors.hire'), ['personell_id' => $this->personellEngineer]);
+
+        $apAfter = app(AdvisorService::class)->getAvailableActionPoints($this->colonyIdBart);
+        $this->assertGreaterThan($apBefore, $apAfter, 'precondition: hiring must actually raise the AP pool');
+        $response->assertOk()->assertJson(['ok' => true, 'apAvailable' => $apAfter]);
     }
 
     public function test_hire_json_returns_422_on_duplicate(): void


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund: nach Anstellen des Analytikers (+2 AP) zeigte der Onboarding-Hint "Forschungs-AP übrig", während der AP-Chip im Header noch "AP 0" zeigte — Widerspruch, da der Hint nur bei `ap >= 1` feuert.

Root Cause: `AdvisorController::hire()`/`fire()` lieferten den aktuellen AP-Pool-Stand nie im JSON-Response (nur `credits` war live-gesynct über `syncCreditsChip()`), `advisors.js` konnte den `#resbar-ap`-Chip entsprechend nie patchen. Bereits als bekannte Lücke im Code kommentiert, aber bisher nur `doFire()` zugeschrieben (siehe `feedback_resourcebar_live_sync`-Notiz) — betraf tatsächlich auch `doHire()`.

**Fix:**
- `apAvailable` jetzt in beiden JSON-Responses (`hire()`/`fire()`)
- `advisors.js::syncApChip()` patcht den Chip nach demselben Muster wie `bar.blade.php`s bestehender `syncAp()`-Handler

## Test-Plan

- [x] TDD: Regressionstest `test_hire_json_returns_ap_available_for_resourcebar_sync` (rot → grün), analog zum bestehenden Credits-Sync-Test
- [x] `bin/phpunit` — 1068/1068 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] `npx prettier --check public/js/advisors.js` — sauber

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9