### PR TITLE
feat: Gefahren-Ereignisse (Sturm/Instabilität/Seuche) als eigene Banner-Zeile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-08-31
 
 - Fix: AP-Chip in der Resourcebar aktualisierte sich nach Berater-Anstellung/-Entlassung nicht live — `AdvisorController::hire()`/`fire()` liefern jetzt `apAvailable` im JSON-Response, `advisors.js` patcht den `#resbar-ap`-Chip analog zum bestehenden Credits-Chip-Sync (Owner-Playtest-Fund: Hint zeigte "Forschungs-AP übrig", Header noch "AP 0").
+- Feat: Gefahren-Ereignisse (Sturmwarnung, Geologische Instabilität, Seuchenausbruch) waren bisher nur im Protokoll sichtbar und leicht zu übersehen — neue `EncounterNoticeService` + eigene, dringlichere Banner-Zeile über dem Hint-Vorschlag in jedem Colony-Screen. Rein serverseitig gerendert, kein Dismiss nötig: verschwindet automatisch, sobald der Sol endet (Owner-Playtest-Fund + Owner-Entscheidung 2026-08-31).
 
 - Fix: `hint_build_priority`-Onboarding-Hint behauptete fälschlich, mehrere Gebäude seien "gerade baubar", obwohl Cantina/Analytik-Labor/Hangar ohne Kommandozentrale Lv2 gar nicht platzierbar sind — Wortlaut korrigiert (Owner-Playtest-Fund).
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Models\Run;
 use App\Services\AdvisorService;
 use App\Services\BarService;
 use App\Services\ColonyService;
+use App\Services\EncounterNoticeService;
 use App\Services\EventService;
 use App\Services\MerchantService;
 use App\Services\OnboardingHintService;
@@ -198,6 +199,14 @@ class AppServiceProvider extends ServiceProvider
                         $hint['text'] = __($hint['text_key']);
                     }
                     $view->with('activeHint', $hint);
+
+                    // Danger notices (GDD §9 Sturm/Instabilität/Seuche) — own, more
+                    // urgent banner above the hint suggestion (Owner-Playtest-Fund
+                    // 2026-08-31). Reuses $activeRunTick (computed above for the Sol
+                    // chip) so both stay on the exact same clock.
+                    $view->with('activeEncounterNotices', $activeRunTick !== null
+                        ? app(EncounterNoticeService::class)->activeNotices($colonyId, (int) $activeRunTick)
+                        : []);
                 }
             }
         });

--- a/app/Services/EncounterNoticeService.php
+++ b/app/Services/EncounterNoticeService.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Surfaces GDD §9 danger events (Sturm/Instabilität/Seuche) prominently in the
+ * UI, above the normal onboarding hint — Owner-Playtest-Fund (2026-08-31):
+ * these previously only appeared in the Protokoll log, easy to miss for a
+ * whole Sol if the player doesn't check it.
+ *
+ * Deliberately stateless: a notice is "active" exactly while its colony_log
+ * entry's tick equals the colony's current tick. No dismiss button, no extra
+ * DB column — it clears itself the moment game:tick advances to the next Sol
+ * (Owner decision 2026-08-31), the same way the Protokoll's own Sol grouping
+ * already works.
+ */
+class EncounterNoticeService
+{
+    private const EVENT_KEYS = [
+        'encounter.storm_warning',
+        'encounter.storm_abgewehrt',
+        'encounter.storm_beschaedigt',
+        'encounter.storm_kritisch',
+        'encounter.instability_triggered',
+        'encounter.plague_triggered',
+    ];
+
+    /**
+     * @return list<array{event: string, text: string}>
+     */
+    public function activeNotices(int $colonyId, int $currentTick): array
+    {
+        return DB::table('colony_log')
+            ->where('area', 'encounter')
+            ->where('tick', $currentTick)
+            ->whereIn('event', self::EVENT_KEYS)
+            ->orderBy('id')
+            ->get()
+            ->filter(fn ($row) => $this->matchesColony($row, $colonyId))
+            ->map(fn ($row) => [
+                'event' => $row->event,
+                'text' => $this->textFor($row->event, json_decode($row->parameters, true) ?? []),
+            ])
+            ->values()
+            ->all();
+    }
+
+    private function matchesColony(object $row, int $colonyId): bool
+    {
+        $params = json_decode($row->parameters, true);
+
+        return is_array($params) && (int) ($params['colony_id'] ?? -1) === $colonyId;
+    }
+
+    private function textFor(string $event, array $params): string
+    {
+        return match ($event) {
+            'encounter.storm_warning' => __('colony.encounter_notice_storm_warning', ['building' => $this->buildingLabel($params)]),
+            'encounter.storm_abgewehrt' => __('colony.encounter_notice_storm_abgewehrt', ['building' => $this->buildingLabel($params)]),
+            'encounter.storm_beschaedigt' => __('colony.encounter_notice_storm_beschaedigt', ['building' => $this->buildingLabel($params)]),
+            'encounter.storm_kritisch' => __('colony.encounter_notice_storm_kritisch', ['building' => $this->buildingLabel($params)]),
+            'encounter.instability_triggered' => __('comm_log.desc.instability_triggered', [
+                'sols' => (int) config('game.encounter.instability.outage_sols', 3),
+            ]),
+            'encounter.plague_triggered' => __('comm_log.desc.plague_triggered'),
+            default => '',
+        };
+    }
+
+    private function buildingLabel(array $params): string
+    {
+        $buildingId = $params['building_id'] ?? null;
+        if ($buildingId === null) {
+            return '?';
+        }
+
+        $nameKey = DB::table('buildings')->where('id', $buildingId)->value('name');
+        if (! $nameKey) {
+            return '?';
+        }
+
+        $translated = __('techtree.'.$nameKey);
+
+        return $translated !== 'techtree.'.$nameKey ? $translated : $nameKey;
+    }
+}

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -371,4 +371,12 @@ return [
     'sol_report_finale_win_cta' => 'Run abschließen',
     'sol_report_finale_lose_cta' => 'Run beenden',
 
+    // Encounter-Gefahrenbanner (GDD §9) — eigene, dringlichere Zeile über dem
+    // normalen Hint-Vorschlag, Owner-Playtest-Fund 2026-08-31: Sturmwarnung etc.
+    // waren zuvor nur im Protokoll sichtbar, leicht zu übersehen.
+    'encounter_notice_storm_warning' => 'Sturmwarnung: :building ist im Vorfeld gefährdet.',
+    'encounter_notice_storm_abgewehrt' => 'Sturm bei :building erfolgreich abgewehrt — kein Schaden.',
+    'encounter_notice_storm_beschaedigt' => 'Sturmschaden an :building.',
+    'encounter_notice_storm_kritisch' => 'Kritischer Sturmschaden an :building — Level gesunken.',
+
 ];

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -1392,6 +1392,26 @@ dialog[x-ref="discoveryDialog"] {
  * Flex row: icon | text (grows) | action link | dismiss button.
  * Uses Alpine x-transition for a smooth fade-in/out on dismiss.
  */
+/* Encounter danger notice (GDD §9 Sturm/Instabilität/Seuche) — sits above the
+ * hint-bar, more urgent styling (red vs. the hint's amber). Static/server-
+ * rendered, no dismiss button: clears itself once game:tick advances past the
+ * tick it was logged at (EncounterNoticeService), see Owner-Playtest-Fund
+ * 2026-08-31. */
+.encounter-notice-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 1rem;
+    background: #fee2e2;
+    border-bottom: 1px solid #fecaca;
+    font-size: 0.8rem;
+    flex-shrink: 0;
+}
+
+.encounter-notice-bar__icon {
+    flex-shrink: 0;
+}
+
 /* Stacking context for the brief overlap between the fading "done" banner
  * and the new hint sliding in above it (see setActiveHint() in
  * colony-hexgrid.js). */

--- a/resources/views/layouts/colony.blade.php
+++ b/resources/views/layouts/colony.blade.php
@@ -224,6 +224,7 @@
         @endif
 
         @auth
+            @include("partials.encounter-notice-bar")
             @include("partials.hint-bar")
         @endauth
     </header>

--- a/resources/views/partials/encounter-notice-bar.blade.php
+++ b/resources/views/partials/encounter-notice-bar.blade.php
@@ -1,0 +1,17 @@
+{{--
+    Encounter danger notice bar (GDD §9 Sturm/Instabilität/Seuche) — shown above
+    the onboarding hint-bar in the shared layout header, Owner-Playtest-Fund
+    2026-08-31: these events previously only appeared in the Protokoll log and
+    were easy to miss for a whole Sol. Purely server-rendered (see
+    AppServiceProvider's $activeEncounterNotices) — no live AJAX sync needed,
+    since these events only ever change at Sol-end (game:tick), which already
+    reloads the page. Clears itself automatically once the Sol ends, no dismiss
+    button (see EncounterNoticeService docblock).
+--}}
+@php($notices = $activeEncounterNotices ?? [])
+@foreach ($notices as $notice)
+    <div class="encounter-notice-bar">
+        <span class="encounter-notice-bar__icon" aria-hidden="true">⚠</span>
+        <span class="encounter-notice-bar__text">{{ $notice["text"] }}</span>
+    </div>
+@endforeach

--- a/tests/Feature/Onboarding/EncounterNoticeServiceTest.php
+++ b/tests/Feature/Onboarding/EncounterNoticeServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Tests\Feature\Onboarding;
+
+use App\Services\EncounterNoticeService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * EncounterNoticeService — surfaces GDD §9 danger events (Sturm/Instabilität/
+ * Seuche) prominently in the UI. Owner-Playtest-Fund (2026-08-31): these events
+ * only ever appeared in the Protokoll log, easy to miss if the player doesn't
+ * check it every Sol.
+ */
+class EncounterNoticeServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private EncounterNoticeService $service;
+
+    private const COLONY_ID = 1;
+
+    private const OTHER_COLONY_ID = 2;
+
+    private const CURRENT_TICK = 42;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        $this->service = $this->app->make(EncounterNoticeService::class);
+    }
+
+    private function insertEncounterLog(string $event, array $params, int $tick = self::CURRENT_TICK): void
+    {
+        DB::table('colony_log')->insert([
+            'user' => 3,
+            'tick' => $tick,
+            'event' => $event,
+            'area' => 'encounter',
+            'parameters' => json_encode($params),
+            'created_at' => now(),
+            'is_read' => false,
+        ]);
+    }
+
+    public function test_no_notices_when_log_empty(): void
+    {
+        $this->assertSame([], $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK));
+    }
+
+    public function test_storm_warning_produces_a_notice_naming_the_target_building(): void
+    {
+        $this->insertEncounterLog('encounter.storm_warning', [
+            'colony_id' => self::COLONY_ID,
+            'building_id' => 25,
+            'instance_id' => 1,
+        ]);
+
+        $notices = $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK);
+
+        $this->assertCount(1, $notices);
+        $this->assertSame('encounter.storm_warning', $notices[0]['event']);
+        $this->assertSame(
+            __('colony.encounter_notice_storm_warning', ['building' => __('techtree.building_commandCenter')]),
+            $notices[0]['text']
+        );
+    }
+
+    public function test_storm_kritisch_produces_a_notice(): void
+    {
+        $this->insertEncounterLog('encounter.storm_kritisch', [
+            'colony_id' => self::COLONY_ID,
+            'building_id' => 25,
+            'instance_id' => 1,
+            'tier' => 'kritisch',
+        ]);
+
+        $notices = $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK);
+
+        $this->assertCount(1, $notices);
+        $this->assertSame(
+            __('colony.encounter_notice_storm_kritisch', ['building' => __('techtree.building_commandCenter')]),
+            $notices[0]['text']
+        );
+    }
+
+    public function test_instability_triggered_produces_a_notice(): void
+    {
+        $this->insertEncounterLog('encounter.instability_triggered', [
+            'colony_id' => self::COLONY_ID,
+            'instance_id' => 1,
+            'outage_until_tick' => self::CURRENT_TICK + 3,
+        ]);
+
+        $notices = $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK);
+
+        $this->assertCount(1, $notices);
+        $this->assertSame('encounter.instability_triggered', $notices[0]['event']);
+        $this->assertSame(
+            __('comm_log.desc.instability_triggered', ['sols' => (int) config('game.encounter.instability.outage_sols', 3)]),
+            $notices[0]['text']
+        );
+    }
+
+    public function test_plague_triggered_produces_a_notice(): void
+    {
+        $this->insertEncounterLog('encounter.plague_triggered', [
+            'colony_id' => self::COLONY_ID,
+            'debuff_until_tick' => self::CURRENT_TICK + 3,
+        ]);
+
+        $notices = $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK);
+
+        $this->assertCount(1, $notices);
+        $this->assertSame(__('comm_log.desc.plague_triggered'), $notices[0]['text']);
+    }
+
+    public function test_notice_disappears_once_tick_advances(): void
+    {
+        // The whole point of the feature: no dismiss button needed, it clears
+        // automatically once the Sol ends (Owner decision 2026-08-31).
+        $this->insertEncounterLog('encounter.plague_triggered', [
+            'colony_id' => self::COLONY_ID,
+            'debuff_until_tick' => self::CURRENT_TICK + 3,
+        ], self::CURRENT_TICK);
+
+        $this->assertNotEmpty($this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK));
+        $this->assertSame([], $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK + 1));
+    }
+
+    public function test_notice_from_a_different_colony_is_not_shown(): void
+    {
+        $this->insertEncounterLog('encounter.plague_triggered', [
+            'colony_id' => self::OTHER_COLONY_ID,
+            'debuff_until_tick' => self::CURRENT_TICK + 3,
+        ]);
+
+        $this->assertSame([], $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK));
+    }
+
+    public function test_non_encounter_log_entries_are_ignored(): void
+    {
+        DB::table('colony_log')->insert([
+            'user' => 3,
+            'tick' => self::CURRENT_TICK,
+            'event' => 'colony.passive_credits',
+            'area' => 'colony',
+            'parameters' => json_encode(['colony_id' => self::COLONY_ID]),
+            'created_at' => now(),
+            'is_read' => false,
+        ]);
+
+        $this->assertSame([], $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK));
+    }
+
+    public function test_multiple_notices_in_the_same_tick_are_all_returned(): void
+    {
+        $this->insertEncounterLog('encounter.instability_triggered', [
+            'colony_id' => self::COLONY_ID,
+            'instance_id' => 1,
+            'outage_until_tick' => self::CURRENT_TICK + 3,
+        ]);
+        $this->insertEncounterLog('encounter.plague_triggered', [
+            'colony_id' => self::COLONY_ID,
+            'debuff_until_tick' => self::CURRENT_TICK + 3,
+        ]);
+
+        $this->assertCount(2, $this->service->activeNotices(self::COLONY_ID, self::CURRENT_TICK));
+    }
+}


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund: eine Sturmwarnung tauchte nur im Protokoll auf, wurde übersehen weil der Spieler es nicht jeden Sol nachschaut. Feature-Wunsch: wichtige Gefahren-Ereignisse müssen prominent im UI erscheinen, am besten neben/über den Hints.

**Owner-Entscheidungen (Klärungsfragen vorab gestellt):**
1. Alle 3 Gefahrentypen (Sturm, Geologische Instabilität, Seuchenausbruch) — nicht nur Sturm
2. Eigene Banner-Zeile mit höherer Priorität als der normale Hint (nicht in dessen Rang-Slot integriert)
3. Kein Dismiss-Mechanismus — verschwindet automatisch, sobald der Sol endet

**Implementierung:**
- Neue `EncounterNoticeService::activeNotices(colonyId, currentTick)` — liest `colony_log`-Einträge (`area=encounter`) für den aktuellen Tick, deckt alle 4 Event-Keys ab (`storm_warning`, `storm_{tier}`, `instability_triggered`, `plague_triggered`)
- Bewusst stateless: "aktiv" = `colony_log.tick === aktueller Tick`. Kein neues DB-Feld, keine Dismiss-Route — die Auto-Clear-Anforderung fällt automatisch aus dem bestehenden Tick-Modell ab
- Eingehängt im selben `AppServiceProvider`-View-Composer wie `$activeHint`, erscheint dadurch auf jedem Colony-Screen (nicht nur der Kolonieansicht)
- Neues `partials/encounter-notice-bar.blade.php`, eigene rote Styling-Klasse (vs. Hint-Bars Amber), oberhalb der Hint-Bar im Layout

## Test-Plan

- [x] TDD: 9 neue Tests (`EncounterNoticeServiceTest`) — alle 4 Event-Typen, Colony-Isolation, Tick-Grenze (Auto-Clear), Mehrfach-Ereignisse im selben Tick
- [x] `bin/phpunit` — 1077/1077 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Prettier (CSS/Blade) sauber

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9