### PR TITLE
fix: Berater verbrauchen kein Supply mehr (GDD-Code-Drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-31
 
+- Fix: Berater zählten fälschlich als Supply-Verbraucher (`ResourcesService::getSupplyBreakdown()` — `config('game.supply.cost_advisor', 2)`, ein nirgends definierter Config-Key), obwohl das GDD an 5 Stellen explizit sagt "Berater kosten ausschließlich Credits, kein Supply". Trieb sogar den Over-Cap-Decay-Straf-Mechanismus fälschlich an — eine Kolonie konnte allein durchs Anheuern eines Beraters unbeabsichtigt ins Supply-Minus rutschen (Owner-Playtest-Fund).
+
 - Fix: AP-Chip in der Resourcebar aktualisierte sich nach Berater-Anstellung/-Entlassung nicht live — `AdvisorController::hire()`/`fire()` liefern jetzt `apAvailable` im JSON-Response, `advisors.js` patcht den `#resbar-ap`-Chip analog zum bestehenden Credits-Chip-Sync (Owner-Playtest-Fund: Hint zeigte "Forschungs-AP übrig", Header noch "AP 0").
 - Feat: Gefahren-Ereignisse (Sturmwarnung, Geologische Instabilität, Seuchenausbruch) waren bisher nur im Protokoll sichtbar und leicht zu übersehen — neue `EncounterNoticeService` + eigene, dringlichere Banner-Zeile über dem Hint-Vorschlag in jedem Colony-Screen. Rein serverseitig gerendert, kein Dismiss nötig: verschwindet automatisch, sobald der Sol endet (Owner-Playtest-Fund + Owner-Entscheidung 2026-08-31).
 

--- a/app/Services/ResourcesService.php
+++ b/app/Services/ResourcesService.php
@@ -283,10 +283,15 @@ class ResourcesService
             ->where('cr.level', '>', 0)
             ->sum(DB::raw('cr.level * COALESCE(r.supply_cost, 0)'));
 
-        $advisorCount = (int) DB::table('advisors')
-            ->where('colony_id', $colonyId)
-            ->count();
-        $usedAdvisors = $advisorCount * (int) config('game.supply.cost_advisor', 2);
+        // Berater belegen KEIN Supply (GDD §6/§13, mehrfach explizit: "Berater
+        // kosten ausschliesslich Credits — Supply ist nicht betroffen"). Owner-
+        // Playtest-Fund 2026-08-31: dieser Wert wurde bis hier hin trotzdem als
+        // Supply-Verbraucher gezählt, über einen nirgends definierten Config-
+        // Key (`game.supply.cost_advisor`, reiner Fallback-Default) — echter
+        // Drift zwischen Code und Design, kein beabsichtigtes Feature. Feld
+        // bleibt in der Rückgabestruktur (API-Stabilität für bestehende
+        // Konsumenten), ist aber immer 0.
+        $usedAdvisors = 0;
 
         return [
             'cap' => $cap,

--- a/tests/Feature/GameTick/OverCapDecayTest.php
+++ b/tests/Feature/GameTick/OverCapDecayTest.php
@@ -94,6 +94,37 @@ class OverCapDecayTest extends TestCase
         $this->assertGreaterThanOrEqual(0, $free, 'getFreeSupply() must not be negative when within cap');
     }
 
+    /**
+     * GDD §6/§13 (mehrfach, z.B. Zeile 946/1019/2170/2177): "Berater belegen
+     * kein Supply — sie kosten Credits." Owner-Playtest-Fund 2026-08-31: eine
+     * Kolonie geriet allein durchs Anheuern eines Beraters ins Supply-Minus,
+     * obwohl AdvisorController::hire() (korrekterweise laut GDD) keinerlei
+     * Supply-Gate hat — der Bug lag in getSupplyBreakdown() selbst, das
+     * Berater fälschlich mit `config('game.supply.cost_advisor', 2)` als
+     * Supply-Verbraucher zählte (ein Config-Key, der nirgends definiert ist —
+     * reiner Fallback-Wert, nie absichtlich gesetzt).
+     */
+    public function test_advisors_do_not_consume_supply(): void
+    {
+        $this->zeroAllSupplyCosts();
+        DB::table('user_resources')->where('user_id', 3)->update(['supply' => 4]);
+
+        /** @var ResourcesService $svc */
+        $svc = $this->app->make(ResourcesService::class);
+
+        $freeBefore = $svc->getFreeSupply(1);
+
+        DB::table('advisors')->insert([
+            'user_id' => 3, 'colony_id' => 1, 'personell_id' => 36, // scientist
+            'rank' => 1, 'active_ticks' => 0,
+        ]);
+
+        $freeAfter = $svc->getFreeSupply(1);
+
+        $this->assertSame($freeBefore, $freeAfter, 'hiring an advisor must not change free supply');
+        $this->assertSame(0, $svc->getSupplyBreakdown(1)['used']['advisors'], 'advisors must never appear as a supply consumer');
+    }
+
     // ── getOverCapColonyIds ───────────────────────────────────────────────────
 
     /**


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund: Kolonie geriet allein durchs Anheuern eines Beraters (Analytiker) ins Supply-Minus (SUP -2/18).

**Root Cause:** `ResourcesService::getSupplyBreakdown()` zählte Berater als Supply-Verbraucher (`advisorCount * config('game.supply.cost_advisor', 2)`) — dieser Config-Key ist nirgends definiert, reiner Fallback-Default, nie absichtlich gesetzt. GDD sagt an 5 Stellen explizit das Gegenteil (§6/§13): "Berater belegen kein Supply — sie kosten Credits." Passt auch zu `AdvisorController::hire()`, das korrekterweise nie ein Supply-Gate hatte — das war kein fehlendes Gate, das Gate war schlicht nie vorgesehen.

**Konsequenz ging über eine falsche Zahl im Header hinaus:** negative freie Supply treibt `GameTick::getOverCapColonyIds()` an, das den Decay-Faktor für Gebäude/Kenntnisse verdoppelt (§6) — eine Kolonie konnte durch reines Berater-Anheuern unbeabsichtigt in eine 2×-Verfall-Strafe rutschen.

**Fix:** `usedAdvisors` auf 0 gesetzt (Feld bleibt in der Rückgabestruktur für API-Stabilität).

**Hinweis:** betrifft nur künftige Berechnungen — bereits laufende Runs mit negativer Supply durch diesen Bug müssten die Ursache manuell auflösen (Berater entlassen oder Cap erhöhen), der Fix korrigiert nicht rückwirkend gespeicherte Zustände.

## Test-Plan

- [x] TDD: neuer Regressionstest beweist, dass sich freie Supply durch Anheuern nicht ändert
- [x] `bin/phpunit` — 1081/1081 grün (inkl. bestehender `OverCapDecayTest`-Suite unverändert grün)
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Pint sauber

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9