### PR TITLE
feat: Effekt-Beschreibung in Gebäude-/Kenntnis-Sidebar anzeigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-31
 
+- Feat: Gebäude-/Kenntnis-Detail-Panels (Kolonie-Sidebar, Techtree-Sidebar) zeigten Kosten und Fortschritt, aber nie was gebaut/erforscht eigentlich bewirkt — Spieler konnte nicht vorausplanen. Bereits vorhandene Beschreibungstexte (`buildings.*_desc`, `techtree.desc_techs_*`) jetzt in beiden Panels verdrahtet (generischer Effekt-Text, noch keine Pro-Level-Freischaltungen — das wäre eine separate Content-Aufgabe) (Owner-Playtest-Fund).
+
 - Fix: Berater zählten fälschlich als Supply-Verbraucher (`ResourcesService::getSupplyBreakdown()` — `config('game.supply.cost_advisor', 2)`, ein nirgends definierter Config-Key), obwohl das GDD an 5 Stellen explizit sagt "Berater kosten ausschließlich Credits, kein Supply". Trieb sogar den Over-Cap-Decay-Straf-Mechanismus fälschlich an — eine Kolonie konnte allein durchs Anheuern eines Beraters unbeabsichtigt ins Supply-Minus rutschen (Owner-Playtest-Fund).
 
 - Fix: AP-Chip in der Resourcebar aktualisierte sich nach Berater-Anstellung/-Entlassung nicht live — `AdvisorController::hire()`/`fire()` liefern jetzt `apAvailable` im JSON-Response, `advisors.js` patcht den `#resbar-ap`-Chip analog zum bestehenden Credits-Chip-Sync (Owner-Playtest-Fund: Hint zeigte "Forschungs-AP übrig", Header noch "AP 0").

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -138,6 +138,7 @@ class ColonyController extends BaseController
             ->map(function ($b) use ($globalTick, $colony) {
                 $b->label = __('techtree.'.$b->building_key);
                 $b->image_slug = self::buildingImageSlug($b->building_key);
+                $b->description = __('buildings.'.preg_replace('/^building_/', '', $b->building_key).'_desc');
                 $b->in_transit = $b->pending_until_tick !== null && (int) $b->pending_until_tick >= $globalTick;
                 $b->levelup_cost = $this->levelupRegolithFor((int) $b->building_id, (int) $b->level + 1);
                 $b->ap_for_levelup = $this->projectBonusService->effectiveApForLevelup($colony->id, (int) $b->ap_for_levelup);
@@ -1056,6 +1057,7 @@ class ColonyController extends BaseController
 
         $row->label = __('techtree.'.$row->building_key);
         $row->image_slug = self::buildingImageSlug($row->building_key);
+        $row->description = __('buildings.'.preg_replace('/^building_/', '', $row->building_key).'_desc');
         $row->in_transit = $row->pending_until_tick !== null && (int) $row->pending_until_tick >= $this->getTick();
         $row->levelup_cost = $this->levelupRegolithFor((int) $row->building_id, (int) $row->level + 1);
         $row->ap_for_levelup = $this->projectBonusService->effectiveApForLevelup($colonyId, (int) $row->ap_for_levelup);

--- a/app/Http/Controllers/Techtree/TechtreeController.php
+++ b/app/Http/Controllers/Techtree/TechtreeController.php
@@ -109,6 +109,14 @@ class TechtreeController extends BaseController
                     'col' => (int) ($tech['column'] ?? 0),
                     'status' => $this->computeStatus($tech, $techtree),
                     'required_desc' => $this->computeRequiredDesc($tech, $techtree),
+                    // What this entity DOES, independent of prereqs — Owner-Playtest-Fund
+                    // 2026-08-31: the sidebar showed cost/progress but never the effect,
+                    // so the player couldn't plan ahead. Reuses the existing desc_techs_*
+                    // texts (already written for every building/knowledge, just unused
+                    // here) — no new content needed for this generic-description pass.
+                    'description' => in_array($type, ['building', 'research'], true)
+                        ? __('techtree.desc_techs_'.preg_replace('/^(building|knowledge)_/', '', $tech['name']))
+                        : null,
                     'max_level' => isset($tech['max_level']) ? (int) $tech['max_level'] : null,
                     'key' => $type === 'building' ? $tech['name'] : null,
                     'image_slug' => $type === 'building' ? self::buildingImageSlug($tech['name']) : null,

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -931,6 +931,16 @@ button.btn-sol:hover,
     color: var(--color-anthracite, #333);
 }
 
+/* General effect text (Owner-Playtest-Fund 2026-08-31) — sits outside
+ * .building-detail-wrap so it still shows for image-less types (knowledge). */
+.building-detail-description {
+    font-size: 0.8rem;
+    line-height: 1.4;
+    color: var(--color-anthracite, #333);
+    opacity: 0.8;
+    margin: 0 0 0.75rem;
+}
+
 /* ── Building level badge (shared building-detail partial) ───────────────── */
 
 .sidebar-level-badge {

--- a/resources/views/partials/building-detail.blade.php
+++ b/resources/views/partials/building-detail.blade.php
@@ -15,30 +15,37 @@
                      null when the item is not a building type → entire block hidden
       level        — integer; level badge shown only when > 0
       <name_field> — display name string
+      description  — general effect text (desc_techs_*/buildings.*_desc lang
+                     strings, existing content, not per-level) — Owner-Playtest-
+                     Fund 2026-08-31: sidebar showed cost/progress but never
+                     what the building/knowledge actually does. Shown only
+                     when truthy (older callers may not pass it yet).
 --}}
 @php
-    $nameField  = $name_field  ?? 'name';
+    $nameField = $name_field ?? "name";
     $showHeader = $show_header ?? true;
 @endphp
 
-{{-- Entire block hidden when image_slug is falsy (non-building types in techtree) --}}
-<div class="building-detail-wrap"
-     x-show="{{ $expr }}.image_slug">
+{{-- Image+header block hidden when image_slug is falsy (non-building types in
+     techtree, e.g. knowledge/ship/personell) — but the description paragraph
+     below is independent of that gate, since knowledge entries have no image
+     yet still need their effect text shown. --}}
+<div class="building-detail-wrap" x-show="{{ $expr }}.image_slug">
 
     <div class="building-detail-img-wrap">
-        <img class="building-detail-img"
-             :src="'/img/buildings/' + {{ $expr }}.image_slug + '.webp'"
-             :alt="{{ $expr }}.{{ $nameField }}">
+        <img class="building-detail-img" :src="'/img/buildings/' + {{ $expr }}.image_slug + '.webp'"
+            :alt="{{ $expr }}.{{ $nameField }}">
     </div>
 
-    @if($showHeader)
-    <div class="building-detail-header">
-        <strong class="building-detail-name"
-                x-text="{{ $expr }}.{{ $nameField }}"></strong>
-        <span class="sidebar-level-badge"
-              x-show="{{ $expr }}.level > 0"
-              x-text="`Lv. ${ {{ $expr }}.level }`"></span>
-    </div>
+    @if ($showHeader)
+        <div class="building-detail-header">
+            <strong class="building-detail-name" x-text="{{ $expr }}.{{ $nameField }}"></strong>
+            <span class="sidebar-level-badge" x-show="{{ $expr }}.level > 0"
+                x-text="`Lv. ${ {{ $expr }}.level }`"></span>
+        </div>
     @endif
 
 </div>
+
+<p class="building-detail-description" x-show="{{ $expr }}.description"
+    x-text="{{ $expr }}.description"></p>

--- a/tests/Feature/Colony/ColonyViewTest.php
+++ b/tests/Feature/Colony/ColonyViewTest.php
@@ -105,6 +105,25 @@ class ColonyViewTest extends TestCase
         $this->assertSame('Vollausstattung', $infirmary->tier_label);
     }
 
+    // Regression (Owner-Playtest 2026-08-31): the sidebar showed build cost
+    // and progress but never what the building actually does — the player
+    // couldn't plan ahead. buildings.*_desc texts already existed, just
+    // weren't wired into the tile-panel data.
+    public function test_hexview_buildings_include_description(): void
+    {
+        $this->app->setLocale('de');
+
+        $response = $this->actingAs($this->makeUser(self::BART_USER_ID))
+            ->get(route('colony.view'));
+
+        $buildings = $response->viewData('buildings');
+        $infirmary = $buildings->firstWhere('building_id', 46);
+
+        $this->assertNotNull($infirmary);
+        $this->assertSame(__('buildings.infirmary_desc'), $infirmary->description);
+        $this->assertNotEmpty($infirmary->description);
+    }
+
     public function test_pending_run_redirects_to_lobby(): void
     {
         // A pending run is active but not yet started (started_at = null).

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -219,6 +219,32 @@ class TechtreeControllerTest extends TestCase
         }
     }
 
+    // Regression (Owner-Playtest 2026-08-31): the techtree sidebar showed cost/
+    // progress for a knowledge or building node but never what it actually
+    // does — the player couldn't plan ahead. desc_techs_* texts already
+    // existed for every building and knowledge, just weren't wired in.
+    public function test_index_knowledge_and_building_items_include_description(): void
+    {
+        $this->app->setLocale('de');
+        $bart = User::find($this->userIdBart);
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        $construction = null;
+        $sciencelab = null;
+        foreach ($pageData['phases'] as $phase) {
+            $construction ??= collect($phase['items'])->first(fn ($t) => $t['type'] === 'research' && $t['id'] === 90);
+            $sciencelab ??= collect($phase['items'])->first(fn ($t) => $t['type'] === 'building' && $t['key'] === 'building_sciencelab');
+        }
+
+        $this->assertNotNull($construction, 'construction (id=90) must be present in the phases');
+        $this->assertSame(__('techtree.desc_techs_construction'), $construction['description']);
+        $this->assertNotEmpty($construction['description']);
+
+        $this->assertNotNull($sciencelab, 'sciencelab building must be present in the phases');
+        $this->assertSame(__('techtree.desc_techs_sciencelab'), $sciencelab['description']);
+        $this->assertNotEmpty($sciencelab['description']);
+    }
+
     public function test_knowledge_ap_for_levelup_matches_config_not_stale_db_value(): void
     {
         // Playtest regression (2026-07-14): researches.ap_for_levelup is a static


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund: Kolonie- und Techtree-Sidebar zeigten Kosten und Baubalken, aber nie was das Gebäude/die Kenntnis tatsächlich bewirkt — Spieler konnte nicht vorausplanen.

**Fund bei der Recherche:** allgemeine Effekt-Beschreibungstexte existierten bereits vollständig für alle 13 Gebäude (`lang/de/buildings.php`) und alle 7 Kenntnisse + Gebäude im Techtree-Kontext (`lang/de/techtree.php`, `desc_techs_*`) — waren aber in keinem der beiden Detail-Panels verdrahtet. **Reine Verdrahtungsaufgabe, kein neuer Content für diesen Schritt.**

- `ColonyController::hexview()`/`fetchBuildingRow()`: neues `description`-Feld
- `TechtreeController::index()`: neues `description`-Feld (nur building/research-Typen)
- `partials/building-detail.blade.php` (geteilt zwischen beiden Panels): neuer Beschreibungs-Absatz, bewusst AUSSERHALB des `image_slug`-gegateten Wrappers — Kenntnisse haben kein Bild, brauchen aber trotzdem den Text (wäre sonst für Techtree-Kenntnisse unsichtbar geblieben)

**Bewusst nicht Teil dieses Fixes:** Pro-Level-Freischalt-Texte ("was genau bringt DIESES Level") — dafür existiert aktuell kein Content, nur verstreute Zahlen-Kurven in Configs. Wäre eine separate Content-Writer-Aufgabe (~65-100 kurze Textbausteine für 13 Gebäude × bis zu 5 Level + 7 Kenntnisse × 5 Level).

## Test-Plan

- [x] TDD: 2 neue Regressionstests (Kolonie-Panel, Techtree-Panel), beide rot→grün verifiziert
- [x] `bin/phpunit` — 1083/1083 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Pint + Prettier sauber

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9