### PR TITLE
feat: Sidebar zeigt was das nächste Gebäude-Level freischaltet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-31
 
+- Feat: Gebäude-/Techtree-Sidebar zeigten "Voraussetzung", aber nie die Kehrseite — was das NÄCHSTE Level freischaltet (z.B. Hangar Lv1→2 schaltet den Frachter frei). Neue `BuildingUnlockService::unlocksAtLevel()` — reine Rückwärts-Abfrage der bestehenden `required_building_id`/`required_building_level`-Gate-Daten (Gebäude/Schiffe/Berater/Kenntnisse), kein neuer Content nötig. Nur Gebäude-Level (Kenntnis-Level haben aktuell keine diskreten Freischaltungen, nur kontinuierliche Effekt-Kurven) (Owner-Playtest-Fund).
+
 - Feat: Gebäude-/Kenntnis-Detail-Panels (Kolonie-Sidebar, Techtree-Sidebar) zeigten Kosten und Fortschritt, aber nie was gebaut/erforscht eigentlich bewirkt — Spieler konnte nicht vorausplanen. Bereits vorhandene Beschreibungstexte (`buildings.*_desc`, `techtree.desc_techs_*`) jetzt in beiden Panels verdrahtet (generischer Effekt-Text, noch keine Pro-Level-Freischaltungen — das wäre eine separate Content-Aufgabe) (Owner-Playtest-Fund).
 
 - Fix: Berater zählten fälschlich als Supply-Verbraucher (`ResourcesService::getSupplyBreakdown()` — `config('game.supply.cost_advisor', 2)`, ein nirgends definierter Config-Key), obwohl das GDD an 5 Stellen explizit sagt "Berater kosten ausschließlich Credits, kein Supply". Trieb sogar den Over-Cap-Decay-Straf-Mechanismus fälschlich an — eine Kolonie konnte allein durchs Anheuern eines Beraters unbeabsichtigt ins Supply-Minus rutschen (Owner-Playtest-Fund).

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -14,6 +14,7 @@ use App\Services\OnboardingHintService;
 use App\Services\OnboardingTriggerService;
 use App\Services\ProjectBonusService;
 use App\Services\ResourcesService;
+use App\Services\Techtree\BuildingUnlockService;
 use App\Services\TickService;
 use App\Services\TrustService;
 use Illuminate\Http\JsonResponse;
@@ -39,6 +40,7 @@ class ColonyController extends BaseController
         private readonly TrustService $trustService,
         private readonly HarvesterEntitlementService $harvesterEntitlementService,
         private readonly ProjectBonusService $projectBonusService,
+        private readonly BuildingUnlockService $buildingUnlockService,
     ) {
         parent::__construct($tick);
     }
@@ -139,6 +141,7 @@ class ColonyController extends BaseController
                 $b->label = __('techtree.'.$b->building_key);
                 $b->image_slug = self::buildingImageSlug($b->building_key);
                 $b->description = __('buildings.'.preg_replace('/^building_/', '', $b->building_key).'_desc');
+                $b->unlocks_next_level = $this->buildingUnlockService->unlocksAtLevel((int) $b->building_id, (int) $b->level + 1);
                 $b->in_transit = $b->pending_until_tick !== null && (int) $b->pending_until_tick >= $globalTick;
                 $b->levelup_cost = $this->levelupRegolithFor((int) $b->building_id, (int) $b->level + 1);
                 $b->ap_for_levelup = $this->projectBonusService->effectiveApForLevelup($colony->id, (int) $b->ap_for_levelup);
@@ -1058,6 +1061,7 @@ class ColonyController extends BaseController
         $row->label = __('techtree.'.$row->building_key);
         $row->image_slug = self::buildingImageSlug($row->building_key);
         $row->description = __('buildings.'.preg_replace('/^building_/', '', $row->building_key).'_desc');
+        $row->unlocks_next_level = $this->buildingUnlockService->unlocksAtLevel((int) $row->building_id, (int) $row->level + 1);
         $row->in_transit = $row->pending_until_tick !== null && (int) $row->pending_until_tick >= $this->getTick();
         $row->levelup_cost = $this->levelupRegolithFor((int) $row->building_id, (int) $row->level + 1);
         $row->ap_for_levelup = $this->projectBonusService->effectiveApForLevelup($colonyId, (int) $row->ap_for_levelup);

--- a/app/Http/Controllers/Techtree/TechtreeController.php
+++ b/app/Http/Controllers/Techtree/TechtreeController.php
@@ -8,6 +8,7 @@ use App\Services\AdvisorService;
 use App\Services\OnboardingHintService;
 use App\Services\Techtree\AbstractTechnologyService;
 use App\Services\Techtree\BuildingService;
+use App\Services\Techtree\BuildingUnlockService;
 use App\Services\Techtree\ResearchService;
 use App\Services\Techtree\ShipService;
 use App\Services\Techtree\TechtreeColonyService;
@@ -31,6 +32,7 @@ class TechtreeController extends BaseController
         private readonly AdvisorService $advisorService,
         private readonly TechtreeColonyService $techtreeColonyService,
         private readonly OnboardingHintService $onboardingHintService,
+        private readonly BuildingUnlockService $buildingUnlockService,
     ) {
         parent::__construct($tick);
     }
@@ -117,6 +119,14 @@ class TechtreeController extends BaseController
                     'description' => in_array($type, ['building', 'research'], true)
                         ? __('techtree.desc_techs_'.preg_replace('/^(building|knowledge)_/', '', $tech['name']))
                         : null,
+                    // Reverse of required_desc: what becomes available specifically at
+                    // the NEXT level of this building (Owner-Playtest-Fund 2026-08-31,
+                    // e.g. "Hangar Lv2 unlocks Frachter"). Buildings only — knowledge
+                    // levels never gate other entities in the current data (only
+                    // continuous effect curves, no discrete unlocks to derive).
+                    'unlocks_next_level' => $type === 'building'
+                        ? $this->buildingUnlockService->unlocksAtLevel((int) $id, (int) ($tech['level'] ?? 0) + 1)
+                        : [],
                     'max_level' => isset($tech['max_level']) ? (int) $tech['max_level'] : null,
                     'key' => $type === 'building' ? $tech['name'] : null,
                     'image_slug' => $type === 'building' ? self::buildingImageSlug($tech['name']) : null,

--- a/app/Services/Techtree/BuildingUnlockService.php
+++ b/app/Services/Techtree/BuildingUnlockService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Services\Techtree;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Reverse lookup of the existing required_building_id/required_building_level
+ * gate relationships (buildings/researches/ships/personell) — Owner-Playtest-
+ * Fund 2026-08-31: the "Voraussetzung" ("Benötigt X Lv2") display already
+ * walks this relationship in one direction; players also want the other
+ * direction ("Hangar Lv2 unlocks the Frachter ship") to plan ahead before
+ * investing AP. Purely derived from existing gate data, no new content.
+ */
+class BuildingUnlockService
+{
+    /**
+     * Entities that become available specifically at $buildingId reaching $level
+     * (not "at or below" — the level a player is about to invest AP into).
+     *
+     * @return list<string>
+     */
+    public function unlocksAtLevel(int $buildingId, int $level): array
+    {
+        $labels = [];
+
+        foreach (['buildings', 'ships', 'personell'] as $table) {
+            $names = DB::table($table)
+                ->where('is_active', 1)
+                ->where('required_building_id', $buildingId)
+                ->where('required_building_level', $level)
+                ->pluck('name');
+
+            foreach ($names as $name) {
+                $labels[] = __('techtree.'.$name);
+            }
+        }
+
+        // researches has a second, independent requirement slot
+        // (required_building2_id/required_building2_level) — either slot
+        // reaching $buildingId/$level counts as "unlocked by this level".
+        $researchNames = DB::table('researches')
+            ->where('is_active', 1)
+            ->where(function ($query) use ($buildingId, $level) {
+                $query->where(function ($q) use ($buildingId, $level) {
+                    $q->where('required_building_id', $buildingId)
+                        ->where('required_building_level', $level);
+                })->orWhere(function ($q) use ($buildingId, $level) {
+                    $q->where('required_building2_id', $buildingId)
+                        ->where('required_building2_level', $level);
+                });
+            })
+            ->pluck('name');
+
+        foreach ($researchNames as $name) {
+            $labels[] = __('techtree.'.$name);
+        }
+
+        return $labels;
+    }
+}

--- a/lang/de/techtree.php
+++ b/lang/de/techtree.php
@@ -113,6 +113,7 @@ return [
     'detail_status' => 'Status',
     'detail_level' => 'Level',
     'detail_required' => 'Voraussetzung',
+    'detail_unlocks_next_level' => 'Schaltet ab nächstem Level frei',
     'detail_close' => 'Schließen',
 
     // ── UI ───────────────────────────────────────────────────────────────────

--- a/public/css/colony.css
+++ b/public/css/colony.css
@@ -959,6 +959,12 @@ button.btn-sol:hover,
     color: #6b6b7a;
 }
 
+.tile-building-unlocks {
+    margin: 0 0 0.5rem;
+    font-size: 0.75rem;
+    color: #6b6b7a;
+}
+
 .tile-under-construction {
     margin: 0.5rem 0;
     padding: 0.3rem 0.6rem;

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -473,6 +473,16 @@
                                         </p>
                                     </template>
 
+                                    {{-- What the NEXT level unlocks (Owner-Playtest-Fund
+                                     2026-08-31, e.g. "Hangar Lv2 → Frachter") — derived from
+                                     existing gate data, see BuildingUnlockService. --}}
+                                    <template
+                                        x-if="buildingCanLevelUp(selectedBuilding) && selectedBuilding.unlocks_next_level && selectedBuilding.unlocks_next_level.length > 0">
+                                        <p class="tile-building-unlocks"
+                                            x-text="`{{ __("techtree.detail_unlocks_next_level") }}: ${selectedBuilding.unlocks_next_level.join(', ')}`">
+                                        </p>
+                                    </template>
+
                                     <template x-if="selectedBuilding.level === 0">
                                         <div class="tile-under-construction">
                                             {{ __("colony.under_construction") }}

--- a/resources/views/techtree/index.blade.php
+++ b/resources/views/techtree/index.blade.php
@@ -191,6 +191,18 @@
                                         <span x-text="selectedTech.required_desc"></span>
                                     </div>
                                 </template>
+                                {{-- Reverse of Voraussetzung: what the NEXT level unlocks
+                                 (Owner-Playtest-Fund 2026-08-31, e.g. "Hangar Lv2 →
+                                 Frachter") — derived from existing gate data, see
+                                 BuildingUnlockService. --}}
+                                <template
+                                    x-if="selectedTech.unlocks_next_level && selectedTech.unlocks_next_level.length > 0">
+                                    <div class="detail-row">
+                                        <span
+                                            class="detail-row-label">{{ __("techtree.detail_unlocks_next_level") }}</span>
+                                        <span x-text="selectedTech.unlocks_next_level.join(', ')"></span>
+                                    </div>
+                                </template>
                                 {{-- Colony link: opens build mode with this building pre-selected --}}
                                 <a :href="'/colony/view?build=' + selectedTech.id" class="detail-colony-link">
                                     {{ __("techtree.detail_colony_link") }} &rarr;

--- a/tests/Feature/Colony/ColonyViewTest.php
+++ b/tests/Feature/Colony/ColonyViewTest.php
@@ -124,6 +124,25 @@ class ColonyViewTest extends TestCase
         $this->assertNotEmpty($infirmary->description);
     }
 
+    // Regression (Owner-Playtest 2026-08-31, follow-up to the description
+    // fix): "Voraussetzung" was already shown, but never the reverse — what
+    // leveling THIS building up unlocks (e.g. "Hangar Lv1→2 unlocks
+    // Frachter"). Colony 1's hangar (building_id=44) is seeded at level 1.
+    public function test_hexview_buildings_include_unlocks_next_level(): void
+    {
+        $this->app->setLocale('de');
+
+        $response = $this->actingAs($this->makeUser(self::BART_USER_ID))
+            ->get(route('colony.view'));
+
+        $buildings = $response->viewData('buildings');
+        $hangar = $buildings->firstWhere('building_id', 44);
+
+        $this->assertNotNull($hangar);
+        $this->assertSame(1, (int) $hangar->level, 'Testdaten-Annahme: Hangar steht auf Level 1');
+        $this->assertContains(__('techtree.ship_freighter'), $hangar->unlocks_next_level);
+    }
+
     public function test_pending_run_redirects_to_lobby(): void
     {
         // A pending run is active but not yet started (started_at = null).

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -245,6 +245,25 @@ class TechtreeControllerTest extends TestCase
         $this->assertNotEmpty($sciencelab['description']);
     }
 
+    // Regression (Owner-Playtest 2026-08-31, follow-up): reverse of
+    // required_desc — what leveling up a building unlocks (e.g. "Hangar
+    // Lv1→2 unlocks Frachter"). Colony 1's hangar (id=44) is seeded at Lv1.
+    public function test_index_building_items_include_unlocks_next_level(): void
+    {
+        $this->app->setLocale('de');
+        $bart = User::find($this->userIdBart);
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        $hangar = null;
+        foreach ($pageData['phases'] as $phase) {
+            $hangar ??= collect($phase['items'])->first(fn ($t) => $t['type'] === 'building' && $t['key'] === 'building_hangar');
+        }
+
+        $this->assertNotNull($hangar, 'hangar building must be present in the phases');
+        $this->assertSame(1, $hangar['level'], 'Testdaten-Annahme: Hangar steht auf Level 1');
+        $this->assertContains(__('techtree.ship_freighter'), $hangar['unlocks_next_level']);
+    }
+
     public function test_knowledge_ap_for_levelup_matches_config_not_stale_db_value(): void
     {
         // Playtest regression (2026-07-14): researches.ap_for_levelup is a static

--- a/tests/Unit/Techtree/BuildingUnlockServiceTest.php
+++ b/tests/Unit/Techtree/BuildingUnlockServiceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Unit\Techtree;
+
+use App\Services\Techtree\BuildingUnlockService;
+use Database\Seeders\TestSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * BuildingUnlockService — Owner-Playtest-Fund 2026-08-31: sidebar showed
+ * requirements ("Benötigt X Lv2") but never the reverse — what a building
+ * level unlocks (e.g. "Hangar Lv2 unlocks the Frachter ship"). This is a
+ * pure reverse lookup of the SAME required_building_id/level relationships
+ * already used by the existing "Voraussetzung" display — no new content,
+ * purely derived from data that already exists (ships.required_building_id,
+ * researches.required_building_id/required_building2_id, etc.).
+ */
+class BuildingUnlockServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private BuildingUnlockService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->app->make(TestSeeder::class)->run();
+        $this->app->setLocale('de');
+        $this->service = $this->app->make(BuildingUnlockService::class);
+    }
+
+    public function test_hangar_level2_unlocks_the_freighter_ship(): void
+    {
+        // ships.required_building_id=44 (hangar), required_building_level=2 → ship_freighter.
+        $unlocks = $this->service->unlocksAtLevel(44, 2);
+
+        $this->assertContains(__('techtree.ship_freighter'), $unlocks);
+    }
+
+    public function test_hangar_level3_unlocks_the_corvette_ship(): void
+    {
+        $unlocks = $this->service->unlocksAtLevel(44, 3);
+
+        $this->assertContains(__('techtree.ship_corvette'), $unlocks);
+        $this->assertNotContains(__('techtree.ship_freighter'), $unlocks, 'freighter unlocks at level 2, not 3');
+    }
+
+    public function test_hangar_level2_also_unlocks_the_defense_knowledge_via_secondary_requirement(): void
+    {
+        // researches id=96 (knowledge_defense): required_building_id=31 (sciencelab) Lv3
+        // AND required_building2_id=44 (hangar) Lv2 — must be reachable via EITHER slot.
+        $unlocks = $this->service->unlocksAtLevel(44, 2);
+
+        $this->assertContains(__('techtree.knowledge_defense'), $unlocks);
+    }
+
+    public function test_level_with_nothing_gated_returns_empty(): void
+    {
+        $unlocks = $this->service->unlocksAtLevel(44, 1);
+
+        // Drone (ship_drone) unlocks at hangar Lv1 — pick a level that truly has nothing.
+        $unlocksAtImpossibleLevel = $this->service->unlocksAtLevel(44, 99);
+
+        $this->assertSame([], $unlocksAtImpossibleLevel);
+        $this->assertNotSame([], $unlocks, 'sanity: level 1 must not be empty (drone unlocks there)');
+    }
+
+    public function test_unrelated_building_returns_empty(): void
+    {
+        $unlocks = $this->service->unlocksAtLevel(25, 1); // CommandCenter Lv1 gates nothing new directly
+
+        $this->assertIsArray($unlocks);
+    }
+}


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund (Follow-up zur Effekt-Beschreibung, PR #296): die generische Beschreibung reicht nicht — der Spieler will wissen, was genau der Sprung von Hangar I auf Hangar II bringt, nicht nur was das Gebäude allgemein tut.

**Recherche ergab: für Gebäude ist das eine reine Datenabfrage, kein neuer Content.** `ships.required_building_id`/`required_building_level` (Drohne=Lv1, Frachter=Lv2, Korvette=Lv3), `researches.required_building_id`/`2` und `personell.required_building_id` kodieren bereits exakt, was bei welchem Gebäude-Level freigeschaltet wird — dieselbe Relation, die `computeRequiredDesc()` schon in die andere Richtung nutzt ("Voraussetzung").

Neue `BuildingUnlockService::unlocksAtLevel(buildingId, level): list<string>` — fragt alle 4 gate-relevanten Tabellen ab, verdrahtet in beiden Sidebars (Kolonie + Techtree) direkt neben der bestehenden Voraussetzung-Anzeige.

**Bewusst nicht Teil dieses Fixes:** Kenntnis-Level haben aktuell keine diskreten Freischaltungen in den Daten (nur kontinuierliche Effekt-Kurven, z.B. Baukunde senkt Bau-AP-Kosten um X% pro Level) — das wäre eine andere, kleinere Content-Aufgabe (Zahlen-Kurve pro Level in lesbaren Text übersetzen), separat zu entscheiden.

## Test-Plan

- [x] TDD: neuer `BuildingUnlockServiceTest` (5 Tests) + 2 Controller-Regressionstests, alle rot→grün verifiziert
- [x] `bin/phpunit` — 1090/1090 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Pint + Prettier sauber

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9