### PR TITLE
feat: Kenntnis-Effekt-Kurven als lesbaren Text in der Techtree-Sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-08-31
 
+- Feat: Techtree-Sidebar zeigt jetzt auch für Kenntnisse, was das nächste Level bringt (z.B. "-4% Bau-AP-Kosten" bei Baukunde) — analog zur Gebäude-Freischaltungsanzeige (PR #297), aber für kontinuierliche Effekt-Kurven statt diskreter Freischaltungen. Neue `KnowledgeEffectDescriptionService` übersetzt die bestehenden `*_per_lv`/`*_per_level`-Kurven (Kenntnis-Effekte-Redesign-Serie) in lesbaren Text, kein neuer Zahlen-Content — nur eine kleine, stabile Label/Einheit-Zuordnung pro Kenntnis (Owner-Playtest-Fund).
+
 - Feat: Gebäude-/Techtree-Sidebar zeigten "Voraussetzung", aber nie die Kehrseite — was das NÄCHSTE Level freischaltet (z.B. Hangar Lv1→2 schaltet den Frachter frei). Neue `BuildingUnlockService::unlocksAtLevel()` — reine Rückwärts-Abfrage der bestehenden `required_building_id`/`required_building_level`-Gate-Daten (Gebäude/Schiffe/Berater/Kenntnisse), kein neuer Content nötig. Nur Gebäude-Level (Kenntnis-Level haben aktuell keine diskreten Freischaltungen, nur kontinuierliche Effekt-Kurven) (Owner-Playtest-Fund).
 
 - Feat: Gebäude-/Kenntnis-Detail-Panels (Kolonie-Sidebar, Techtree-Sidebar) zeigten Kosten und Fortschritt, aber nie was gebaut/erforscht eigentlich bewirkt — Spieler konnte nicht vorausplanen. Bereits vorhandene Beschreibungstexte (`buildings.*_desc`, `techtree.desc_techs_*`) jetzt in beiden Panels verdrahtet (generischer Effekt-Text, noch keine Pro-Level-Freischaltungen — das wäre eine separate Content-Aufgabe) (Owner-Playtest-Fund).

--- a/app/Http/Controllers/Techtree/TechtreeController.php
+++ b/app/Http/Controllers/Techtree/TechtreeController.php
@@ -9,6 +9,7 @@ use App\Services\OnboardingHintService;
 use App\Services\Techtree\AbstractTechnologyService;
 use App\Services\Techtree\BuildingService;
 use App\Services\Techtree\BuildingUnlockService;
+use App\Services\Techtree\KnowledgeEffectDescriptionService;
 use App\Services\Techtree\ResearchService;
 use App\Services\Techtree\ShipService;
 use App\Services\Techtree\TechtreeColonyService;
@@ -33,6 +34,7 @@ class TechtreeController extends BaseController
         private readonly TechtreeColonyService $techtreeColonyService,
         private readonly OnboardingHintService $onboardingHintService,
         private readonly BuildingUnlockService $buildingUnlockService,
+        private readonly KnowledgeEffectDescriptionService $knowledgeEffectDescriptionService,
     ) {
         parent::__construct($tick);
     }
@@ -119,14 +121,20 @@ class TechtreeController extends BaseController
                     'description' => in_array($type, ['building', 'research'], true)
                         ? __('techtree.desc_techs_'.preg_replace('/^(building|knowledge)_/', '', $tech['name']))
                         : null,
-                    // Reverse of required_desc: what becomes available specifically at
-                    // the NEXT level of this building (Owner-Playtest-Fund 2026-08-31,
-                    // e.g. "Hangar Lv2 unlocks Frachter"). Buildings only — knowledge
-                    // levels never gate other entities in the current data (only
-                    // continuous effect curves, no discrete unlocks to derive).
-                    'unlocks_next_level' => $type === 'building'
-                        ? $this->buildingUnlockService->unlocksAtLevel((int) $id, (int) ($tech['level'] ?? 0) + 1)
-                        : [],
+                    // Reverse of required_desc: what becomes available/changes specifically
+                    // at the NEXT level (Owner-Playtest-Fund 2026-08-31, e.g. "Hangar Lv2
+                    // unlocks Frachter" for buildings, "-4% Bau-AP-Kosten" for knowledge —
+                    // buildings have discrete gate-unlocks (BuildingUnlockService), knowledge
+                    // has continuous effect curves (KnowledgeEffectDescriptionService,
+                    // follow-up 2026-08-31) — same UI slot either way.
+                    'unlocks_next_level' => match ($type) {
+                        'building' => $this->buildingUnlockService->unlocksAtLevel((int) $id, (int) ($tech['level'] ?? 0) + 1),
+                        'research' => $this->knowledgeEffectDescriptionService->effectsAtLevel(
+                            preg_replace('/^knowledge_/', '', $tech['name']),
+                            (int) ($tech['level'] ?? 0) + 1
+                        ),
+                        default => [],
+                    },
                     'max_level' => isset($tech['max_level']) ? (int) $tech['max_level'] : null,
                     'key' => $type === 'building' ? $tech['name'] : null,
                     'image_slug' => $type === 'building' ? self::buildingImageSlug($tech['name']) : null,

--- a/app/Services/Techtree/KnowledgeEffectDescriptionService.php
+++ b/app/Services/Techtree/KnowledgeEffectDescriptionService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Services\Techtree;
+
+/**
+ * Translates a knowledge's per-level effect CURVE value into a short readable
+ * line — Owner-Playtest-Fund 2026-08-31 (follow-up to BuildingUnlockService,
+ * PR #297): buildings show what the NEXT level unlocks via a pure data
+ * lookup; knowledge levels have no discrete unlock to look up the same way —
+ * their effect is a continuous curve (config/knowledge.php + config/game.php
+ * `*_per_lv`/`*_per_level` arrays, from the Kenntnis-Effekte-Redesign
+ * series). This is the mapping (curve → label/unit/direction) that content
+ * would otherwise have to spell out per level — the numbers themselves stay
+ * in config, only the small, stable mapping (7 knowledges, 1-3 effects
+ * each) lives here.
+ *
+ * A level whose curve entry is 0 (no change at that level, e.g. trade's
+ * bar_offer_boost_per_lv has zeros at Lv1/4/5) produces no line — matching
+ * BuildingUnlockService's "nothing to show if nothing changes" behaviour.
+ */
+class KnowledgeEffectDescriptionService
+{
+    private const DIRECTION_REDUCTION = 'reduction';
+
+    private const DIRECTION_INCREASE = 'increase';
+
+    /**
+     * @var array<string, list<array{config: string, label: string, unit: string, direction: string}>>
+     */
+    private const EFFECTS = [
+        'construction' => [
+            ['config' => 'knowledge.construction.ap_cost_reduction_per_lv', 'label' => 'Bau-AP-Kosten', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
+        ],
+        'cartography' => [
+            ['config' => 'knowledge.cartography.nav_ap_reduction_per_lv', 'label' => 'Navigations-AP-Kosten', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
+        ],
+        'geology' => [
+            ['config' => 'game.geology_harvester_bonus_per_level', 'label' => 'Harvester-Ertrag', 'unit' => 'Rg/Sol', 'direction' => self::DIRECTION_INCREASE],
+            ['config' => 'game.geology_instability_risk_reduction_per_lv', 'label' => 'Instabilitäts-Risiko', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
+        ],
+        'agronomy' => [
+            ['config' => 'game.agronomy_agrardom_bonus_per_level', 'label' => 'Agrardom-Ertrag', 'unit' => 'Or/Sol', 'direction' => self::DIRECTION_INCREASE],
+        ],
+        'health' => [
+            ['config' => 'game.health_plague_risk_reduction_per_lv', 'label' => 'Seuchenausbruch-Risiko', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
+        ],
+        'trade' => [
+            ['config' => 'knowledge.trade.ap_cost_reduction_per_lv', 'label' => 'Bau-AP-Kosten', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
+            ['config' => 'knowledge.trade.bar_offer_boost_per_lv', 'label' => 'Bar-Angebotsslot', 'unit' => '', 'direction' => self::DIRECTION_INCREASE],
+            ['config' => 'knowledge.trade.trade_price_bonus_per_lv', 'label' => 'Handelspreis-Bonus', 'unit' => '%', 'direction' => self::DIRECTION_INCREASE],
+        ],
+        'defense' => [
+            ['config' => 'game.defense_storm_risk_reduction_per_lv', 'label' => 'Sturm-Risiko', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
+        ],
+    ];
+
+    /** @return list<string> */
+    public function effectsAtLevel(string $knowledgeKey, int $level): array
+    {
+        if ($level < 1 || ! isset(self::EFFECTS[$knowledgeKey])) {
+            return [];
+        }
+
+        $lines = [];
+        foreach (self::EFFECTS[$knowledgeKey] as $effect) {
+            $curve = config($effect['config'], []);
+            $delta = (int) ($curve[$level] ?? 0);
+            if ($delta === 0) {
+                continue;
+            }
+
+            $lines[] = $this->formatLine($delta, $effect);
+        }
+
+        return $lines;
+    }
+
+    /** @param array{config: string, label: string, unit: string, direction: string} $effect */
+    private function formatLine(int $delta, array $effect): string
+    {
+        $sign = $effect['direction'] === self::DIRECTION_REDUCTION ? '-' : '+';
+        $unit = $effect['unit'];
+
+        if ($unit === '%') {
+            return "{$sign}{$delta}% {$effect['label']}";
+        }
+
+        if ($unit === '') {
+            // Singular/plural label chosen by the caller-side config entry
+            // (only trade's bar-slot effect uses this — always ±1 in practice).
+            return "{$sign}{$delta} {$effect['label']}";
+        }
+
+        return "{$sign}{$delta} {$unit} {$effect['label']}";
+    }
+}

--- a/resources/views/techtree/index.blade.php
+++ b/resources/views/techtree/index.blade.php
@@ -226,6 +226,17 @@
                                         <span x-text="selectedTech.required_desc"></span>
                                     </div>
                                 </template>
+                                {{-- What the NEXT level's effect curve delivers (Owner-Playtest-
+                                 Fund 2026-08-31, follow-up — e.g. "-4% Bau-AP-Kosten") — see
+                                 KnowledgeEffectDescriptionService. --}}
+                                <template
+                                    x-if="selectedTech.unlocks_next_level && selectedTech.unlocks_next_level.length > 0">
+                                    <div class="detail-row">
+                                        <span
+                                            class="detail-row-label">{{ __("techtree.detail_unlocks_next_level") }}</span>
+                                        <span x-text="selectedTech.unlocks_next_level.join(', ')"></span>
+                                    </div>
+                                </template>
                                 {{-- AP invest bar for knowledge --}}
                                 <template x-if="selectedTech.ap_for_levelup > 0 && selectedTech.status !== 'locked'">
                                     <div class="detail-ap-section">

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -264,6 +264,33 @@ class TechtreeControllerTest extends TestCase
         $this->assertContains(__('techtree.ship_freighter'), $hangar['unlocks_next_level']);
     }
 
+    // Regression (Owner-Playtest 2026-08-31, follow-up to
+    // test_index_building_items_include_unlocks_next_level): knowledge
+    // levels reuse the SAME unlocks_next_level UI slot, populated from the
+    // curve-based KnowledgeEffectDescriptionService instead of the discrete
+    // BuildingUnlockService (knowledge has no discrete gate-unlocks).
+    public function test_index_knowledge_items_include_curve_based_unlocks_next_level(): void
+    {
+        $this->app->setLocale('de');
+        $bart = User::find($this->userIdBart);
+
+        // construction (id=90) at level 2 → next level 3 → ap_cost_reduction_per_lv[3]=4.
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => $this->colonyIdBart, 'research_id' => 90],
+            ['level' => 2, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        $construction = null;
+        foreach ($pageData['phases'] as $phase) {
+            $construction ??= collect($phase['items'])->first(fn ($t) => $t['type'] === 'research' && $t['id'] === 90);
+        }
+
+        $this->assertNotNull($construction);
+        $this->assertContains('-4% Bau-AP-Kosten', $construction['unlocks_next_level']);
+    }
+
     public function test_knowledge_ap_for_levelup_matches_config_not_stale_db_value(): void
     {
         // Playtest regression (2026-07-14): researches.ap_for_levelup is a static

--- a/tests/Unit/Techtree/KnowledgeEffectDescriptionServiceTest.php
+++ b/tests/Unit/Techtree/KnowledgeEffectDescriptionServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Unit\Techtree;
+
+use App\Services\Techtree\KnowledgeEffectDescriptionService;
+use Tests\TestCase;
+
+/**
+ * KnowledgeEffectDescriptionService — Owner-Playtest-Fund 2026-08-31
+ * (follow-up to BuildingUnlockService): buildings show what the NEXT level
+ * unlocks via a pure data lookup (required_building_id/level). Knowledge
+ * levels have no such discrete unlock — their effect is a continuous curve
+ * (config/knowledge.php, config/game.php `*_per_lv`/`*_per_level` arrays,
+ * from the Kenntnis-Effekte-Redesign series). This translates the curve
+ * VALUE AT a given level into a short readable line, e.g. "construction Lv3"
+ * → "-4% Bau-AP-Kosten" (config/knowledge.php: ap_cost_reduction_per_lv[3]=4).
+ * Levels whose curve entry is 0 (no change at that level) produce no line.
+ */
+class KnowledgeEffectDescriptionServiceTest extends TestCase
+{
+    private KnowledgeEffectDescriptionService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = $this->app->make(KnowledgeEffectDescriptionService::class);
+    }
+
+    public function test_construction_level3_reduces_construction_ap_cost(): void
+    {
+        // config/knowledge.php: construction.ap_cost_reduction_per_lv[3] = 4
+        $lines = $this->service->effectsAtLevel('construction', 3);
+
+        $this->assertContains('-4% Bau-AP-Kosten', $lines);
+    }
+
+    public function test_geology_level1_has_two_distinct_effects(): void
+    {
+        // config/game.php: geology_harvester_bonus_per_level[1]=3,
+        // geology_instability_risk_reduction_per_lv[1]=3
+        $lines = $this->service->effectsAtLevel('geology', 1);
+
+        $this->assertContains('+3 Rg/Sol Harvester-Ertrag', $lines);
+        $this->assertContains('-3% Instabilitäts-Risiko', $lines);
+    }
+
+    public function test_trade_level4_has_three_distinct_effects(): void
+    {
+        // config/knowledge.php trade: ap_cost_reduction_per_lv[4]=3,
+        // bar_offer_boost_per_lv[4]=0 (must be OMITTED), trade_price_bonus_per_lv[4]=2
+        $lines = $this->service->effectsAtLevel('trade', 4);
+
+        $this->assertContains('-3% Bau-AP-Kosten', $lines);
+        $this->assertContains('+2% Handelspreis-Bonus', $lines);
+        $this->assertCount(2, $lines, 'bar_offer_boost_per_lv[4]=0 must not produce a line');
+    }
+
+    public function test_trade_level2_includes_the_bar_slot_effect(): void
+    {
+        // bar_offer_boost_per_lv[2]=1 — the one level where it's non-zero.
+        $lines = $this->service->effectsAtLevel('trade', 2);
+
+        $this->assertContains('+1 Bar-Angebotsslot', $lines);
+    }
+
+    public function test_defense_level_reduces_storm_risk(): void
+    {
+        $lines = $this->service->effectsAtLevel('defense', 2);
+
+        $this->assertContains('-5% Sturm-Risiko', $lines);
+    }
+
+    public function test_health_level_reduces_plague_risk(): void
+    {
+        $lines = $this->service->effectsAtLevel('health', 3);
+
+        $this->assertContains('-5% Seuchenausbruch-Risiko', $lines);
+    }
+
+    public function test_agronomy_level_increases_agrardom_yield(): void
+    {
+        $lines = $this->service->effectsAtLevel('agronomy', 2);
+
+        $this->assertContains('+2 Or/Sol Agrardom-Ertrag', $lines);
+    }
+
+    public function test_cartography_level_reduces_navigation_ap_cost(): void
+    {
+        $lines = $this->service->effectsAtLevel('cartography', 1);
+
+        $this->assertContains('-4% Navigations-AP-Kosten', $lines);
+    }
+
+    public function test_unknown_knowledge_key_returns_empty(): void
+    {
+        $this->assertSame([], $this->service->effectsAtLevel('does_not_exist', 1));
+    }
+
+    public function test_level_zero_returns_empty(): void
+    {
+        $this->assertSame([], $this->service->effectsAtLevel('construction', 0));
+    }
+}


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund (Follow-up zu PR #297, Gebäude-Freischaltungen): Kenntnis-Level haben keine diskreten Freischaltungen wie Gebäude, sondern kontinuierliche Effekt-Kurven (`config/knowledge.php` + `config/game.php`, `*_per_lv`/`*_per_level`-Arrays aus der Kenntnis-Effekte-Redesign-Serie). Bisher stand nur der Gebäude-Fall im UI.

Neue `KnowledgeEffectDescriptionService::effectsAtLevel(key, level): list<string>` — eine kleine, stabile Zuordnungstabelle (7 Kenntnisse, 1-3 Effekte je Kenntnis) aus Config-Pfad + Label + Einheit + Richtung, liest den Kurvenwert AN diesem Level (nicht kumulativ) und formatiert ihn lesbar, z.B. `-4% Bau-AP-Kosten` oder `+3 Rg/Sol Harvester-Ertrag`. Ein Level mit Kurvenwert 0 erzeugt keine Zeile — gleiches Verhalten wie `BuildingUnlockService`.

Verdrahtet ins bestehende `unlocks_next_level`-UI-Feld (dieselbe Techtree-Sidebar-Zeile "Schaltet ab nächstem Level frei" aus PR #297) — für `type=research` wird jetzt dieser Service statt `BuildingUnlockService` aufgerufen.

**Kein neuer Zahlen-Content** — nur eine kleine, stabile Label/Einheit-Zuordnung pro Kenntnis, alle Zahlen bleiben in Config.

## Test-Plan

- [x] TDD: neuer `KnowledgeEffectDescriptionServiceTest` (10 Tests, alle 7 Kenntnisse + Edge Cases), 1 neuer Controller-Regressionstest, rot→grün verifiziert
- [x] `bin/phpunit` — 1101/1101 grün
- [x] `bin/phpstan analyse --no-progress` — keine Fehler
- [x] Pint + Prettier sauber

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9