### PR TITLE
fix: Techtree-Sidebar poliert — Aufzählungspunkte, Ressourcen-Chips, korrekter AP-Hinweis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-09-01
+
+- Fix/Feat: Techtree-Sidebar-Politur (Owner-Playtest-Fund) — "Voraussetzung"/"Schaltet frei" zeigen jetzt Aufzählungspunkte statt einer zusammengequetschten Zeile (Überschrift "Voraussetzungen", redundantes "Benötigt" im Text entfernt), Kenntnis-Effekte mit echtem Ressourcenbezug (Harvester-/Agrardom-Ertrag) rendern als Ressourcen-Chip statt Fließtext, und der stale Hint "Kein Forschungs-AP verfügbar — Analytiker-Berater einstellen" (referenzierte den längst zusammengelegten AP-Pool) heißt jetzt schlicht "Keine AP mehr verfügbar".
+
 ## 2026-08-31
 
 - Feat: Techtree-Sidebar zeigt jetzt auch für Kenntnisse, was das nächste Level bringt (z.B. "-4% Bau-AP-Kosten" bei Baukunde) — analog zur Gebäude-Freischaltungsanzeige (PR #297), aber für kontinuierliche Effekt-Kurven statt diskreter Freischaltungen. Neue `KnowledgeEffectDescriptionService` übersetzt die bestehenden `*_per_lv`/`*_per_level`-Kurven (Kenntnis-Effekte-Redesign-Serie) in lesbaren Text, kein neuer Zahlen-Content — nur eine kleine, stabile Label/Einheit-Zuordnung pro Kenntnis (Owner-Playtest-Fund).

--- a/app/Http/Controllers/Techtree/TechtreeController.php
+++ b/app/Http/Controllers/Techtree/TechtreeController.php
@@ -113,6 +113,11 @@ class TechtreeController extends BaseController
                     'col' => (int) ($tech['column'] ?? 0),
                     'status' => $this->computeStatus($tech, $techtree),
                     'required_desc' => $this->computeRequiredDesc($tech, $techtree),
+                    // Same prerequisites as required_desc, as separate parts for a
+                    // bullet list — Owner-Playtest-Fund 2026-08-31: the detail panel's
+                    // "Voraussetzungen" heading already says what the line means, so
+                    // repeating "Benötigt " in the value read redundant/cluttered.
+                    'required_list' => $this->computeRequiredList($tech, $techtree),
                     // What this entity DOES, independent of prereqs — Owner-Playtest-Fund
                     // 2026-08-31: the sidebar showed cost/progress but never the effect,
                     // so the player couldn't plan ahead. Reuses the existing desc_techs_*
@@ -301,6 +306,41 @@ class TechtreeController extends BaseController
         }
 
         return "Benötigt {$desc}";
+    }
+
+    /**
+     * Same prerequisites as computeRequiredDesc(), split into separate parts
+     * for a bullet list (no "Benötigt " prefix — the caller's heading already
+     * says that). Returns [] when the tech has no building dependency.
+     *
+     * @return list<string>
+     */
+    private function computeRequiredList(array $tech, array $techtree): array
+    {
+        if (empty($tech['required_building_id'])) {
+            return [];
+        }
+
+        $reqId = (int) $tech['required_building_id'];
+        $reqLevel = (int) ($tech['required_building_level'] ?? 1);
+        $reqBuilding = $techtree['building'][$reqId] ?? null;
+
+        if (! $reqBuilding) {
+            return [];
+        }
+
+        $parts = [__('techtree.'.$reqBuilding['name'])." Lv{$reqLevel}"];
+
+        if (! empty($tech['required_building2_id'])) {
+            $req2Id = (int) $tech['required_building2_id'];
+            $req2Level = (int) ($tech['required_building2_level'] ?? 1);
+            $req2Building = $techtree['building'][$req2Id] ?? null;
+            if ($req2Building) {
+                $parts[] = __('techtree.'.$req2Building['name'])." Lv{$req2Level}";
+            }
+        }
+
+        return $parts;
     }
 
     /**

--- a/app/Services/Techtree/KnowledgeEffectDescriptionService.php
+++ b/app/Services/Techtree/KnowledgeEffectDescriptionService.php
@@ -35,11 +35,11 @@ class KnowledgeEffectDescriptionService
             ['config' => 'knowledge.cartography.nav_ap_reduction_per_lv', 'label' => 'Navigations-AP-Kosten', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
         ],
         'geology' => [
-            ['config' => 'game.geology_harvester_bonus_per_level', 'label' => 'Harvester-Ertrag', 'unit' => 'Rg/Sol', 'direction' => self::DIRECTION_INCREASE],
+            ['config' => 'game.geology_harvester_bonus_per_level', 'label' => 'Harvester-Ertrag', 'unit' => 'Rg/Sol', 'direction' => self::DIRECTION_INCREASE, 'resAbbr' => 'RG', 'resCls' => 'Rg'],
             ['config' => 'game.geology_instability_risk_reduction_per_lv', 'label' => 'Instabilitäts-Risiko', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
         ],
         'agronomy' => [
-            ['config' => 'game.agronomy_agrardom_bonus_per_level', 'label' => 'Agrardom-Ertrag', 'unit' => 'Or/Sol', 'direction' => self::DIRECTION_INCREASE],
+            ['config' => 'game.agronomy_agrardom_bonus_per_level', 'label' => 'Agrardom-Ertrag', 'unit' => 'Or/Sol', 'direction' => self::DIRECTION_INCREASE, 'resAbbr' => 'OR', 'resCls' => 'Or'],
         ],
         'health' => [
             ['config' => 'game.health_plague_risk_reduction_per_lv', 'label' => 'Seuchenausbruch-Risiko', 'unit' => '%', 'direction' => self::DIRECTION_REDUCTION],
@@ -54,7 +54,7 @@ class KnowledgeEffectDescriptionService
         ],
     ];
 
-    /** @return list<string> */
+    /** @return list<array{text: string, chip: null|array{abbr: string, value: string, cls: string}}> */
     public function effectsAtLevel(string $knowledgeKey, int $level): array
     {
         if ($level < 1 || ! isset(self::EFFECTS[$knowledgeKey])) {
@@ -75,22 +75,36 @@ class KnowledgeEffectDescriptionService
         return $lines;
     }
 
-    /** @param array{config: string, label: string, unit: string, direction: string} $effect */
-    private function formatLine(int $delta, array $effect): string
+    /**
+     * @param  array{config: string, label: string, unit: string, direction: string, resAbbr?: string, resCls?: string}  $effect
+     * @return array{text: string, chip: null|array{abbr: string, value: string, cls: string}}
+     */
+    private function formatLine(int $delta, array $effect): array
     {
         $sign = $effect['direction'] === self::DIRECTION_REDUCTION ? '-' : '+';
         $unit = $effect['unit'];
 
+        // Effects tied to an actual resource (Rg, Or) render as a resourcebar
+        // chip in the sidebar — the label alone is the text, the number/unit
+        // moves into the chip. Everything else (%, slot counts) has no
+        // matching resource, so it stays a single formatted text line.
+        if (isset($effect['resAbbr'], $effect['resCls'])) {
+            return [
+                'text' => $effect['label'],
+                'chip' => ['abbr' => $effect['resAbbr'], 'value' => "{$sign}{$delta}/Sol", 'cls' => $effect['resCls']],
+            ];
+        }
+
         if ($unit === '%') {
-            return "{$sign}{$delta}% {$effect['label']}";
+            return ['text' => "{$sign}{$delta}% {$effect['label']}", 'chip' => null];
         }
 
         if ($unit === '') {
             // Singular/plural label chosen by the caller-side config entry
             // (only trade's bar-slot effect uses this — always ±1 in practice).
-            return "{$sign}{$delta} {$effect['label']}";
+            return ['text' => "{$sign}{$delta} {$effect['label']}", 'chip' => null];
         }
 
-        return "{$sign}{$delta} {$unit} {$effect['label']}";
+        return ['text' => "{$sign}{$delta} {$unit} {$effect['label']}", 'chip' => null];
     }
 }

--- a/lang/de/techtree.php
+++ b/lang/de/techtree.php
@@ -112,7 +112,7 @@ return [
     'detail_type' => 'Typ',
     'detail_status' => 'Status',
     'detail_level' => 'Level',
-    'detail_required' => 'Voraussetzung',
+    'detail_required' => 'Voraussetzungen',
     'detail_unlocks_next_level' => 'Schaltet ab nächstem Level frei',
     'detail_close' => 'Schließen',
 
@@ -124,8 +124,8 @@ return [
     'costs and requirements' => 'Kosten und Voraussetzungen',
 
     // ── AP-Hinweise (wenn keine AP verfügbar) ─────────────────────────────────
-    'hint_no_research_ap' => 'Kein Forschungs-AP verfügbar — Analytiker-Berater einstellen.',
-    'hint_no_construction_ap' => 'Kein Bau-AP verfügbar — Baumeister-Berater einstellen.',
+    'hint_no_research_ap' => 'Keine AP mehr verfügbar.',
+    'hint_no_construction_ap' => 'Keine AP mehr verfügbar.',
 
     // ── Berater-Chip im Techtree ──────────────────────────────────────────────
     'advisor_hired' => 'Eingestellt',

--- a/public/css/techtree-view.css
+++ b/public/css/techtree-view.css
@@ -483,6 +483,18 @@
     color: #999;
 }
 
+.detail-list {
+    margin: 0;
+    padding-left: 1.1rem;
+    list-style: disc;
+}
+
+.detail-list li {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
 .detail-close {
     display: block;
     width: 100%;

--- a/resources/views/techtree/index.blade.php
+++ b/resources/views/techtree/index.blade.php
@@ -156,10 +156,15 @@
                                         <span x-text="selectedTech.hire_cost + ' Cr'"></span>
                                     </div>
                                 </template>
-                                <template x-if="selectedTech.required_desc">
+                                <template x-if="selectedTech.required_list && selectedTech.required_list.length > 0">
                                     <div class="detail-row">
                                         <span class="detail-row-label">{{ __("techtree.detail_required") }}</span>
-                                        <span x-text="selectedTech.required_desc"></span>
+                                        <ul class="detail-list">
+                                            <template x-for="(part, idx) in selectedTech.required_list"
+                                                :key="idx">
+                                                <li x-text="part"></li>
+                                            </template>
+                                        </ul>
                                     </div>
                                 </template>
                                 <a href="{{ route("advisors.index") }}" class="detail-advisor-link">
@@ -185,10 +190,15 @@
                                             x-text="selectedTech.instance_count + (selectedTech.max_level ? ' / ' + selectedTech.max_level : '')"></span>
                                     </div>
                                 </template>
-                                <template x-if="selectedTech.required_desc">
+                                <template x-if="selectedTech.required_list && selectedTech.required_list.length > 0">
                                     <div class="detail-row">
                                         <span class="detail-row-label">{{ __("techtree.detail_required") }}</span>
-                                        <span x-text="selectedTech.required_desc"></span>
+                                        <ul class="detail-list">
+                                            <template x-for="(part, idx) in selectedTech.required_list"
+                                                :key="idx">
+                                                <li x-text="part"></li>
+                                            </template>
+                                        </ul>
                                     </div>
                                 </template>
                                 {{-- Reverse of Voraussetzung: what the NEXT level unlocks
@@ -200,7 +210,12 @@
                                     <div class="detail-row">
                                         <span
                                             class="detail-row-label">{{ __("techtree.detail_unlocks_next_level") }}</span>
-                                        <span x-text="selectedTech.unlocks_next_level.join(', ')"></span>
+                                        <ul class="detail-list">
+                                            <template x-for="(name, idx) in selectedTech.unlocks_next_level"
+                                                :key="idx">
+                                                <li x-text="name"></li>
+                                            </template>
+                                        </ul>
                                     </div>
                                 </template>
                                 {{-- Colony link: opens build mode with this building pre-selected --}}
@@ -220,10 +235,15 @@
                                             x-text="selectedTech.level + (selectedTech.max_level ? ' / ' + selectedTech.max_level : '')"></span>
                                     </div>
                                 </template>
-                                <template x-if="selectedTech.required_desc">
+                                <template x-if="selectedTech.required_list && selectedTech.required_list.length > 0">
                                     <div class="detail-row">
                                         <span class="detail-row-label">{{ __("techtree.detail_required") }}</span>
-                                        <span x-text="selectedTech.required_desc"></span>
+                                        <ul class="detail-list">
+                                            <template x-for="(part, idx) in selectedTech.required_list"
+                                                :key="idx">
+                                                <li x-text="part"></li>
+                                            </template>
+                                        </ul>
                                     </div>
                                 </template>
                                 {{-- What the NEXT level's effect curve delivers (Owner-Playtest-
@@ -234,7 +254,20 @@
                                     <div class="detail-row">
                                         <span
                                             class="detail-row-label">{{ __("techtree.detail_unlocks_next_level") }}</span>
-                                        <span x-text="selectedTech.unlocks_next_level.join(', ')"></span>
+                                        <ul class="detail-list">
+                                            <template x-for="(line, idx) in selectedTech.unlocks_next_level"
+                                                :key="idx">
+                                                <li>
+                                                    <template x-if="line.chip">
+                                                        <span :class="'res-chip res-' + line.chip.cls">
+                                                            <span class="res-abbr" x-text="line.chip.abbr"></span>
+                                                            <span class="res-amount" x-text="line.chip.value"></span>
+                                                        </span>
+                                                    </template>
+                                                    <span x-text="line.text"></span>
+                                                </li>
+                                            </template>
+                                        </ul>
                                     </div>
                                 </template>
                                 {{-- AP invest bar for knowledge --}}
@@ -274,10 +307,15 @@
                                             x-text="selectedTech.level + (selectedTech.hangar_cap ? ' / ' + selectedTech.hangar_cap : '')"></span>
                                     </div>
                                 </template>
-                                <template x-if="selectedTech.required_desc">
+                                <template x-if="selectedTech.required_list && selectedTech.required_list.length > 0">
                                     <div class="detail-row">
                                         <span class="detail-row-label">{{ __("techtree.detail_required") }}</span>
-                                        <span x-text="selectedTech.required_desc"></span>
+                                        <ul class="detail-list">
+                                            <template x-for="(part, idx) in selectedTech.required_list"
+                                                :key="idx">
+                                                <li x-text="part"></li>
+                                            </template>
+                                        </ul>
                                     </div>
                                 </template>
                             </div>

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -288,7 +288,9 @@ class TechtreeControllerTest extends TestCase
         }
 
         $this->assertNotNull($construction);
-        $this->assertContains('-4% Bau-AP-Kosten', $construction['unlocks_next_level']);
+        $this->assertTrue(
+            collect($construction['unlocks_next_level'])->contains(fn ($l) => $l['text'] === '-4% Bau-AP-Kosten' && $l['chip'] === null)
+        );
     }
 
     public function test_knowledge_ap_for_levelup_matches_config_not_stale_db_value(): void
@@ -373,6 +375,30 @@ class TechtreeControllerTest extends TestCase
         $this->assertNotNull($cartography['required_desc'], 'knowledge_cartography must have a required_desc');
         $this->assertStringContainsString('+', $cartography['required_desc'],
             'Dual prerequisites must be joined by "+"');
+    }
+
+    // Owner-Playtest-Fund 2026-08-31 (follow-up): the detail panel now renders
+    // prerequisites as a bullet list instead of one "Benötigt X + Y" line, so
+    // the controller must expose the parts separately.
+    public function test_required_list_shows_dual_prerequisites_as_separate_parts(): void
+    {
+        $bart = User::find($this->userIdBart);
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        // knowledge_cartography (ID 91) has dual prereq: Analytik-Labor Lv1 + Hangar Lv1
+        $cartography = null;
+        foreach ($pageData['phases'] as $phase) {
+            $found = collect($phase['items'])->first(fn ($t) => $t['id'] === 91 && $t['type'] === 'research');
+            if ($found) {
+                $cartography = $found;
+                break;
+            }
+        }
+
+        $this->assertNotNull($cartography, 'knowledge_cartography (ID 91) must be in a phase');
+        $this->assertCount(2, $cartography['required_list']);
+        $this->assertStringNotContainsString('Benötigt', $cartography['required_list'][0],
+            'bullet parts must not repeat the "Benötigt" prefix already implied by the heading');
     }
 
     public function test_knowledge_cartography_is_in_phase3(): void

--- a/tests/Unit/Techtree/KnowledgeEffectDescriptionServiceTest.php
+++ b/tests/Unit/Techtree/KnowledgeEffectDescriptionServiceTest.php
@@ -15,6 +15,12 @@ use Tests\TestCase;
  * VALUE AT a given level into a short readable line, e.g. "construction Lv3"
  * → "-4% Bau-AP-Kosten" (config/knowledge.php: ap_cost_reduction_per_lv[3]=4).
  * Levels whose curve entry is 0 (no change at that level) produce no line.
+ *
+ * Each line is ['text' => string, 'chip' => null|array{abbr,value,cls}] —
+ * Owner-Playtest-Fund 2026-08-31 (2nd follow-up): effects tied to an actual
+ * resource (Rg, Or) render as a resourcebar-style chip in the sidebar, same
+ * visual language as elsewhere in the UI. Percentage/slot-count effects have
+ * no matching resource, so they stay plain text (chip => null).
  */
 class KnowledgeEffectDescriptionServiceTest extends TestCase
 {
@@ -26,12 +32,20 @@ class KnowledgeEffectDescriptionServiceTest extends TestCase
         $this->service = $this->app->make(KnowledgeEffectDescriptionService::class);
     }
 
+    private function assertHasTextLine(array $lines, string $text): void
+    {
+        $this->assertTrue(
+            collect($lines)->contains(fn ($l) => $l['text'] === $text && $l['chip'] === null),
+            "Expected a plain-text line '{$text}' with no chip"
+        );
+    }
+
     public function test_construction_level3_reduces_construction_ap_cost(): void
     {
         // config/knowledge.php: construction.ap_cost_reduction_per_lv[3] = 4
         $lines = $this->service->effectsAtLevel('construction', 3);
 
-        $this->assertContains('-4% Bau-AP-Kosten', $lines);
+        $this->assertHasTextLine($lines, '-4% Bau-AP-Kosten');
     }
 
     public function test_geology_level1_has_two_distinct_effects(): void
@@ -40,8 +54,11 @@ class KnowledgeEffectDescriptionServiceTest extends TestCase
         // geology_instability_risk_reduction_per_lv[1]=3
         $lines = $this->service->effectsAtLevel('geology', 1);
 
-        $this->assertContains('+3 Rg/Sol Harvester-Ertrag', $lines);
-        $this->assertContains('-3% Instabilitäts-Risiko', $lines);
+        $harvester = collect($lines)->first(fn ($l) => $l['text'] === 'Harvester-Ertrag');
+        $this->assertNotNull($harvester, 'Harvester-Ertrag line must be present');
+        $this->assertSame(['abbr' => 'RG', 'value' => '+3/Sol', 'cls' => 'Rg'], $harvester['chip']);
+
+        $this->assertHasTextLine($lines, '-3% Instabilitäts-Risiko');
     }
 
     public function test_trade_level4_has_three_distinct_effects(): void
@@ -50,8 +67,8 @@ class KnowledgeEffectDescriptionServiceTest extends TestCase
         // bar_offer_boost_per_lv[4]=0 (must be OMITTED), trade_price_bonus_per_lv[4]=2
         $lines = $this->service->effectsAtLevel('trade', 4);
 
-        $this->assertContains('-3% Bau-AP-Kosten', $lines);
-        $this->assertContains('+2% Handelspreis-Bonus', $lines);
+        $this->assertHasTextLine($lines, '-3% Bau-AP-Kosten');
+        $this->assertHasTextLine($lines, '+2% Handelspreis-Bonus');
         $this->assertCount(2, $lines, 'bar_offer_boost_per_lv[4]=0 must not produce a line');
     }
 
@@ -60,35 +77,37 @@ class KnowledgeEffectDescriptionServiceTest extends TestCase
         // bar_offer_boost_per_lv[2]=1 — the one level where it's non-zero.
         $lines = $this->service->effectsAtLevel('trade', 2);
 
-        $this->assertContains('+1 Bar-Angebotsslot', $lines);
+        $this->assertHasTextLine($lines, '+1 Bar-Angebotsslot');
     }
 
     public function test_defense_level_reduces_storm_risk(): void
     {
         $lines = $this->service->effectsAtLevel('defense', 2);
 
-        $this->assertContains('-5% Sturm-Risiko', $lines);
+        $this->assertHasTextLine($lines, '-5% Sturm-Risiko');
     }
 
     public function test_health_level_reduces_plague_risk(): void
     {
         $lines = $this->service->effectsAtLevel('health', 3);
 
-        $this->assertContains('-5% Seuchenausbruch-Risiko', $lines);
+        $this->assertHasTextLine($lines, '-5% Seuchenausbruch-Risiko');
     }
 
     public function test_agronomy_level_increases_agrardom_yield(): void
     {
         $lines = $this->service->effectsAtLevel('agronomy', 2);
 
-        $this->assertContains('+2 Or/Sol Agrardom-Ertrag', $lines);
+        $agrardom = collect($lines)->first(fn ($l) => $l['text'] === 'Agrardom-Ertrag');
+        $this->assertNotNull($agrardom, 'Agrardom-Ertrag line must be present');
+        $this->assertSame(['abbr' => 'OR', 'value' => '+2/Sol', 'cls' => 'Or'], $agrardom['chip']);
     }
 
     public function test_cartography_level_reduces_navigation_ap_cost(): void
     {
         $lines = $this->service->effectsAtLevel('cartography', 1);
 
-        $this->assertContains('-4% Navigations-AP-Kosten', $lines);
+        $this->assertHasTextLine($lines, '-4% Navigations-AP-Kosten');
     }
 
     public function test_unknown_knowledge_key_returns_empty(): void


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund 2026-09-01 (3. Iteration nach #296/#297/#298 zur Sidebar-Freischaltungsanzeige):

- **Voraussetzungen als Bullet-Liste**: Überschrift "Voraussetzung" → "Voraussetzungen", Werte als `<ul>` statt einer verquetschten Zeile. Redundantes "Benötigt "-Präfix im Wert entfernt (Heading sagt es bereits). Neues `required_list`-Feld im Controller (`required_desc` bleibt unverändert für die kompakte Lock-Badge-Anzeige in der Kartenliste).
- **Ressourcen-Chips für Kenntnis-Effekte**: Effekte mit echtem Ressourcenbezug (Harvester-Ertrag Rg/Sol, Agrardom-Ertrag Or/Sol) rendern jetzt als Ressourcen-Chip — gleiche `.res-chip`-Optik wie Resourcebar/Protokoll. Prozent-/Slot-Effekte ohne Ressourcenbezug (kein passender Chip) bleiben Text. `KnowledgeEffectDescriptionService::effectsAtLevel()` liefert dafür strukturierte `{text, chip}`-Zeilen statt reiner Strings; `unlocks_next_level` auch für Gebäude jetzt als Bullet-Liste.
- **Fix AP-Hinweis**: "Kein Forschungs-AP verfügbar — Analytiker-Berater einstellen." referenzierte den längst zusammengelegten AP-Pool (AP-Pool-Konsolidierung) und war fachlich falsch → "Keine AP mehr verfügbar."

## Test plan

- [x] TDD: neuer Controller-Test `test_required_list_shows_dual_prerequisites_as_separate_parts` (rot→grün via `git stash`)
- [x] TDD: `KnowledgeEffectDescriptionServiceTest` auf strukturierte `{text, chip}`-Zeilen umgestellt (rot→grün)
- [x] Voller Testlauf: 1102/1102 grün
- [x] phpstan clean, Pint/Prettier clean
- [x] CHANGELOG-Eintrag ergänzt

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9