### PR TITLE
fix: Techtree-Sidebar — grauer Kasten entfernt, linksbündig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-09-01
 
 - Fix/Feat: Techtree-Sidebar-Politur (Owner-Playtest-Fund) — "Voraussetzung"/"Schaltet frei" zeigen jetzt Aufzählungspunkte statt einer zusammengequetschten Zeile (Überschrift "Voraussetzungen", redundantes "Benötigt" im Text entfernt), Kenntnis-Effekte mit echtem Ressourcenbezug (Harvester-/Agrardom-Ertrag) rendern als Ressourcen-Chip statt Fließtext, und der stale Hint "Kein Forschungs-AP verfügbar — Analytiker-Berater einstellen" (referenzierte den längst zusammengelegten AP-Pool) heißt jetzt schlicht "Keine AP mehr verfügbar".
+- Fix: Techtree-Sidebar — grauer Hintergrundkasten bei Voraussetzungen/Freischaltungen entfernt, Bullet-Einzug auf 0 (linksbündig statt optisch eingerückt/zentriert wirkend) (Owner-Playtest-Fund, Follow-up).
 
 ## 2026-08-31
 

--- a/public/css/techtree-view.css
+++ b/public/css/techtree-view.css
@@ -459,7 +459,7 @@
 .detail-body {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.85rem;
     margin-bottom: 0;
     font-size: 0.82rem;
     flex: 1;
@@ -470,9 +470,6 @@
     flex-direction: column;
     gap: 0.15rem;
     color: #555;
-    padding: 0.5rem 0.6rem;
-    background: #f8f8f8;
-    border-radius: 4px;
 }
 
 .detail-row-label {
@@ -485,8 +482,8 @@
 
 .detail-list {
     margin: 0;
-    padding-left: 1.1rem;
-    list-style: disc;
+    padding-left: 0;
+    list-style: none;
 }
 
 .detail-list li {


### PR DESCRIPTION
## Zusammenfassung

Owner-Playtest-Fund 2026-09-01 (Follow-up zu #299) — CSS-Politur der Techtree-Sidebar:

- `.detail-row` Hintergrundfarbe + `border-radius` entfernt (kein grauer Kasten mehr um Voraussetzungen/Freischaltungen).
- `.detail-list` Bullet-Einzug (`list-style: disc` + `padding-left`) entfernt → Werte jetzt linksbündig statt eingerückt/optisch zentriert wirkend.
- `.detail-body` Zeilenabstand leicht erhöht (0.5rem → 0.85rem) als Ersatz für die visuelle Trennung, die vorher der Kasten geleistet hat.

Reine CSS-Änderung, kein Codepfad — kein neuer Test nötig (TDD-Ausnahme laut CLAUDE.md).

## Test plan

- [x] `bin/phpunit --filter Techtree` grün (93/93)
- [x] CHANGELOG-Eintrag ergänzt

https://claude.ai/code/session_01Fa5VdiMfDzXcYDnwE7B4S9