### PR TITLE
Fix Techtree-Sidebar: PicoCSS-Spezifität + Design-Politur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2026-09-02
 
+- Fix: PicoCSS-Spezifitätsbug behoben — alle `.detail-*`-Selektoren in `techtree-view.css` mit `.tech-panel` prefixed, da Pico's globale `aside li`/`aside ul`-Regeln das gemergte Redesign (PR #305) trotz korrekt geladenem CSS unsichtbar gemacht hatten.
+- Fix/Feat: Techtree-Sidebar Nachbesserungen (Owner-Playtest, mehrere Iterationen) — Kenntnisname-Titel-Overlap behoben (Panel als Full-Height-Overlay über Header statt fixer `top`-Offset), kompakte Level-Anzeige direkt unter dem Titel (dedupliziert mit Status-Chip), neues Feld `effects_current_level` (Backend, TDD) ergänzt "Effekte der aktuellen Stufe" neben "Effekte der nächsten Stufe", Listen-Einrückungen entfernt, Ressourcenchip statt Chip+durchgestrichenem Text, Detail-Werte final auf `0.78rem`/`font-weight: 400`/sekundäre Grau-Farbe (`#9a9aa4`) angeglichen — vorherige Iteration hatte nur Größe/Gewicht reduziert, nicht aber die Farbe, wodurch der Text trotzdem "prägnant" wirkte.
 - Design: Techtree-Sidebar-Detailpanel Komplettüberarbeitung im Apple-Stil (ui-specialist, finale Iteration) — Kenntnisname nicht mehr überdeckt (z-index + overflow fix), diskrete Labels (0.64rem, #9a9aa4, 0.08em tracking), prominente Werte (0.95rem, fw600), großzügige 1.25rem Gaps zwischen Info-Blöcken statt Trennlinien/Boxen, keine Einrückung (Listen flush-left), AP-Segmente 20px in sauberer Wrap-Grid, Button-Spacing vergrößert — reine CSS-Überarbeitung, kein Blade-Template-Change (Owner-Playtest-Fund, finale Iteration: "wie würde ein Designer von Apple das designen").
 
 ## 2026-09-01

--- a/app/Http/Controllers/Techtree/TechtreeController.php
+++ b/app/Http/Controllers/Techtree/TechtreeController.php
@@ -140,6 +140,17 @@ class TechtreeController extends BaseController
                         ),
                         default => [],
                     },
+                    // What the CURRENT level already delivers — same services, called at
+                    // the current level instead of level+1 (Owner-Playtest-Fund 2026-09-02:
+                    // sidebar showed only the next level's effect, never the active one).
+                    'effects_current_level' => match ($type) {
+                        'building' => $this->buildingUnlockService->unlocksAtLevel((int) $id, (int) ($tech['level'] ?? 0)),
+                        'research' => $this->knowledgeEffectDescriptionService->effectsAtLevel(
+                            preg_replace('/^knowledge_/', '', $tech['name']),
+                            (int) ($tech['level'] ?? 0)
+                        ),
+                        default => [],
+                    },
                     'max_level' => isset($tech['max_level']) ? (int) $tech['max_level'] : null,
                     'key' => $type === 'building' ? $tech['name'] : null,
                     'image_slug' => $type === 'building' ? self::buildingImageSlug($tech['name']) : null,

--- a/docs/frontend-conventions.md
+++ b/docs/frontend-conventions.md
@@ -113,3 +113,5 @@ Verbindliches Set — keine weiteren Schwellwerte einführen:
 |---|---|
 | Alpine.js + Vanilla `fetch()` für alle Interaktionen | jQuery verwenden (vollständig entfernt, Mai 2026) |
 | Container in `em`/`rem` | Fixe `px`-Grössen für Icons und Portraits |
+| Neue Panel-/Card-Klassen mit dem Wrapper-Container prefixen (z.B. `.tech-panel .detail-row`) | Bare Klassen wie `.detail-row` ohne Scope — PicoCSS hat globale `aside li`/`aside ul`-Regeln, die bei gleicher Spezifität gewinnen und neue Styles unsichtbar machen (Bug in PR #305/#306, Techtree-Sidebar) |
+| Sekundäre Detail-Zeilen (Werte neben Meta-Labels, Listeneinträge) klein + `font-weight: 500` halten, angelehnt an die Description-Textgröße (~0.8rem) | Body-Werte in Sidebars mit `font-weight: 600–700` + `~0.95rem` — wirkt in schmalen Panels zu groß/prägnant, nicht "modern/elegant/minimal" |

--- a/lang/de/techtree.php
+++ b/lang/de/techtree.php
@@ -114,6 +114,12 @@ return [
     'detail_level' => 'Level',
     'detail_required' => 'Voraussetzungen',
     'detail_unlocks_next_level' => 'Schaltet ab nächstem Level frei',
+    // Split of detail_unlocks_next_level into "current" vs "next" (Owner-
+    // Fund 2026-09-02, techtree sidebar only) — detail_unlocks_next_level
+    // above stays untouched, it's still used by the colony sidebar
+    // (hexview.blade.php).
+    'detail_effects_current_level' => 'Effekte der aktuellen Stufe',
+    'detail_effects_next_level' => 'Effekte der nächsten Stufe',
     'detail_close' => 'Schließen',
 
     // ── UI ───────────────────────────────────────────────────────────────────

--- a/public/css/techtree-view.css
+++ b/public/css/techtree-view.css
@@ -318,24 +318,30 @@
 }
 
 /* ── Tech detail panel (replaces dialog) ─────────────────── */
+/* Sits above .colony-header (z-index: 100) and spans the full viewport
+   height. The header's own height is dynamic (nav + resource bar +
+   encounter-notice-bar + hint-bar can all stack), so anchoring the panel's
+   `top` to a hardcoded pixel value drifted out of sync and clipped the
+   title under the header whenever an extra bar was showing. A full-height
+   overlay sidesteps that entirely instead of trying to track header height. */
 .tech-panel-backdrop {
     position: fixed;
     inset: 0;
     background: rgba(0, 0, 0, 0.2);
     backdrop-filter: blur(1px);
-    z-index: 40;
+    z-index: 150;
 }
 
 .tech-panel {
     position: fixed;
-    top: 84px; /* colony-header: 44px nav + ~38px resource bar + 2px border */
+    top: 0;
     right: 0;
     bottom: 0;
-    width: 280px;
+    width: 300px;
     background: #fff;
-    border-left: 1px solid #ddd;
+    border-left: 1px solid var(--color-border, #e8e8ec);
     box-shadow: -4px 0 24px rgba(0, 0, 0, 0.12);
-    z-index: 50;
+    z-index: 151;
     overflow-y: auto;
     transition: transform 0.2s ease;
     padding: 0;
@@ -370,12 +376,15 @@
     }
 }
 
-.detail-inner {
+.tech-panel .detail-inner {
     --detail-accent: #3b82f6;
     --detail-accent-bg: #eff4fe;
     --detail-accent-line: rgba(59, 130, 246, 0.3);
     border-top: 4px solid var(--detail-accent);
-    padding: 1.25rem 1.25rem 1.5rem;
+    /* Extra top padding: the panel now overlays the header (see .tech-panel
+       above), so the title needs its own breathing room instead of relying
+       on sitting just below the resource bar. */
+    padding: 1.75rem 1.25rem 1.5rem;
     display: flex;
     flex-direction: column;
     min-height: 100%;
@@ -384,42 +393,42 @@
     overflow: visible;
 }
 
-.detail-cat-building {
+.tech-panel .detail-cat-building {
     --detail-accent: #3b82f6;
     --detail-accent-bg: #eff4fe;
     --detail-accent-line: rgba(59, 130, 246, 0.3);
 }
-.detail-cat-research {
+.tech-panel .detail-cat-research {
     --detail-accent: #10b981;
     --detail-accent-bg: #ecf9f5;
     --detail-accent-line: rgba(16, 185, 129, 0.3);
 }
-.detail-cat-ship {
+.tech-panel .detail-cat-ship {
     --detail-accent: #f59e0b;
     --detail-accent-bg: #fef8ec;
     --detail-accent-line: rgba(245, 158, 11, 0.3);
 }
-.detail-cat-personell {
+.tech-panel .detail-cat-personell {
     --detail-accent: #8b5cf6;
     --detail-accent-bg: #f4f0fe;
     --detail-accent-line: rgba(139, 92, 246, 0.3);
 }
 
-.detail-head {
+.tech-panel .detail-head {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
     margin-bottom: 1rem;
 }
 
-.detail-badges {
+.tech-panel .detail-badges {
     display: flex;
     gap: 0.4rem;
     align-items: center;
     flex-wrap: wrap;
 }
 
-.detail-type-badge {
+.tech-panel .detail-type-badge {
     font-size: 0.62rem;
     font-weight: 700;
     text-transform: uppercase;
@@ -431,7 +440,7 @@
     border-radius: var(--radius-pill, 20px);
 }
 
-.detail-x {
+.tech-panel .detail-x {
     background: none;
     border: none;
     font-size: 1.3rem;
@@ -447,28 +456,40 @@
         background 0.12s;
 }
 
-.detail-x:hover {
+.tech-panel .detail-x:hover {
     color: var(--color-text-primary, #1a1a1e);
     background: rgba(0, 0, 0, 0.05);
 }
 
 /* Full-bleed building image in techtree detail-inner (padding: 1.25rem) */
-.detail-inner .building-detail-img-wrap {
+.tech-panel .detail-inner .building-detail-img-wrap {
     width: calc(100% + 2.5rem);
     margin: 0 -1.25rem 1rem;
     overflow: hidden;
 }
 
-.detail-inner .building-detail-img {
+.tech-panel .detail-inner .building-detail-img {
     width: 100%;
     height: auto;
     display: block;
     object-fit: cover;
 }
 
-.detail-title {
-    margin: 0 0 1.5rem;
-    font-size: 1.15rem;
+/* Effect-description paragraph reads as supplementary copy, not body text —
+   sized to match .detail-ap-hint's existing "secondary helper text" weight
+   in this panel rather than colony.css's generic 0.8rem default, which read
+   too large next to the 0.62–0.64rem meta labels around it. */
+.tech-panel .building-detail-description {
+    font-size: 0.75rem;
+    line-height: 1.45;
+    color: var(--color-text-secondary, #9a9aa4);
+    opacity: 1;
+    margin: 0 0 1rem;
+}
+
+.tech-panel .detail-title {
+    margin: 0 0 1rem;
+    font-size: 1.1rem;
     font-weight: 700;
     color: var(--color-text-primary, #1a1a1e);
     line-height: 1.3;
@@ -477,29 +498,60 @@
     z-index: 2;
 }
 
-.detail-body {
+/* Compact level indicator directly under the title (Owner-Fund 2026-09-02) —
+   pulled up into the title's own bottom margin via a negative top margin so
+   it reads as a subheader of the name, not a body row. Deliberately small:
+   this is a secondary detail, not the headline of the panel. */
+.tech-panel .detail-subhead {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    margin: -0.7rem 0 1rem;
+    position: relative;
+    z-index: 2;
+}
+
+.tech-panel .detail-subhead-label {
+    font-size: 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-secondary, #9a9aa4);
+}
+
+.tech-panel .detail-subhead-value {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--color-text-primary, #1a1a1e);
+}
+
+.tech-panel .detail-body {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: 1rem;
     margin-bottom: 0;
     flex: 1;
     position: relative;
     z-index: 1;
 }
 
-.detail-row {
+.tech-panel .detail-row {
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.3rem;
     color: var(--color-text-primary, #333);
     padding: 0;
 }
 
-.detail-row + .detail-row {
+/* Single spacing rhythm: rows within the same per-type wrapper use this
+   margin, top-level siblings (e.g. the AP-invest block) use .detail-body's
+   flex gap above — both set to the same 1rem so the panel doesn't mix two
+   different vertical rhythms. */
+.tech-panel .detail-row + .detail-row {
     margin-top: 1.25rem;
 }
 
-.detail-row-label {
+.tech-panel .detail-row-label {
     font-size: 0.64rem;
     font-weight: 700;
     text-transform: uppercase;
@@ -507,37 +559,51 @@
     color: var(--color-text-secondary, #9a9aa4);
 }
 
-.detail-row > span:not(.detail-row-label),
-.detail-row > ul {
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--color-text-primary, #1a1a1e);
+/* Values should read exactly as unobtrusive as .building-detail-description
+   above (Owner-Fund 2026-09-02, round 3: size+weight alone weren't enough —
+   the near-black text-primary color was still the dominant reason these
+   rows looked bold/prominent). Match secondary color + regular weight. */
+.tech-panel .detail-row > span:not(.detail-row-label),
+.tech-panel .detail-row > ul {
+    font-size: 0.78rem;
+    font-weight: 400;
+    color: var(--color-text-secondary, #9a9aa4);
 }
 
-.detail-list {
+.tech-panel .detail-list {
     margin: 0;
     padding: 0;
+    padding-left: 0;
     list-style: none;
+    list-style-position: outside;
     display: flex;
     flex-direction: column;
     gap: 0.4rem;
 }
 
-.detail-list li {
+/* Explicit reset — Pico's base `ul`/`li` rules otherwise leave a
+   marker-position gutter even with list-style: none on the parent alone
+   (Owner-Fund 2026-09-02: Voraussetzungen/Effekte list items read as
+   indented relative to the row label above them). */
+.tech-panel .detail-list li {
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
     line-height: 1.4;
-    font-weight: 600;
-    color: var(--color-text-primary, #1a1a1e);
-    font-size: 0.95rem;
+    font-weight: 400;
+    color: var(--color-text-secondary, #9a9aa4);
+    font-size: 0.78rem;
+    margin: 0;
+    padding: 0;
+    padding-left: 0;
+    list-style: none;
 }
 
-.detail-close {
+.tech-panel .detail-close {
     display: block;
     width: 100%;
     padding: 0.75rem;
-    margin-top: 2rem;
+    margin-top: 1.5rem;
     border: 1px solid var(--color-border-strong, #d0d0dc);
     background: transparent;
     color: var(--color-text-primary, #2c2c2c);
@@ -553,23 +619,23 @@
         border-color 0.12s;
 }
 
-.detail-close:hover {
+.tech-panel .detail-close:hover {
     background: var(--color-text-primary, #2c2c2c);
     border-color: var(--color-text-primary, #2c2c2c);
     color: #fff;
 }
 
 /* Advisor-specific detail panel */
-.detail-advisor-hired {
+.tech-panel .detail-advisor-hired {
     color: var(--color-success, #16a34a);
     font-weight: 600;
 }
 
-.detail-cta-link {
+.tech-panel .detail-cta-link {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
-    margin-top: 1.25rem;
+    margin-top: 1rem;
     padding: 0.6rem 1rem;
     background: var(--detail-accent-bg);
     border: 1px solid var(--detail-accent-line);
@@ -583,7 +649,7 @@
         border-color 0.12s;
 }
 
-.detail-cta-link:hover {
+.tech-panel .detail-cta-link:hover {
     background: var(--detail-accent);
     border-color: var(--detail-accent);
     color: #fff;
@@ -591,12 +657,12 @@
 }
 
 /* ── Sidebar AP invest bar ──────────────────────────────────────────────── */
-.detail-ap-section {
+.tech-panel .detail-ap-section {
     margin-top: 0;
     padding: 0;
 }
 
-.detail-row--ap {
+.tech-panel .detail-row--ap {
     flex-direction: row;
     align-items: baseline;
     justify-content: space-between;
@@ -604,7 +670,7 @@
     gap: 0.75rem;
 }
 
-.detail-row--ap .detail-row-label {
+.tech-panel .detail-row--ap .detail-row-label {
     font-size: 0.64rem;
     font-weight: 700;
     text-transform: uppercase;
@@ -612,14 +678,14 @@
     color: var(--color-text-secondary, #9a9aa4);
 }
 
-.detail-row--ap > span:not(.detail-row-label) {
+.tech-panel .detail-row--ap > span:not(.detail-row-label) {
     font-variant-numeric: tabular-nums;
-    font-weight: 700;
-    font-size: 0.95rem;
-    color: var(--color-text-primary, #1a1a1e);
+    font-weight: 400;
+    font-size: 0.78rem;
+    color: var(--color-text-secondary, #9a9aa4);
 }
 
-.detail-ap-bar {
+.tech-panel .detail-ap-bar {
     display: flex;
     flex-wrap: wrap;
     gap: 5px;
@@ -654,7 +720,7 @@
     cursor: not-allowed;
 }
 
-.detail-ap-hint {
+.tech-panel .detail-ap-hint {
     font-size: 0.75rem;
     color: var(--color-text-secondary, #9a9aa4);
     margin: 0.6rem 0 0;
@@ -662,13 +728,13 @@
 }
 
 @media (max-width: 599px) {
-    .detail-inner {
+    .tech-panel .detail-inner {
         padding: 1.5rem 1.25rem 1.75rem;
     }
 
     /* Grabber handle for the mobile bottom sheet — signals "swipeable panel"
        without needing extra markup or JS. */
-    .detail-inner::before {
+    .tech-panel .detail-inner::before {
         content: "";
         position: absolute;
         top: 0.55rem;

--- a/resources/views/techtree/index.blade.php
+++ b/resources/views/techtree/index.blade.php
@@ -115,7 +115,12 @@
                     <div class="detail-head">
                         <div class="detail-badges">
                             <span class="detail-type-badge" x-text="typeLabel(selectedTech.type)"></span>
+                            {{-- Hidden when the compact .detail-subhead level indicator below
+                             the title already shows the same value (building/research at
+                             level > 0) — avoids showing "Lv 1" twice. --}}
                             <span class="tech-status-chip" :class="'chip-' + selectedTech.status"
+                                x-show="!((selectedTech.type === 'building' && !selectedTech.is_instanced && selectedTech.level > 0) ||
+                                    (selectedTech.type === 'research' && selectedTech.level > 0))"
                                 x-text="statusLabel(selectedTech)"></span>
                         </div>
                         <button class="detail-x" @click="closeDetail()"
@@ -124,6 +129,20 @@
 
                     {{-- Title --}}
                     <h3 class="detail-title" x-text="selectedTech.name"></h3>
+
+                    {{-- Compact level indicator directly under the title (Owner-Fund
+                     2026-09-02: LEVEL sat buried further down in the body as an
+                     oversized label+value row — moved up here and shrunk to a
+                     subheader-sized detail, right where it belongs next to the name). --}}
+                    <template
+                        x-if="(selectedTech.type === 'building' && !selectedTech.is_instanced && selectedTech.level > 0) ||
+                            (selectedTech.type === 'research' && selectedTech.level > 0)">
+                        <div class="detail-subhead">
+                            <span class="detail-subhead-label">{{ __("techtree.detail_level") }}</span>
+                            <span class="detail-subhead-value"
+                                x-text="selectedTech.level + (selectedTech.max_level ? ' / ' + selectedTech.max_level : '')"></span>
+                        </div>
+                    </template>
 
                     {{-- Building image (only for building-type items with a resolved image_slug).
                      show_header:false because the <h3 detail-title> above already renders the name. --}}
@@ -177,13 +196,9 @@
                         {{-- BUILDING --}}
                         <template x-if="selectedTech.type === 'building'">
                             <div>
-                                <template x-if="!selectedTech.is_instanced && selectedTech.level > 0">
-                                    <div class="detail-row">
-                                        <span class="detail-row-label">{{ __("techtree.detail_level") }}</span>
-                                        <span
-                                            x-text="selectedTech.level + (selectedTech.max_level ? ' / ' + selectedTech.max_level : '')"></span>
-                                    </div>
-                                </template>
+                                {{-- Level moved to .detail-subhead right under the title,
+                                 see above — kept only the instanced-count row here since
+                                 that's a different metric (built count vs. level). --}}
                                 <template x-if="selectedTech.is_instanced && selectedTech.instance_count > 0">
                                     <div class="detail-row">
                                         <span class="detail-row-label">{{ __("techtree.detail_instances") }}</span>
@@ -202,6 +217,24 @@
                                         </ul>
                                     </div>
                                 </template>
+                                {{-- What the CURRENT level already delivers (Owner-Fund
+                                 2026-09-02: sidebar only ever showed the next level's
+                                 effect, never the active one) — see
+                                 BuildingUnlockService::unlocksAtLevel() called at the
+                                 current level instead of level+1. --}}
+                                <template
+                                    x-if="selectedTech.effects_current_level && selectedTech.effects_current_level.length > 0">
+                                    <div class="detail-row">
+                                        <span
+                                            class="detail-row-label">{{ __("techtree.detail_effects_current_level") }}</span>
+                                        <ul class="detail-list">
+                                            <template x-for="(name, idx) in selectedTech.effects_current_level"
+                                                :key="idx">
+                                                <li x-text="name"></li>
+                                            </template>
+                                        </ul>
+                                    </div>
+                                </template>
                                 {{-- Reverse of Voraussetzung: what the NEXT level unlocks
                                  (Owner-Playtest-Fund 2026-08-31, e.g. "Hangar Lv2 →
                                  Frachter") — derived from existing gate data, see
@@ -210,7 +243,7 @@
                                     x-if="selectedTech.unlocks_next_level && selectedTech.unlocks_next_level.length > 0">
                                     <div class="detail-row">
                                         <span
-                                            class="detail-row-label">{{ __("techtree.detail_unlocks_next_level") }}</span>
+                                            class="detail-row-label">{{ __("techtree.detail_effects_next_level") }}</span>
                                         <ul class="detail-list">
                                             <template x-for="(name, idx) in selectedTech.unlocks_next_level"
                                                 :key="idx">
@@ -229,13 +262,8 @@
                         {{-- RESEARCH / KNOWLEDGE --}}
                         <template x-if="selectedTech.type === 'research'">
                             <div>
-                                <template x-if="selectedTech.level > 0">
-                                    <div class="detail-row">
-                                        <span class="detail-row-label">{{ __("techtree.detail_level") }}</span>
-                                        <span
-                                            x-text="selectedTech.level + (selectedTech.max_level ? ' / ' + selectedTech.max_level : '')"></span>
-                                    </div>
-                                </template>
+                                {{-- Level moved to .detail-subhead right under the title,
+                                 see above. --}}
                                 <template x-if="selectedTech.required_list && selectedTech.required_list.length > 0">
                                     <div class="detail-row">
                                         <span class="detail-row-label">{{ __("techtree.detail_required") }}</span>
@@ -247,6 +275,34 @@
                                         </ul>
                                     </div>
                                 </template>
+                                {{-- What the CURRENT level's effect curve already delivers
+                                 (Owner-Fund 2026-09-02: sidebar only ever showed the next
+                                 level's effect, never the active one) — see
+                                 KnowledgeEffectDescriptionService, called at the current
+                                 level instead of level+1. --}}
+                                <template
+                                    x-if="selectedTech.effects_current_level && selectedTech.effects_current_level.length > 0">
+                                    <div class="detail-row">
+                                        <span
+                                            class="detail-row-label">{{ __("techtree.detail_effects_current_level") }}</span>
+                                        <ul class="detail-list">
+                                            <template x-for="(line, idx) in selectedTech.effects_current_level"
+                                                :key="idx">
+                                                <li>
+                                                    <template x-if="line.chip">
+                                                        <span :class="'res-chip res-' + line.chip.cls">
+                                                            <span class="res-abbr" x-text="line.chip.abbr"></span>
+                                                            <span class="res-amount" x-text="line.chip.value"></span>
+                                                        </span>
+                                                    </template>
+                                                    <template x-if="!line.chip">
+                                                        <span x-text="line.text"></span>
+                                                    </template>
+                                                </li>
+                                            </template>
+                                        </ul>
+                                    </div>
+                                </template>
                                 {{-- What the NEXT level's effect curve delivers (Owner-Playtest-
                                  Fund 2026-08-31, follow-up — e.g. "-4% Bau-AP-Kosten") — see
                                  KnowledgeEffectDescriptionService. --}}
@@ -254,7 +310,7 @@
                                     x-if="selectedTech.unlocks_next_level && selectedTech.unlocks_next_level.length > 0">
                                     <div class="detail-row">
                                         <span
-                                            class="detail-row-label">{{ __("techtree.detail_unlocks_next_level") }}</span>
+                                            class="detail-row-label">{{ __("techtree.detail_effects_next_level") }}</span>
                                         <ul class="detail-list">
                                             <template x-for="(line, idx) in selectedTech.unlocks_next_level"
                                                 :key="idx">
@@ -265,7 +321,9 @@
                                                             <span class="res-amount" x-text="line.chip.value"></span>
                                                         </span>
                                                     </template>
-                                                    <span x-text="line.text"></span>
+                                                    <template x-if="!line.chip">
+                                                        <span x-text="line.text"></span>
+                                                    </template>
                                                 </li>
                                             </template>
                                         </ul>

--- a/tests/Feature/Techtree/TechtreeControllerTest.php
+++ b/tests/Feature/Techtree/TechtreeControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Techtree;
 
 use App\Models\User;
+use App\Services\Techtree\BuildingUnlockService;
 use Database\Seeders\TestSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -291,6 +292,50 @@ class TechtreeControllerTest extends TestCase
         $this->assertTrue(
             collect($construction['unlocks_next_level'])->contains(fn ($l) => $l['text'] === '-4% Bau-AP-Kosten' && $l['chip'] === null)
         );
+    }
+
+    // Owner-Playtest-Fund 2026-09-02: the sidebar only showed what the NEXT
+    // level unlocks, never what the CURRENT level already does — same
+    // service, called at the current level instead of level+1.
+    public function test_index_building_items_include_effects_current_level(): void
+    {
+        $this->app->setLocale('de');
+        $bart = User::find($this->userIdBart);
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        $hangar = null;
+        foreach ($pageData['phases'] as $phase) {
+            $hangar ??= collect($phase['items'])->first(fn ($t) => $t['type'] === 'building' && $t['key'] === 'building_hangar');
+        }
+
+        $this->assertNotNull($hangar, 'hangar building must be present in the phases');
+        $this->assertSame(1, $hangar['level'], 'Testdaten-Annahme: Hangar steht auf Level 1');
+        $this->assertSame(
+            $this->app->make(BuildingUnlockService::class)->unlocksAtLevel(44, 1),
+            $hangar['effects_current_level']
+        );
+    }
+
+    public function test_index_knowledge_items_include_effects_current_level(): void
+    {
+        $this->app->setLocale('de');
+        $bart = User::find($this->userIdBart);
+
+        // construction (id=90) at level 1 -> next level 2 (=4%) differs from current level 1 (=2%).
+        DB::table('colony_researches')->updateOrInsert(
+            ['colony_id' => $this->colonyIdBart, 'research_id' => 90],
+            ['level' => 1, 'ap_spend' => 0, 'status_points' => 20]
+        );
+
+        $pageData = $this->actingAs($bart)->get(route('techtree.index'))->viewData('pageData');
+
+        $construction = null;
+        foreach ($pageData['phases'] as $phase) {
+            $construction ??= collect($phase['items'])->first(fn ($t) => $t['type'] === 'research' && $t['id'] === 90);
+        }
+
+        $this->assertNotNull($construction);
+        $this->assertNotSame($construction['unlocks_next_level'], $construction['effects_current_level']);
     }
 
     public function test_knowledge_ap_for_levelup_matches_config_not_stale_db_value(): void


### PR DESCRIPTION
## Summary
- PicoCSS-Spezifitätsbug behoben: alle `.detail-*`-Selektoren in `techtree-view.css` mit `.tech-panel` prefixed — Pico's globale `aside li`/`aside ul`-Regeln hatten das gemergte Apple-Style-Redesign (PR #305) trotz korrekt geladenem CSS unsichtbar gemacht.
- Titel-Overlap-Fix: Panel als Full-Height-Overlay statt fixem `top`-Offset (der mit variabler Header-Höhe driftete).
- Kompakte Level-Anzeige direkt unter dem Titel, Status-Chip-Dopplung entfernt.
- Neues Feld `effects_current_level` (Backend, TDD-Test zuerst rot→grün) für "Effekte der aktuellen Stufe" neben "Effekte der nächsten Stufe".
- Listen-Einrückungen entfernt, Ressourcenchip statt Chip+Strikethrough-Text.
- Detail-Werte final auf Größe/Gewicht/Farbe der grauen Description angeglichen (0.78rem, weight 400, `#9a9aa4`) — vorherige Iteration hatte nur Größe/Gewicht reduziert, Farbe blieb dunkel.
- `docs/frontend-conventions.md` um zwei Do/Don't-Einträge ergänzt (PicoCSS-Spezifität, Sidebar-Typografie).

## Test plan
- [x] `bin/phpunit tests/Feature/Techtree/TechtreeControllerTest.php` — 27/27 grün
- [x] `npx prettier --check` auf geänderte Blade/CSS-Dateien
- [x] Live im Browser geprüft (mehrere Owner-Iterationen)

https://claude.ai/code/session_01WxxGZ4rwE1eRBRhwUNiJiT