### PR TITLE
Regolith-Depletion: Warnhinweis + Ausweich-Tile-Markierung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: proaktiver Onboarding-Hinweis, wenn das Regolith-Vorkommen des aktiven Harvester-Tiles unter `game.harvester.low_regolith_warning_pct` (30%) fällt (`OnboardingHintService::checkHintHarvesterLowRegolith()`, GDD §4c BALANCE CONCERN, Owner-Playtest-Fund 2026-09-04). Gemeinsame Query mit der Hex-Grid-Anzeige in `ColonyTileService::activeHarvesterRegolithTiles()` extrahiert, damit Hint und Kartenanzeige nie auseinanderlaufen.
 - Backend: `ColonyController::hexview()` liefert neu `regolithFallbackTiles` (erkundete, nicht erschöpfte Regolith-Ausweich-Tiles außer dem aktiven Harvester-Tile) für eine kommende Kartenmarkierung (UI-Folge-Task).
+- UI: Kolonie-Hex-Karte markiert jedes Tile aus `regolithFallbackTiles` zusätzlich zum blauen Ressourcen-Punkt mit einem violetten Pfeil-Badge (`isRegolithFallbackTile()` in `colony-hexgrid.js`) inkl. Tooltip "Ausweichziel für Harvester-Verlegung" — schließt den zweiten Teil der GDD §4c-BALANCE-CONCERN-Empfehlung ab.
 
 ## 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-09-06
+
+- Feature: proaktiver Onboarding-Hinweis, wenn das Regolith-Vorkommen des aktiven Harvester-Tiles unter `game.harvester.low_regolith_warning_pct` (30%) fällt (`OnboardingHintService::checkHintHarvesterLowRegolith()`, GDD §4c BALANCE CONCERN, Owner-Playtest-Fund 2026-09-04). Gemeinsame Query mit der Hex-Grid-Anzeige in `ColonyTileService::activeHarvesterRegolithTiles()` extrahiert, damit Hint und Kartenanzeige nie auseinanderlaufen.
+- Backend: `ColonyController::hexview()` liefert neu `regolithFallbackTiles` (erkundete, nicht erschöpfte Regolith-Ausweich-Tiles außer dem aktiven Harvester-Tile) für eine kommende Kartenmarkierung (UI-Folge-Task).
+
 ## 2026-09-05
 
 - Fix: Owner-Korrektur zur Gebäude-Zustandsanzeige (nach 585fc5e) — Hex-Tile-Ring und Farbcodierung an Sidebar-Titel/Zustand-Chip waren zu viel des Guten, komplett entfernt. Einziger verbleibender Zustands-Hinweis ist jetzt die Textfarbe des Gebäude-Labels direkt auf dem Hex-Tile (z.B. "CA 1"), gelb/rot bei denselben Schwellen wie zuvor.

--- a/app/Http/Controllers/Colony/ColonyController.php
+++ b/app/Http/Controllers/Colony/ColonyController.php
@@ -123,28 +123,37 @@ class ColonyController extends BaseController
         // Same activity gate GameTick::generateHarvesterYield() uses to decide whether
         // a Harvester instance produces this Sol (Owner-Playtest-Fund 2026-09-04: the
         // depleting resource_amount was invisible to the player, a shrinking yield
-        // looked like a bug instead of the intended depletion mechanic).
-        $activeHarvesterTileKeys = DB::table('colony_buildings')
-            ->where('colony_id', $colony->id)
-            ->where('building_id', BuildingId::Harvester->value)
-            ->where('level', '>', 0)
-            ->whereNotNull('tile_x')
-            ->whereNotNull('tile_y')
-            ->where(fn ($q) => $q->whereNull('pending_until_tick')->orWhere('pending_until_tick', '<', $globalTick))
-            ->get(['tile_x', 'tile_y'])
-            ->map(fn ($row) => $row->tile_x.','.$row->tile_y)
-            ->flip();
+        // looked like a bug instead of the intended depletion mechanic). Shared with
+        // OnboardingHintService — see ColonyTileService::activeHarvesterRegolithTiles().
+        $activeRegolithTiles = $this->tileService->activeHarvesterRegolithTiles($colony->id, $globalTick)
+            ->keyBy(fn ($tile) => $tile->q.','.$tile->r);
 
-        $regolithMaxCfg = config('game.harvester.resource_max', []);
-        $tiles = $tiles->map(function ($tile) use ($activeHarvesterTileKeys, $regolithMaxCfg) {
-            $configMax = (int) ($regolithMaxCfg[$tile['tile_type']] ?? 0);
-            if ($configMax > 0 && isset($activeHarvesterTileKeys[$tile['q'].','.$tile['r']])) {
-                $tile['regolith_remaining'] = min((int) ($tile['resource_amount'] ?? $configMax), $configMax);
-                $tile['regolith_max'] = $configMax;
+        $tiles = $tiles->map(function ($tile) use ($activeRegolithTiles) {
+            $active = $activeRegolithTiles->get($tile['q'].','.$tile['r']);
+            if ($active !== null) {
+                $tile['regolith_remaining'] = $active->resource_amount;
+                $tile['regolith_max'] = $active->resource_max;
             }
 
             return $tile;
         });
+
+        // Ausweich-Tiles (GDD §4c BALANCE CONCERN, Owner-Playtest-Fund 2026-09-04):
+        // explored, not-yet-depleted regolith tiles other than the currently active
+        // Harvester tile(s) — the pre-scouted Ring-3 relocation targets the map should
+        // highlight once the active tile runs low. Pure data for the map UI (see
+        // OnboardingHintService::checkHintHarvesterLowRegolith() for the accompanying
+        // hint bar warning).
+        $activeRegolithKeys = $activeRegolithTiles->keys();
+        $regolithFallbackTiles = DB::table('colony_tiles')
+            ->where('colony_id', $colony->id)
+            ->where('is_explored', 1)
+            ->where('resource_max', '>', 0)
+            ->where('resource_amount', '>', 0)
+            ->get(['q', 'r'])
+            ->reject(fn ($tile) => $activeRegolithKeys->contains($tile->q.','.$tile->r))
+            ->map(fn ($tile) => ['q' => (int) $tile->q, 'r' => (int) $tile->r])
+            ->values();
 
         // Name lookup for computeRequiredList() — buildings only ever carry a
         // single required_building_id (no required_building2_id, unlike researches).
@@ -209,7 +218,7 @@ class ColonyController extends BaseController
 
         $phaseProgress = $this->colonyService->getPhaseProgress($colony);
 
-        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'colonyAp', 'activeHint', 'supplyCapFull', 'trust', 'regolith', 'werkstoffe', 'freeSupply', 'currentSol', 'solLimit', 'merchantVisit', 'merchantItems', 'phaseProgress'));
+        return view('colony.hexview', compact('colony', 'tiles', 'ccLevel', 'buildings', 'colonyAp', 'activeHint', 'supplyCapFull', 'trust', 'regolith', 'werkstoffe', 'freeSupply', 'currentSol', 'solLimit', 'merchantVisit', 'merchantItems', 'phaseProgress', 'regolithFallbackTiles'));
     }
 
     // ── Tile actions ──────────────────────────────────────────────────────────

--- a/app/Services/ColonyTileService.php
+++ b/app/Services/ColonyTileService.php
@@ -382,6 +382,51 @@ class ColonyTileService
         return $rows;
     }
 
+    /**
+     * Tiles currently occupied by an active Harvester instance (level > 0, placed,
+     * not mid-relocation) that carry a regolith resource_max — i.e. the tiles the
+     * hex-grid regolith badge and the low-regolith onboarding hint both read.
+     * Single source of truth for "which tile is the active Harvester on, and how
+     * much regolith does it have left" — kept here so ColonyController::hexview()
+     * (tile display) and OnboardingHintService (warning hint) can never disagree
+     * on the underlying numbers (see Owner-Playtest-Fund 2026-09-04, GDD §4c).
+     *
+     * @return Collection<int, \stdClass> each with q, r, tile_type, resource_amount, resource_max
+     */
+    public function activeHarvesterRegolithTiles(int $colonyId, int $globalTick): Collection
+    {
+        $activeHarvesterTileKeys = DB::table('colony_buildings')
+            ->where('colony_id', $colonyId)
+            ->where('building_id', BuildingId::Harvester->value)
+            ->where('level', '>', 0)
+            ->whereNotNull('tile_x')
+            ->whereNotNull('tile_y')
+            ->where(fn ($q) => $q->whereNull('pending_until_tick')->orWhere('pending_until_tick', '<', $globalTick))
+            ->get(['tile_x', 'tile_y'])
+            ->map(fn ($row) => $row->tile_x.','.$row->tile_y)
+            ->flip();
+
+        if ($activeHarvesterTileKeys->isEmpty()) {
+            return collect();
+        }
+
+        $regolithMaxCfg = config('game.harvester.resource_max', []);
+
+        return DB::table('colony_tiles')
+            ->where('colony_id', $colonyId)
+            ->get(['q', 'r', 'tile_type', 'resource_amount'])
+            ->filter(fn ($tile) => $activeHarvesterTileKeys->has($tile->q.','.$tile->r))
+            ->map(function ($tile) use ($regolithMaxCfg) {
+                $configMax = (int) ($regolithMaxCfg[$tile->tile_type] ?? 0);
+                $tile->resource_max = $configMax;
+                $tile->resource_amount = min((int) ($tile->resource_amount ?? $configMax), $configMax);
+
+                return $tile;
+            })
+            ->filter(fn ($tile) => $tile->resource_max > 0)
+            ->values();
+    }
+
     private function ringCoords(int $ring): array
     {
         if ($ring === 0) {

--- a/app/Services/OnboardingHintService.php
+++ b/app/Services/OnboardingHintService.php
@@ -19,6 +19,8 @@ class OnboardingHintService
         private readonly AdvisorService $advisorService,
         private readonly ResourcesService $resourcesService,
         private readonly OnboardingTriggerService $onboardingTriggerService,
+        private readonly ColonyTileService $colonyTileService,
+        private readonly TickService $tickService,
     ) {}
 
     /**
@@ -256,6 +258,13 @@ class OnboardingHintService
                 'text_key' => 'colony.onboarding_hint_encounter',
                 'target_url' => '/colony/view',
             ],
+            [
+                'rank' => 19,
+                'key' => 'hint_harvester_low_regolith',
+                'active' => $this->checkHintHarvesterLowRegolith($colonyId),
+                'text_key' => 'colony.onboarding_hint_harvester_low_regolith',
+                'target_url' => '/colony/view',
+            ],
         ];
     }
 
@@ -463,6 +472,30 @@ class OnboardingHintService
             ->where('r', $harvester->tile_y)
             ->where('is_colony_zone', 1)
             ->exists();
+    }
+
+    /**
+     * Harvester low-regolith warning (rank 19 — appended after hint_encounter rather
+     * than renumbered into hint_2's neighbourhood, to keep the many existing rank
+     * assertions in OnboardingHintServiceTest stable; thematically it belongs here,
+     * next to hint_2's "move the Harvester" guidance). Owner-Playtest-Fund
+     * 2026-09-04 (GDD §4c BALANCE CONCERN): declining yield from tile depletion
+     * read as a bug because nothing told the player their active tile was running
+     * low, or that a pre-scouted Ring-3 fallback (ColonyTileService::
+     * randomizeOuterRingRows()) was already available to relocate to.
+     *
+     * Reuses ColonyTileService::activeHarvesterRegolithTiles() — the exact same
+     * query ColonyController::hexview() uses for the tile's regolith_remaining/
+     * regolith_max display — so the hint and the hex-grid badge can never disagree
+     * on whether a tile counts as "low".
+     */
+    private function checkHintHarvesterLowRegolith(int $colonyId): bool
+    {
+        $threshold = (float) config('game.harvester.low_regolith_warning_pct', 0.30);
+        $globalTick = $this->tickService->getTickCount();
+
+        return $this->colonyTileService->activeHarvesterRegolithTiles($colonyId, $globalTick)
+            ->contains(fn ($tile) => ($tile->resource_amount / $tile->resource_max) < $threshold);
     }
 
     /**

--- a/config/game.php
+++ b/config/game.php
@@ -126,6 +126,13 @@ return [
         // against buildings.max_status_points at placement time. Full-health placement
         // (Weg A / Orin) does not use this value.
         'salvage_arrival_sp_pct' => 0.25,
+
+        // Onboarding warning threshold (Owner-Playtest-Fund 2026-09-04, GDD §4c
+        // BALANCE CONCERN): resource_amount / resource_max ratio below which
+        // OnboardingHintService::checkHintHarvesterLowRegolith() surfaces the
+        // "relocate soon" hint. Placeholder calibration like other balance
+        // values in this file — revisit after playtest.
+        'low_regolith_warning_pct' => 0.30,
     ],
 
     // Orin (`corporate_rep`, config('characters').corporate_contact) — Weg A for the

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -171,6 +171,7 @@ return [
     'harvester_move_mode_hint' => 'Erkundetes Regolith-Tile außerhalb der Koloniezone anklicken — zeigt Vorschaupfeil mit AP-Kosten. Gedrückt halten zum Verlegen.',
     'harvester_move_no_targets' => 'Kein freies erkundetes Regolith-Tile verfügbar — erst neue Tiles erkunden (AP).',
     'harvester_move_invalid_target' => 'Kein gültiges Ziel — der Harvester braucht ein freies, erkundetes Regolith-Tile (hellblau markiert).',
+    'regolith_fallback_tile_hint' => 'Erkundetes Regolith-Vorkommen — Ausweichziel für Harvester-Verlegung.',
     'network_error' => 'Netzwerkfehler — bitte erneut versuchen.',
     'error_harvester_in_transit' => 'Der Harvester ist noch unterwegs — Verlegen erst nach Ankunft möglich.',
     'harvester_in_transit' => 'Unterwegs — Ankunft nächsten Sol.',

--- a/lang/de/colony.php
+++ b/lang/de/colony.php
@@ -97,6 +97,7 @@ return [
     'onboarding_hint_repair' => 'Ein Gebäude zeigt deutlichen Verschleiß — reparieren, bevor der Verfall teurer wird. Gebäude antippen, dann „Reparieren" wählen (1 AP + 2 Regolith pro Punkt).',
     'onboarding_hint_repair_urgent' => 'Warnung: ein Gebäude steht kurz vor dem Stufenverlust. Jetzt reparieren — bevor der nächste Sol die Entscheidung abnimmt.',
     'onboarding_hint_2' => 'Der Harvester dreht Leerrunden — er steht noch in der Koloniezone. Auf ein erkundetes Regolith-Tile außerhalb verlegen, damit er wirklich fördert.',
+    'onboarding_hint_harvester_low_regolith' => 'Das Regolith-Vorkommen des Harvesters wird knapp — ein Ausweich-Vorkommen ist bereits erkundet, jetzt verlegen.',
     'onboarding_hint_3' => 'Agrardom und zweites Gebäude stehen — jetzt die Kommandozentrale auf Level 2 ausbauen. Das erweitert die Koloniezone und schaltet den zweiten Beraterslot frei.',
     'onboarding_hint_advisor_slot2' => 'Berater-Slot 2 ist offen und das dafür nötige Gebäude steht — im Berater-Screen den passenden Berater einstellen.',
     'onboarding_hint_advisor_slot2_analytik' => 'Das Analytik-Labor wurde fertiggestellt — jetzt kannst du einen Analytiker anheuern!',

--- a/public/js/colony-hexgrid.js
+++ b/public/js/colony-hexgrid.js
@@ -118,6 +118,9 @@ function colonyHexView(config) {
         criticalThresholdPct: config.criticalThresholdPct ?? 0.33,
         relocateApPerHex: config.relocateApPerHex ?? 2,
         phaseProgress: config.phaseProgress ?? null,
+        // Explored, non-depleted regolith tiles other than the active harvester
+        // tile — flagged on the grid as relocation alternatives (GDD §4c).
+        regolithFallbackTiles: config.regolithFallbackTiles ?? [],
         selectedTile: null,
         buildMode: false,
         pendingBuilding: null,
@@ -190,6 +193,8 @@ function colonyHexView(config) {
                 conditionTone: (building) => this.conditionTone(building),
                 relocateApPerHex: this.relocateApPerHex,
                 panState: this._panState,
+                regolithFallbackTiles: this.regolithFallbackTiles,
+                regolithFallbackTileHint: this.i18n.regolithFallbackTileHint ?? '',
             });
         },
 
@@ -810,6 +815,14 @@ function isHarvesterTargetTile(tile, buildingsByTile) {
     return tile.is_explored && tile.tile_type.startsWith('regolith_') && !buildingsByTile?.has(`${tile.q},${tile.r}`);
 }
 
+// Explored, non-depleted regolith tile flagged server-side as a harvester
+// relocation alternative (ColonyTileService::activeHarvesterRegolithTiles()),
+// excluding the currently-worked tile. Small list, linear scan is fine.
+function isRegolithFallbackTile(tile, regolithFallbackTiles) {
+    if (!regolithFallbackTiles || regolithFallbackTiles.length === 0) return false;
+    return regolithFallbackTiles.some((t) => t.q === tile.q && t.r === tile.r);
+}
+
 // Rounds fractional cube coordinates to the nearest valid hex (Red Blob Games
 // "cube_round") — needed because linear interpolation between two hex centers
 // rarely lands exactly on a third hex's center.
@@ -1358,6 +1371,23 @@ function createHexTile(cx, cy, size, tile, building, opts, buildingsByTile) {
     if (tile.is_explored && tile.resource_max > 0) {
         const dot = svgCircle(cx + size * 0.38, cy - size * 0.38, 4, '#2196f3', '#fff');
         g.appendChild(dot);
+    }
+
+    // Harvester-relocation fallback badge (bottom-right, purple arrow). Deliberately
+    // distinct from the blue resource dot above — shape (arrow glyph, not a plain
+    // dot), color (purple — unused elsewhere on the grid), and position (bottom vs.
+    // top corner) so "has a resource" and "is a viable relocation target" never
+    // read as the same signal (GDD §4c BALANCE CONCERN follow-up).
+    if (isRegolithFallbackTile(tile, opts.regolithFallbackTiles)) {
+        const bx = cx + size * 0.38;
+        const by = cy + size * 0.38;
+        const badge = svgCircle(bx, by, 5, '#7c65cc', '#fff');
+        badge.setAttribute('pointer-events', 'auto'); // keep hoverable for the native tooltip
+        const title = document.createElementNS('http://www.w3.org/2000/svg', 'title');
+        title.textContent = opts.regolithFallbackTileHint ?? '';
+        badge.appendChild(title);
+        g.appendChild(badge);
+        g.appendChild(svgText(bx, by, '→', 7, '#fff', 700));
     }
 
     // Building badge (center-bottom, skip CC — already labeled)

--- a/resources/views/colony/hexview.blade.php
+++ b/resources/views/colony/hexview.blade.php
@@ -49,6 +49,7 @@
             criticalThresholdPct: {{ (float) config("game.encounter.critical_threshold_pct", 0.33) }},
             relocateApPerHex: {{ (int) config("game.harvester.relocate_ap_per_hex", 2) }},
             phaseProgress: @json($phaseProgress),
+            regolithFallbackTiles: @json($regolithFallbackTiles ?? []),
             routes: {
                 explore: '{{ route("colony.tile.explore") }}',
                 deepScan: '{{ route("colony.tile.deep-scan") }}',
@@ -76,6 +77,7 @@
                 harvesterMoveModeHint: @json(__("colony.harvester_move_mode_hint")),
                 harvesterMoveNoTargets: @json(__("colony.harvester_move_no_targets")),
                 harvesterMoveInvalidTarget: @json(__("colony.harvester_move_invalid_target")),
+                regolithFallbackTileHint: @json(__("colony.regolith_fallback_tile_hint")),
                 networkError: @json(__("colony.network_error")),
             },
         };

--- a/tests/Feature/Colony/ColonyViewTest.php
+++ b/tests/Feature/Colony/ColonyViewTest.php
@@ -200,6 +200,65 @@ class ColonyViewTest extends TestCase
         $this->assertSame(300, $tile['regolith_max']);
     }
 
+    // Teil 2 (Owner-Playtest-Fund 2026-09-04, GDD §4c BALANCE CONCERN): the map
+    // needs data about pre-scouted regolith relocation targets so the ui-specialist
+    // follow-up task can highlight them once the active Harvester tile runs low.
+    public function test_hexview_exposes_regolith_fallback_tiles_excluding_active_harvester_tile(): void
+    {
+        // Currently-used Harvester tile — must NOT appear in the fallback list.
+        DB::table('colony_tiles')->insert([
+            'colony_id' => self::COLONY_ID_FOR_REGOLITH,
+            'q' => 5, 'r' => 5, 'ring' => 3,
+            'tile_type' => 'regolith_normal',
+            'is_colony_zone' => 0, 'is_explored' => 1, 'is_deep_scanned' => 0,
+            'resource_amount' => 111, 'resource_max' => 300,
+        ]);
+        DB::table('colony_buildings')
+            ->where('colony_id', self::COLONY_ID_FOR_REGOLITH)
+            ->where('building_id', 27)
+            ->update(['tile_x' => 5, 'tile_y' => 5]);
+
+        // Explored, not-yet-depleted fallback tile — must appear.
+        DB::table('colony_tiles')->insert([
+            'colony_id' => self::COLONY_ID_FOR_REGOLITH,
+            'q' => 7, 'r' => 2, 'ring' => 3,
+            'tile_type' => 'regolith_poor',
+            'is_colony_zone' => 0, 'is_explored' => 1, 'is_deep_scanned' => 0,
+            'resource_amount' => 160, 'resource_max' => 160,
+        ]);
+
+        // Fully-depleted regolith tile — must NOT appear (nothing left to relocate to).
+        DB::table('colony_tiles')->insert([
+            'colony_id' => self::COLONY_ID_FOR_REGOLITH,
+            'q' => 8, 'r' => 2, 'ring' => 3,
+            'tile_type' => 'regolith_poor',
+            'is_colony_zone' => 0, 'is_explored' => 1, 'is_deep_scanned' => 0,
+            'resource_amount' => 0, 'resource_max' => 160,
+        ]);
+
+        // Unexplored regolith tile — must NOT appear (player hasn't scouted it).
+        DB::table('colony_tiles')->insert([
+            'colony_id' => self::COLONY_ID_FOR_REGOLITH,
+            'q' => 9, 'r' => 2, 'ring' => 3,
+            'tile_type' => 'regolith_rich',
+            'is_colony_zone' => 0, 'is_explored' => 0, 'is_deep_scanned' => 0,
+            'resource_amount' => 500, 'resource_max' => 500,
+        ]);
+
+        $response = $this->actingAs($this->makeUser(self::BART_USER_ID))
+            ->get(route('colony.view'));
+
+        $response->assertOk();
+        $fallbackTiles = $response->viewData('regolithFallbackTiles')
+            ->map(fn ($t) => [$t['q'], $t['r']])
+            ->all();
+
+        $this->assertContains([7, 2], $fallbackTiles);
+        $this->assertNotContains([5, 5], $fallbackTiles);
+        $this->assertNotContains([8, 2], $fallbackTiles);
+        $this->assertNotContains([9, 2], $fallbackTiles);
+    }
+
     public function test_pending_run_redirects_to_lobby(): void
     {
         // A pending run is active but not yet started (started_at = null).

--- a/tests/Feature/Onboarding/OnboardingHintServiceTest.php
+++ b/tests/Feature/Onboarding/OnboardingHintServiceTest.php
@@ -1386,6 +1386,77 @@ class OnboardingHintServiceTest extends TestCase
         $this->assertSame('colony.onboarding_hint_encounter', $hint['text_key']);
     }
 
+    // ── Harvester low-regolith warning (Owner-Playtest-Fund 2026-09-04, GDD §4c) ──
+
+    /**
+     * Rank 19 (lowest — appended after hint_encounter rather than renumbering
+     * hint_2's neighbourhood, so the many hardcoded rank assertions above stay
+     * stable): an active Harvester's tile has dropped below the configured
+     * low-regolith warning threshold. Mirrors ColonyController::hexview()'s
+     * regolith_remaining/regolith_max computation exactly (both read
+     * ColonyTileService::activeHarvesterRegolithTiles()) so the hint and the
+     * hex-grid tile display can never disagree on the underlying numbers.
+     */
+    public function test_harvester_low_regolith_hint_fires_below_threshold(): void
+    {
+        $this->moveHarvesterOutside();
+        DB::table('colony_tiles')
+            ->where('colony_id', $this->colonyId)->where('q', 3)->where('r', 0)
+            ->update(['resource_amount' => 50, 'resource_max' => 300]); // 16.7% — below default 30%
+
+        foreach ([
+            'hint_1', 'hint_repair_urgent', 'hint_2', 'hint_3', 'hint_advisor_slot2',
+            'hint_agrardome', 'hint_repair', 'hint_invest_site', 'hint_build_priority',
+            'hint_6', 'hint_analytik', 'hint_hangar_path', 'hint_explore', 'hint_4',
+            'hint_5', 'hint_spend_remaining_ap', 'hint_end_sol', 'hint_encounter',
+        ] as $key) {
+            $this->service->dismissHint($this->userId, $key);
+        }
+
+        $hint = $this->service->getActiveHint($this->colonyId, $this->userId);
+
+        $this->assertNotNull($hint);
+        $this->assertSame('hint_harvester_low_regolith', $hint['key']);
+        $this->assertSame(19, $hint['rank']);
+        $this->assertSame('colony.onboarding_hint_harvester_low_regolith', $hint['text_key']);
+        $this->assertSame('/colony/view', $hint['target_url']);
+    }
+
+    public function test_harvester_low_regolith_hint_silent_above_threshold(): void
+    {
+        $this->moveHarvesterOutside();
+        DB::table('colony_tiles')
+            ->where('colony_id', $this->colonyId)->where('q', 3)->where('r', 0)
+            ->update(['resource_amount' => 240, 'resource_max' => 300]); // 80% — above threshold
+
+        foreach ([
+            'hint_1', 'hint_repair_urgent', 'hint_2', 'hint_3', 'hint_advisor_slot2',
+            'hint_agrardome', 'hint_repair', 'hint_invest_site', 'hint_build_priority',
+            'hint_6', 'hint_analytik', 'hint_hangar_path', 'hint_explore', 'hint_4',
+            'hint_5', 'hint_spend_remaining_ap', 'hint_end_sol', 'hint_encounter',
+        ] as $key) {
+            $this->service->dismissHint($this->userId, $key);
+        }
+
+        $this->assertNull($this->service->getActiveHint($this->colonyId, $this->userId));
+    }
+
+    public function test_harvester_low_regolith_hint_silent_without_active_harvester(): void
+    {
+        // Harvester stays in the colony zone (never relocated) — no regolith tile
+        // is associated with it at all, so the hint must not crash or fire.
+        foreach ([
+            'hint_1', 'hint_repair_urgent', 'hint_2', 'hint_3', 'hint_advisor_slot2',
+            'hint_agrardome', 'hint_repair', 'hint_invest_site', 'hint_build_priority',
+            'hint_6', 'hint_analytik', 'hint_hangar_path', 'hint_explore', 'hint_4',
+            'hint_5', 'hint_spend_remaining_ap', 'hint_end_sol', 'hint_encounter',
+        ] as $key) {
+            $this->service->dismissHint($this->userId, $key);
+        }
+
+        $this->assertNull($this->service->getActiveHint($this->colonyId, $this->userId));
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private function moveHarvesterOutside(): void


### PR DESCRIPTION
## Summary

Umsetzung der game-designer-Empfehlung aus der Regolith-Balance-Analyse (GDD §4c, `⚠️ BALANCE CONCERN`) — sinkender Harvester-Ertrag durch Tile-Depletion wirkte wie ein Bug, weil (1) kein proaktiver Warnhinweis existierte und (2) das seit Sol 1 vorerkundete Ausweich-Regolith-Vorkommen (Ring 3, "Nexus-Scout") auf der Karte nicht als Ausweichziel erkennbar war.

- Neuer Onboarding-Hint (`OnboardingHintService::checkHintHarvesterLowRegolith()`): warnt sobald das Restvorkommen des aktiven Harvester-Tiles unter `game.harvester.low_regolith_warning_pct` (Platzhalter 30%) fällt.
- Harvester-Tile-Ermittlung in `ColonyTileService::activeHarvesterRegolithTiles()` extrahiert — von Hint UND Sidebar-Anzeige geteilt, damit beide nie auseinanderlaufen können.
- `ColonyController::hexview()` liefert `regolithFallbackTiles` (erkundete, nicht-erschöpfte Regolith-Tiles außer dem aktiven Harvester-Tile).
- Kolonie-Karte markiert diese Tiles mit einem violetten Pfeil-Badge (unterscheidbar vom bestehenden blauen Ressourcen-Punkt), Tooltip erklärt den Zweck.

## Test plan
- [x] TDD durchgehend (rote Tests vor jeder Implementierung, Backend + Datenlogik)
- [x] `bin/phpunit --testsuite=laravel-feature,laravel-unit,playtest` — 1147/1147 grün
- [x] Live gegen Bart's echte Playtest-Kolonie verifiziert (Scratch-DB-Kopie, nur lesend) — korrekt 2 von 3 qualifizierenden Tiles als Fallback markiert, aktives Harvester-Tile korrekt ausgeschlossen

https://claude.ai/code/session_019Ky8f724MQzPqeRs1y2zhr