### PR TITLE
docs: Owner-Fragen F1-F3 entschieden, GDD/ROADMAP nachgezogen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-09-07
+
+- Docs: Owner-Fragen F1-F3 aus dem Implementierungsstand-Audit entschieden und im GDD nachgetragen (§3, §4b, §4c, §7, §12, §13, §15, §18.2, §18.5) — Agrardom bleibt Level-Gebäude (F1/C9), Decay-Instanzen werden nie gelöscht, Effekte kehren erst ab ~50% Reparatur zurück (F2/C2), Nexus-Schulden bleiben eigenes `nexus_debt`-Ledger und Berater-Upkeep-Defizit fließt künftig hinein statt zu klemmen (F3/C1), Konsul-Handelsvertrag ersatzlos gestrichen (Pfad-Paritätsverletzung), Berater-Beförderung wird von automatisch auf manuell umgestellt. ROADMAP.md entsprechend markiert (A8 obsolet, neue Umsetzungs-Tasks A19-A23). Reine Doku-Änderung, Umsetzung folgt separat.
+
 ## 2026-09-06
 
 - Docs: Implementierungsstand-Audit `docs/audit-implementierungsstand-2026-09-06.md` — GDD (inkl. `docs/gdd/*`), ROADMAP, CHANGELOG, Anhänge und CLAUDE.md gegen Config/Code abgeglichen; ~45 Abweichungen in vier Kategorien (Design ohne Code, Code ohne Doku-Update, inhaltliche Widersprüche, Doku-Hygiene) plus 8 Owner-Entscheidungsfragen und Task-Cluster-Vorschlag. Ersetzt `docs/gdd-config-audit.md` (jetzt Stub mit Verweis).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,9 @@ Quelle: `docs/audit-implementierungsstand-2026-09-06.md` (Kategorien A + C, Absc
 
 ### Owner-Fragen (zuerst klären, blockieren Tasks)
 
-- [ ] **F1 Agrardom: Level oder Instanz?** (C9) — Config ist Level/3, GDD §4c sagt Instanz. Bleibt Level → GDD-Korrektur; sonst Umstellung inkl. Instanz-Deckel (Stufe 1d)
-- [ ] **F2 Instanz-Zerstörung bei Decay** (C2) — Ruine auf Level 0 (heute) oder Löschung + Hangar-Schiff deaktivieren (GDD §7)?
-- [ ] **F3 Upkeep-Defizit → Nexus-Schulden?** (C1) — Feature oder GDD-Text streichen; hängt an A8 (Rückzahlung)
+- [x] **F1 Agrardom: Level oder Instanz?** ✅ 2026-09-07 (C9) — Entschieden: bleibt Level, Config unverändert (max_level=3), keine Instanz-Umstellung. Einziger Task war die GDD-Korrektur (game-designer, parallel in Bearbeitung).
+- [x] **F2 Instanz-Zerstörung bei Decay** ✅ 2026-09-07 (C2) — Entschieden: Instanzen werden nie gelöscht (bestätigter Ist-Zustand, kein Codeänderung nötig). NEU beschlossen: Reparatur-Hysterese ersetzt binäres `status_points > 0`-Modell — Effekte/Boni fallen bei 0 Status Points aus und kehren erst ab ~50 % Reparatur zurück. Hangar-Schiffe bleiben bewusster binärer Sonderfall (nicht anfassen). Umsetzungs-Tasks siehe **A19/A20**.
+- [x] **F3 Upkeep-Defizit → Nexus-Schulden?** ✅ 2026-09-07 (C1) — Entschieden: `nexus_debt` bleibt bestehen, Upkeep-Defizit fließt künftig hinein statt zu verpuffen. Konsul-„Handelsvertrag" entfällt ersatzlos. Berater-Beförderung wird von automatisch auf manuell (spielerausgelöst) umgestellt. Umsetzungs-Tasks siehe **A21/A22/A23** (drei zusammenhängende, aber separat umsetzbare Tasks — keiner ist Voraussetzung für einen anderen, aber A21 sollte zuerst gehen, da A8 daran hängt).
 - [ ] **F4 Harvester Konstant-Yield-Spec** (A16) — zurückziehen oder umsetzen? Betrifft §13.7-Sockelrechnung
 - [ ] **F5 Kanal 2 Nexus-Handelsschiffe** (A12) — streichen zugunsten Werkstoff-Direktimport?
 - [ ] **F6 Roguelike-Kenntnis-Teilmenge pro Run** (A10) — noch gewollt? §8b-Argumentation hängt daran
@@ -26,7 +26,7 @@ Quelle: `docs/audit-implementierungsstand-2026-09-06.md` (Kategorien A + C, Absc
 - [x] **A5** ✅ 2026-09-06 — `bar.ap_cost_accept` 1 → 2, `ap_cost_negotiate` 3 → 4 (Stufe 3) — Klein
 - [ ] **A6 Trust-Warnstufen** < −10 (roter Chip) und < −18 (Nexus-Warnung) (§18.2) — Mittel
 - [ ] **A7 Nexus-Milestones**: Sol-90-Letzte-Warnung, Fristverkürzung auf Sol 95 nach Sanktion (§15); toten Config-Block `run.nexus_milestones` verdrahten oder entfernen — Mittel
-- [ ] **A8 Nexus-Schulden**: 95 %-Warnmeldung + manuelle Rückzahlung (§18.2) — Mittel, nach F3
+- [x] **A8** ✅ 2026-09-07 — Nexus-Schulden-Rückzahlungs-Sondermechanik (§18.2) erledigt sich strukturell durch F3-Entscheidung (`nexus_debt` bleibt als laufender Fehlbetrags-Topf, keine separate Rückzahlungsmechanik nötig) — obsolet, kein eigener Task mehr
 - [ ] **A9 Nexus-Boni** ahead-of-curve (§15) — Niedrig, Design-Frage (A.4) zuerst
 - [ ] **A10 Kenntnis-Teilmenge pro Run** (§10) — nach F6
 - [ ] **A11 Uplink-Station Lv2/Lv3**: Händler-Frequenz (Lv2), Kolonialbericht/Meta-Bonus (Lv3) definieren oder streichen; Lv1 „Verwaltungsanfragen" klären — Mittel
@@ -37,19 +37,24 @@ Quelle: `docs/audit-implementierungsstand-2026-09-06.md` (Kategorien A + C, Absc
 - [ ] **A16 Konstant-Yield-Spec** — nach F4
 - [ ] **A17 Playtest-Instrumentierung** 11 Metriken in `RunReport` — nach F8
 - [ ] **A18** `mission_perimeter_patrol` in `config/missions.php` aufnehmen (§8b) — Klein
+- [ ] **A19 Reparatur-Hysterese: Schwellenwert einbauen** (nach F2, §7) — neuen Config-Wert (~50 %, z.B. `game.decay.effect_restore_threshold`) anlegen und an der/den Stelle(n) verdrahten, die Gebäude-Boni aktuell binär über `status_points > 0` gaten (u.a. `TrustService` — exakte Fundstellen von game-developer per Grep ermitteln, ggf. weitere Services betroffen). Effekt „aus bei 0, zurück ab ~50 % Reparatur", nicht mehr binär. TDD: Test zuerst (Zustandsübergänge 0 → <50 % → ≥50 %). — Mittel
+- [ ] **A20 Reparatur-Hysterese: Kaskaden-Schutz** (nach F2, §7, vor A19 zu klären) — Design-Klärung + Balance-Dämpfung gegen Abwärtsspirale (negativer Supply-Puffer → Trust runter → mehr Verfall → noch weniger Trust) VOR der A19-Implementierung; sonst Risiko eines Spiralen-Bugs (Softlock-Gefahr). Owner-Entscheidung zum Dämpfungsmechanismus einholen, dann Umsetzung + Regressionstest. — Mittel, Design-Frage zuerst
+- [ ] **A21 Nexus-Schulden: Upkeep-Defizit einspeisen** (nach F3, §13.1/§18.2) — `GameTick::processAdvisorUpkeep()`: `MAX(0, credits - upkeep)`-Klemme entfernen, Fehlbetrag stattdessen zu `nexus_debt` addieren. Dazu `nexus_debt_fail_threshold` (aktuell 12000) neu kalibrieren, da eine zusätzliche laufende Schuldenquelle hinzukommt. TDD: Test zuerst (Defizit-Szenario erhöht `nexus_debt` statt zu verpuffen; Threshold-Grenzfall). — Mittel
+- [ ] **A22 Konsul-„Handelsvertrag" entfernen** (nach F3, §15) — `config/game.php → credits.consul_contract_income_per_rank` löschen, zugehörige GameTick-Berechnung (~Zeile 1588ff) entfernen, `docs/game-reference.md` Konsul-Rang-Tabelle korrigieren (Pflicht-Checkliste vor Merge, ADR 0004). TDD: bestehende Tests, die den Contract-Income prüfen, anpassen/entfernen, ggf. Regressionstest „kein Contract-Income mehr" ergänzen. Unabhängig von A21/A23 umsetzbar. — Klein
+- [ ] **A23 Berater-Beförderung: automatisch → manuell** (nach F3, §13) — `GameTick::processAdvisorPromotions()` von Auto-Beförderung auf spielerausgelösten Trigger umstellen; neuer Endpoint (backend-coder) + UI-Trigger im Berater-Screen (ui-specialist), Spieler kann Beförderung bei erreichtem Threshold beliebig aufschieben. Cross-Cutting zwischen backend-coder und ui-specialist. TDD: Service-/Endpoint-Test zuerst (kein Auto-Trigger mehr im Tick; manueller Endpoint befördert nur bei erfülltem Threshold). Unabhängig von A21/A22 umsetzbar. — Mittel
 - [ ] **T7 Encounter-Reste**: Geologische Instabilität + Seuchenausbruch in `SolReportService::eventsGroup()` (B12) — Klein
 
 ### C — Doku widerspricht Code (Entscheidung, dann GDD oder Code anpassen)
 
-- [ ] **C1** §13.1 „Upkeep-Verlust läuft über `nexus_debt`" — nach F3
-- [ ] **C2** §7 Instanz-Zerstörung vs. Level-0-Ruine — nach F2
+- [x] **C1** ✅ 2026-09-07 — §13.1 „Upkeep-Verlust läuft über `nexus_debt`" — entschieden: GDD-Text bestätigt sich als Zielzustand, Umsetzung fehlt noch (Code-Gap, siehe A21)
+- [x] **C2** ✅ 2026-09-07 — §7 Instanz-Zerstörung vs. Level-0-Ruine — entschieden: nie löschen (Ist-Zustand bestätigt), zusätzlich neue Reparatur-Hysterese für Effekt-Rückkehr ab ~50 % beschlossen (siehe A19/A20); GDD §7 bereits parallel aktualisiert
 - [x] **C3** ✅ 2026-09-06 (GDD-Konsolidierung) — §4 Uplink Lv2 „Tiefenscan 1 Sol weniger" → Code: Scan-AP 2 → 1; Text angleichen
 - [ ] **C4** §15/§18.4 Phase-1-Bedingung — nach F7
 - [x] **C5** ✅ 2026-09-06 (GDD-Konsolidierung) — §15 Fail States / Gnadenfrist auf Phase-2-Sol-Basis und Instant-Trust-Fail umschreiben (§18.5-TODO seit 06-28) — zusammen mit A7
 - [ ] **C6** §6 Supply-Cap Wohnhabitat: „pro Einheit" vs. Σ Level × 8; Ziel-Cap nach Tier-System neu prüfen (Stufe 1d, `cap_max` 200)
 - [x] **C7** ✅ 2026-09-06 (GDD-Konsolidierung) — §8b Missionstabelle: `mission_aid_transport` ungegatet, `mission_harvester_salvage` ergänzen, Lieferzeiten 1/2/3
 - [x] **C8** ✅ 2026-09-06 (GDD-Konsolidierung) — §4 Gebäudetabelle: Max-Level-Spalte (alle 13 gedeckelt), Wohnhabitat Lv3 × 6 Instanzen, „11 aktive + 3 im Design" → 13 implementiert
-- [ ] **C9** §4c Zuordnungstabelle — nach F1
+- [x] **C9** ✅ 2026-09-07 — §4c Zuordnungstabelle — entschieden: Agrardom bleibt Level (F1), Config/GDD stimmen nach GDD-Korrektur überein
 - [x] **C10** ✅ 2026-09-06 (GDD-Konsolidierung) — §10 Liste implementierter Kenntnis-Effekte vervollständigen (geology, agronomy-Organika, health-Seuche, defense-Sturm, trade-Preisbonus, Analytik Lv4/5)
 - [x] **C11** ✅ 2026-09-06 (GDD-Konsolidierung) — §13 „Implementierung": `PersonellService` → `AdvisorService`, `FleetService` entfernen
 - [x] **C12** ✅ 2026-09-06 (GDD-Konsolidierung) — Tick-Schrittnummern in §8b/§13/§14 auf die 1–15-Nummerierung von `GameTick.php` (Stufe 6)

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -279,7 +279,6 @@ Credits werden durch vier Quellen erworben:
 |--------|-------------|
 | Relaisvergütung | Nexus zahlt pro Sol eine Vergütung für die Relais-/Sensor-Infrastruktur der Uplink-Station — abhängig vom Uplink-Station-Level |
 | Galaktischer Rat | Staatliche Subventionen für aktive Kolonien pro Sol (Arbeitstitel: Name noch offen) |
-| Handelsvertrag (Konsul) | Garantierte Bar-Einnahme, sobald ein Konsul zugewiesen ist und die Cantina Lv1+ steht — steigt mit Konsul-Rang (§12, §13) |
 | Handel | Einnahmen aus Handelsrouten beim Verkauf von Regolith / Organika / Werkstoffen |
 | Events | Einmalige Gutschriften durch zufällige Ereignisse |
 
@@ -647,7 +646,9 @@ Was ein Pfad liefert, ist deshalb ein **Vorsprung von 1–2 CC-Leveln** in seine
 
 **Pfad B — Hangar.** Der Pfad der aktiven Versorgung. Schiffe erschließen den Missionskatalog (§8b) und damit die breiteste Ressourcenbasis im Spiel — Regolith, Organika, Credits, Almanach-Funde und Tile-Aufklärung kommen alle über Missionen. Der Preis ist dauerhafter Aufwand: jede Mission kostet AP und Proviant, Schiffe verschleißen und wollen repariert werden. Wer diesen Pfad zuerst geht, hat früh viele Hebel, muss sie aber jeden Sol bedienen.
 
-**Pfad C — Cantina.** Der Pfad der Flexibilität. Der Konsul bringt mit dem Handelsvertrag eine garantierte Sol-Einnahme (§12), die Cantina selbst gibt Vertrauen (`trust_per_lv`), und der Handel erlaubt, jeden konkreten Engpass gegen Credits zu lösen — statt ihn produzieren zu müssen. Wer diesen Pfad zuerst geht, ist gegen Überraschungen am besten aufgestellt, hängt dafür aber an der Credits-Decke und an der Angebotslage.
+**Pfad C — Cantina.** Der Pfad der Flexibilität. Die Cantina selbst gibt Vertrauen (`trust_per_lv`), und der Handel erlaubt, jeden konkreten Engpass gegen Credits zu lösen — statt ihn produzieren zu müssen. Wer diesen Pfad zuerst geht, ist gegen Überraschungen am besten aufgestellt, hängt dafür aber an der Credits-Decke und an der Angebotslage.
+
+> ⚠️ **Konsul-Credits-Hebel offen (Owner-Entscheidung F3):** Der frühere „Handelsvertrag" (garantierte Dauer-Sol-Einnahme sobald Konsul + Cantina Lv1 stehen) wurde ersatzlos gestrichen — er war bedingungslos und ohne weiteres Zutun stärker als die Hebel von Analytiker und Raumfahrer und verletzte damit die Paritäts-Anforderung unten. Pfad C hat damit aktuell denselben offenen Credits-Hebel wie Pfad A (siehe Tabelle unten). Eine Ersatzmechanik ist nicht vorgesehen.
 
 ### Paritäts-Anforderung: jeder Pfad muss die Grundbedürfnisse decken
 
@@ -659,10 +660,10 @@ Der Harvester (Regolith) und der Agrardom (Organika) sind der **gemeinsame Socke
 |---|---|---|---|---|
 | **Regolith** | 1 Harvester-Instanz, Grundeinkommen pro Sol (Standard-Baseline, §4c) | `geology` senkt Erschöpfung | Mission-Missionen liefern variable Mengen je Umlauf | **kein dedizierter Wachstumshebel** — opportunistischer Credits→Regolith-Kauf als Sicherheitsnetz (§12), siehe „Pfad-C-Hebel" unten |
 | **Organika** | Agrardom | `agronomy` erhöht die Produktion mit jedem Level (glockenförmig) | Missions-Missionen liefern Organika je Umlauf | Ankauf über Bar-Angebote |
-| **Credits** | Relaisvergütung, Ratssubvention | ⚠️ Hebel offen | Botenflug / Konvoi-Begleitung | Handelsvertrag + Organika-Verkauf |
+| **Credits** | Relaisvergütung, Ratssubvention | ⚠️ Hebel offen | Botenflug / Konvoi-Begleitung | ⚠️ Hebel offen (Organika-Verkauf als opportunistische Teillösung) |
 | **Vertrauen** | Gebäude-Boni, Ereignisse | `health` + Krankenstation | `mission_aid_transport` (+2) | Cantina `trust_per_lv` + Handelserfolge |
 
-**Pfad A Credits-Hebel:** Offen (s. Tabelle). Kandidat: Kenntnis-Effekt, der Kosten senkt — passt besser zum Pfad-Charakter als eine zusätzliche Einnahmequelle.
+**Pfad A und Pfad C Credits-Hebel:** Beide offen (s. Tabelle). Kandidat für Pfad A: Kenntnis-Effekt, der Kosten senkt — passt besser zum Pfad-Charakter als eine zusätzliche Einnahmequelle. Für Pfad C ist noch kein Kandidat benannt (der bisherige Handelsvertrag ist gestrichen, siehe oben).
 
 > **Prüfregel für künftige Mechaniken:** Wird eine neue Ressource, Kosten- oder Bedarfsachse eingeführt, ist zu prüfen, ob alle drei Pfade sie bedienen können. Ist das nicht der Fall, ist entweder die Mechanik anzupassen oder den unterversorgten Pfaden ein Hebel zu geben — **nicht** die Ungleichheit hinzunehmen.
 
@@ -722,7 +723,7 @@ Ein Level-Up ist zusätzlich gerechtfertigt, wenn die Stufe **etwas Bestimmtes f
 | **Kommandozentrale** | Level | Lv5 | Eine pro Kolonie, per Definition. Die Level tragen die Progressionsgates des gesamten Spiels. |
 | **Harvester** | **Instanz** | **2** | Mehrere Abbaurigs auf mehreren Regolith-Tiles. Bewusst knapp gedeckelt — siehe unten. |
 | **Wohnhabitat** | Instanz (+ Level 1–3 je Instanz) | 6 | Mehrere Habitate; das Level je Instanz trägt den Supply-Cap-Beitrag (§6). |
-| **Agrardom** | **Instanz** (Ziel) | offen | Mehrere Kuppeln; Nahrungsproduktion skaliert natürlich mit der Anzahl. **Owner-Frage F1:** Config führt den Agrardom als Level-Gebäude (max Lv3, nicht instanziert) — Umstellung oder Zielkorrektur offen. |
+| **Agrardom** | Level | Lv3 | Bleibt Level-Gebäude (Owner-Entscheidung F1). Er hat mit Level und `agronomy`-Kenntnis bereits zwei Wachstumshebel — eine dritte Achse (Instanz) wäre Redundanz ohne neue Entscheidung, und eine zusätzliche Instanz würde ein knappes Koloniefeld binden, das mit einzigartigen Gebäuden konkurriert. |
 | **Hangar** | **Instanz + Level** | Instanzen offen, Lv3 | Der einzige Fall, der beide Achsen braucht — siehe unten. |
 | **Analytik-Labor** | Level | Lv3+ | Lv1-3 **sind** die Kenntnis-Stufen (`cartography` Lv1, `geology`/`trade` Lv2, `defense` Lv3) — ohne sie bricht die Staffelung weg. Lv4/5 haben zusätzlich einen eigenen Effekt (Kenntnis-Kosten-Rabatt, §13.3), keine reinen Gate-Stufen mehr. |
 | **Uplink-Station** | Level | Lv3 | §4 nennt sie „das einzige Kommunikationsgebäude der Kolonie". Eine zweite Funkanlage verdoppelt keine Reichweite. |
@@ -1026,22 +1027,20 @@ max_status_points=5, decay_rate=0.5
   Nach Sol 4: status_points = 3.00  ← zwei ganze SP verloren
 ```
 
-**Konsequenzen nach Building-Typ:**
-
-| Entität | Typ | Konsequenz bei SP ≤ 0 |
-|---------|-----|----------------------|
-| Leveled Building (allgemein) | Leveled | Level − 1; status_points reset auf max_status_points; Protokoll-Ereignis |
-| Wohnhabitat | Instanced | **Instanz zerstört** (kein Level zum Abziehen); Supply-Cap sinkt; Protokoll-Ereignis |
-| Hangar | Instanced | **Instanz zerstört**; zugewiesenes Schiff wird **unbrauchbar** (nicht zerstört); Protokoll-Ereignis |
+**Konsequenz bei SP ≤ 0 — einheitlich, keine Zerstörung (Owner-Entscheidung F2):** Ein Gebäude oder eine Instanz wird durch Decay **nie gelöscht**. Erreichen die `status_points` 0, levelt das Exemplar um 1 herunter (min. Level 0), die `status_points` werden auf `max_status_points` zurückgesetzt, ein Protokoll-Ereignis wird geschrieben. Das gilt gleichermaßen für Level-Gebäude und für Instanzen (Wohnhabitat, Hangar) — eine Instanz bleibt als Instanz bestehen, auch auf Level 0.
 *(Kenntnis — kein Decay; Kenntnisse haben kein SP-System, siehe §10)*
 
-> **Instanced vs. Leveled:** Leveled Buildings verlieren ein Level und regenerieren SP — sie geben mehrere Chancen. Instanced Buildings (Wohnhabitat, Hangar) haben kein Level: Decay auf 0 zerstört die Instanz sofort. Das macht sie gefährlicher zu vernachlässigen, erlaubt aber bewusst riskantes Spiel (Repair-AP sparen auf eigene Gefahr).
+> **Effekte folgen dem Status, nicht dem Level (Owner-Entscheidung F2, Design-Ergänzung):** Das bisherige binäre Modell „Effekt an, solange `status_points > 0`" gilt nicht mehr uneingeschränkt. Sobald die `status_points` eines Exemplars 0 erreichen, fällt sein Effekt/Bonus vollständig aus — er kehrt erst zurück, wenn das Exemplar zu einem guten Teil wieder repariert ist (Richtwert **~50 %** von `max_status_points`), nicht schon beim ersten Reparatur-Klick. Beispiel: Ein verfallenes Wohnhabitat verliert seinen Supply-Beitrag vollständig, der Supply-Puffer der Kolonie kann dadurch negativ werden — das ist **beabsichtigt** und soll sich als Vertrauens-Malus niederschlagen (Kolonisten ohne ausreichend Wohnraum/Versorgung).
+>
+> **Ausnahme Hangar-Schiffe:** Schiffe bleiben ein bewusster binärer Sonderfall — ein Schiff ist entweder voll einsatzfähig oder vollständig deaktiviert, es gibt keinen Teil-Zustand. Sie werden **nicht** in das ~50 %-Reparatur-Modell gezwungen.
+>
+> ⚠️ BALANCE CONCERN: Ein negativer Supply-Puffer braucht eine Dämpfung gegen eine Verfalls-Kaskade (Vertrauen sinkt → mehr Verfall → noch weniger Vertrauen). Diese Dämpfung ist noch ungeklärt und muss vor der Implementierung geklärt werden.
 
 > **Manuelle Reparatur:** kostet Construction-AP und Regolith pro Schritt. Hartes Gate — ohne Regolith ist der Reparatur-Button gesperrt. CC und Harvester sind regolithfrei reparierbar (AP-only, Bootstrap-Schutz). Vollständige Kosten-Regeln siehe §4 „Baukosten & Level-Up-Kosten" und `config/game.php`.
 
 > **Notreparatur (CC und Wohnhabitat):** Wenn SP dieser kritischen Strukturen unter einen Schwellwert fällt, wird automatisch eine Notreparatur ausgelöst — kostet Credits statt AP. Verhindert unbeabsichtigten Verlust, nicht aber bewusste Vernachlässigung (Credits müssen vorhanden sein).
 
-> **Hangar-Decay-Detail:** Ein Schiff im zerstörten Hangar bleibt in der Datenbank erhalten — es ist nur deaktiviert. Sobald ein neuer Hangar gebaut oder der alte repariert wird, ist das Schiff wieder einsatzbereit.
+> **Hangar-Decay-Detail:** Levelt der Hangar auf Decay herunter, wird ein zugewiesenes Schiff deaktiviert, nicht zerstört — es bleibt in der Datenbank erhalten. Sobald der Hangar wieder auf den Reparatur-Schwellwert (~50 %, siehe oben) instand gesetzt ist, ist das Schiff wieder einsatzbereit.
 
 > **Schiffe haben keinen passiven Decay.** Schiffs-Verschleiß entsteht durch aktiven Einsatz (Außenmissionen), nicht durch Zeitablauf — siehe §7 "Schiffs-Verschleiß".
 
@@ -1490,18 +1489,7 @@ Die Bar ist ab CC Lv2 verfügbar. Sie ist der Ort des Handels — verkörpert du
 
 Der Spieler entscheidet pro Angebot: annehmen oder ablehnen. **Annehmen kostet AP** aus dem gemeinsamen Pool (§13.1) — der Handel konkurriert damit direkt mit Bau und Kenntnissen um dieselbe Kapazität. Exakte Kosten: siehe `config/game.php`.
 
-**Handelsvertrag (garantierte Einnahmequelle):** Kauf- und Tauschangebote erzeugen kein Credits-Einkommen — sie kosten Credits oder sind ressourcenneutral. Das strukturelle Handelseinkommen der Kolonie ist deshalb der Handelsvertrag: kein Bar-Angebot (kein Karten-Slot, keine Annahme, keine AP-Kosten), sondern eine **passive Cr/Sol-Einnahme**, strukturell identisch zur Relaisvergütung (§3). Sie fließt automatisch pro Tick, solange ein Konsul der Kolonie zugewiesen ist **und** die Cantina mindestens Lv1 steht; der Konsul vermittelt laufende Handelsverträge im Hintergrund, die Kolonie liefert dafür keine Ressourcen. Config: `game.credits.consul_contract_income_per_rank`, verarbeitet in `GameTick` im selben Schritt wie `nexus_subsidy`/`relay_bonus_per_uplink_level`. Werte nach Konsul-Rang:
-
-| Konsul-Rang | Handelsvertrag-Einkommen |
-|-------------|--------------------------|
-| Kein Konsul | — |
-| 1 — Junior | Niedrig |
-| 2 — Senior | Mittel |
-| 3 — Experte | Hoch |
-
-Exakte Werte pro Rang: siehe `config/game.php → credits.consul_contract_income_per_rank`.
-
-Ohne zugewiesenen Konsul entfällt diese Einnahme vollständig — **beabsichtigt**: die Konsul-Entscheidung erhält einen echten Gegenwert. Wichtig: Der Handelsvertrag wie auch Corvans Alltagsgeschäft sind beide an die gebaute Cantina (Bar Lv1+) gekoppelt. Für Läufe, die Sciencelab oder Hangar zuerst bauen (gleichwertige Pfadwahl, §13), entfällt damit der komplette Cantina-Einnahmepfad — das ist kein Edge-Case, sondern der Normalfall für jeden Lauf ohne frühe Cantina. Credits-Planung muss das berücksichtigen (Missionen, Nexus-Reserve, Berater-AP-Beitrag fallen schwächer aus).
+> ⚠️ **Handelsvertrag gestrichen (Owner-Entscheidung F3):** Es gab bis Anfang September 2026 eine passive Cr/Sol-Einnahme, die automatisch floss, sobald ein Konsul zugewiesen war und die Cantina Lv1+ stand. Sie wurde ersatzlos gestrichen — bedingungslos und ohne weiteres Zutun war sie stärker als die vergleichbaren Hebel von Analytiker (Kenntnis-Boni) und Raumfahrer (Missions-Erträge) und verletzte damit die Paritäts-Anforderung (§4b). Corvans Alltagsgeschäft (Kauf/Verkauf) bleibt an die Cantina Lv1+ gekoppelt und erzeugt weiterhin kein passives Einkommen — Kauf- und Tauschangebote kosten Credits oder sind ressourcenneutral. Pfad C hat aktuell keinen dedizierten Credits-Wachstumshebel (§4b); eine Ersatzmechanik ist nicht vorgesehen.
 
 **Bar-Level-Progression:**
 
@@ -1972,10 +1960,12 @@ Exakte Werte (AP-Bonus je Rang, Upkeep, Rang-Aufstiegs-Schwellen in aktiven Tick
 
 **Einstellungskosten (Rang 1) — typ-spezifisch:** Baumeister ist der günstigste Einstieg (Kernanforderung Tag 1); Analytiker, Raumfahrer und Konsul sind höher gestaffelt, gekoppelt an ihre spätere Verfügbarkeit (Analytiker erst ab CC Lv2, Raumfahrer voller Nutzen erst mit Hangar, Konsul mittlere Priorität). Exakte Beträge: `config/advisors.php`, `docs/game-reference.md`.
 
-**Beförderung** kostet beim Erreichen von Rang 2 bzw. Rang 3 zusätzlich zum laufenden Upkeep einen einmaligen Credits-Betrag (`config/game.php → advisor.promotion_costs`). Kann der Spieler die Beförderung nicht bezahlen, wird sie auf den nächsten Sol verschoben, bis genug Credits verfügbar sind.
+**Beförderung** kostet beim Erreichen von Rang 2 bzw. Rang 3 zusätzlich zum laufenden Upkeep einen einmaligen Credits-Betrag (`config/game.php → advisor.promotion_costs`).
+
+**Beförderung ist eine aktive Entscheidung, kein Automatismus (Owner-Entscheidung F3).** Sobald ein Berater den `active_ticks`-Schwellwert für den nächsten Rang erreicht hat, steht die Beförderung bereit — der Spieler löst sie selbst aus, wann er will, und kann sie beliebig lange hinauszögern, um den höheren Upkeep und die Einmalkosten erst zu tragen, wenn die Kolonie es sich leisten kann. Das folgt demselben Grundsatz wie an anderer Stelle im AP-/Berater-System: aktive Entscheidungen statt automatischer Fortschritt.
 
 - **Upkeep** wird jeden Sol von den Colony-Credits abgezogen, solange der Berater `colony_id` gesetzt hat (Berater ist aktiv zugewiesen).
-- **Rang-Aufstieg:** automatisch nach ausreichend kumulierten `active_ticks` (`config/game.php → advisor.rank_thresholds`).
+- **Rang-Aufstieg:** Bereitschaft wird nach ausreichend kumulierten `active_ticks` erreicht (`config/game.php → advisor.rank_thresholds`); der Vollzug bleibt manuell, siehe oben.
 - Alle Werte stehen in `config/game.php → advisor` (Einstellungskosten, AP-Bonus, Upkeep, Rang-Thresholds, Beförderungskosten).
 
 > **UI-Anforderung:** Die Berater-Verwaltung zeigt für jeden aktiven Berater: Rang, AP-Beitrag/Sol, laufender Upkeep (Cr/Sol) und `active_ticks` zum nächsten Rang-Aufstieg. Diese vier Werte müssen auf einen Blick lesbar sein.
@@ -2580,6 +2570,8 @@ Nexus-intern heißt die Position **Konzessionär**: jemand der eine Betriebslize
 
 **Nexus** ist kein Staat und keine Armee — es ist ein interstellares Entwicklungskonsortium, das Kolonisierungsrechte vergibt, Startkapital vorschießt und am Ende Rechenschaft erwartet. Der Spieler hat eine Konzession unterzeichnet: Aufbau und Betrieb einer Siedlung auf einem zugewiesenen Planeten, für eine definierte Laufzeit, gegen Vorauszahlung in Credits. Was in der Konzession nicht steht: wie rau die Bedingungen vor Ort sind, was die Kolonisten wirklich brauchen, und wie wenig Nexus bereit ist zu helfen wenn es brennt.
 
+**Das Startkapital ist wörtlich ein Vorschuss, kein Geschenk (Owner-Entscheidung F3):** Die Kolonie startet mit nutzbaren Credits — und in exakt gleicher Höhe gleichzeitig mit `nexus_debt`. Das ist ein bewusster Härtefaktor, kein Rechentrick: Er erzeugt von Sol 1 an denselben Druck, den das Frontier-Survival-Ton verspricht, und macht die Konzessions-Entzug-Drohung (Fail State 2, §18.2) von Anfang an glaubwürdig statt erst spät im Run relevant zu werden.
+
 Der Direktor steht zwischen zwei Loyalitäten: den Kolonisten (Vertrauen) und Nexus (Schulden). Wer zu sehr für Nexus optimiert, verliert das Vertrauen der Siedler. Wer Nexus ignoriert, wird zurückgerufen. Das ist kein Widerspruch — das ist der Job.
 
 ---
@@ -2635,9 +2627,9 @@ Genau vier Fail States — kanonische Definition, Warnstufen und Auslösung in *
 4. **Phase-1-Fristbruch** — Phase 1 bei `run.phase1_deadline_sol` nicht abgeschlossen.
 
 **Nexus-Schulden-Mechanik:**
-- Schulden akkumulieren durch: Startkapital (Vorschuss, initialer `nexus_debt`) + Nexus-Deals (Schiffskauf auf Nexus-Kredit, §8b)
+- Schulden akkumulieren durch: Startkapital (Vorschuss, initialer `nexus_debt`), Nexus-Deals (Schiffskauf auf Nexus-Kredit, §8b) und — Owner-Entscheidung F3 — jedes Berater-Upkeep-Defizit, das die Credits nicht mehr deckt können: Credits werden dabei auf 0 geklemmt statt negativ zu werden, das Defizit fließt stattdessen in `nexus_debt`. `nexus_debt` ist damit das alleinige Schulden-Ledger der Kolonie; Credits selbst bleiben immer nutzbares, nicht-negatives Kapital (§13.1).
 - Keine Zinsen
-- Rückzahlung: nur manuell — *geplant, noch nicht implementiert* (ROADMAP A8)
+- Rückzahlung (Owner-Entscheidung F3, beantwortet ROADMAP A8): kein eigenes Rückzahlungs-Feature nötig — normales positives Sol-Einkommen tilgt `nexus_debt` automatisch mit, sobald wieder ein Überschuss entsteht. Kein separater manueller Rückzahlungs-Workflow geplant.
 - Schuldenlimit: fester Wert (`config/game.php`), als Balken im UI kommuniziert („Nexus-Kredit: X / Cap"), Farbwechsel bei moderaten und hohen Schwellen
 - Lose Kopplung mit Vertrauen: kein automatischer Zusammenhang, der Spieler managt beide Achsen aktiv. Ein Schiffskauf auf Kredit löst einen einmaligen kleinen Trust-Malus aus (`nexus_credit`-Event).
 
@@ -2799,7 +2791,7 @@ Begründung gegen eine Streak-Mechanikverzögerung: Trust unter −20 bedeutet a
 | > 95 % des Limits | Schuldenbalken wechselt auf Rot; *geplant:* Nexus-Meldung „Kreditlimit fast erreicht." |
 | > 100 % | Fail State — Run endet sofort |
 
-> **Implementierungsstand:** Akkumulation (Startkapital als initiale Schuld, Nexus-Kredit-Schiffskauf) und Fail-State-Prüfung sind implementiert. Offen: manuelle Rückzahlung und die 95 %-Warnmeldung (ROADMAP A8).
+> **Implementierungsstand:** Akkumulation (Startkapital als initiale Schuld, Nexus-Kredit-Schiffskauf, Berater-Upkeep-Defizit — Owner-Entscheidung F3, §15 Nexus-Schulden-Mechanik) und Fail-State-Prüfung sind implementiert. Rückzahlung braucht kein eigenes Feature (F3, beantwortet A8) — normales positives Einkommen tilgt automatisch. Offen bleibt nur die 95 %-Warnmeldung.
 
 **Narrativer Ausgang:** "Nexus hat die Konzession entzogen. Der Direktor wurde zurückgerufen."
 
@@ -2930,16 +2922,16 @@ Bei Phase-1-Ende Sol 20 fällt Phase-2-Sol 80 exakt auf Gesamt-Sol 100 — das i
 - `task_colony_prosperity` (Vertrauen über Schwelle) wird nicht am Zielwert kalibriert, solange die Trust-Ökonomie selbst nicht kalibriert ist (Trust bewegt sich im Bot nur um den Neutralbereich) — eigene Untersuchung.
 - `task_credit_reserve` liest die Schwelle aus `run.task_credit_reserve_threshold`.
 
-**Credits-Ökonomie — Break-even-Regel:** Der Berater-Unterhalt (`advisor.upkeep`, steigend mit dem Rang) muss im **worst case ohne Cantina** (keine Handelsvertrag- und Corvan-Einnahmen) spätestens mit ausgebauter Uplink-Station tragbar sein — sonst ist die Cantina eine verdeckte Pflicht statt eine gleichrangige Pfadwahl. Einnahmen ohne Cantina sind `nexus_subsidy` (flat, bedingungslos) und die Relaisvergütung (`relay_bonus_per_uplink_level`); der Handelsvertrag (`consul_contract_income_per_rank`) bleibt ein Bonus des Cantina-Pfads. Herleitung mit vier Beratern (Werte `config/game.php`):
+**Credits-Ökonomie — Break-even-Regel:** Der Berater-Unterhalt (`advisor.upkeep`, steigend mit dem Rang) muss spätestens mit ausgebauter Uplink-Station tragbar sein, unabhängig davon, ob die Cantina gebaut wurde — der frühere Handelsvertrag (Cantina-Bonuseinkommen) ist gestrichen (Owner-Entscheidung F3, §12 Kanal 1), Cantina liefert seither kein dediziertes Dauereinkommen mehr. Strukturelles Einkommen ist damit für alle drei Pfade gleich: `nexus_subsidy` (flat, bedingungslos) und die Relaisvergütung (`relay_bonus_per_uplink_level`). Herleitung mit vier Beratern (Werte `config/game.php`):
 
 | Rang | Upkeep (4 Berater) | Einkommen, Uplink Lv0 | Einkommen, Uplink Lv2 | Einkommen, Uplink Lv3 (max.) |
 |------|---------------------|------------------------|-------------------------|---------------------------------|
 | 2 | 100 Cr/Sol | 50 Cr/Sol (−50) | 140 Cr/Sol (+40) | 185 Cr/Sol (+85) |
 | 3 | 140 Cr/Sol | 50 Cr/Sol (−90) | 140 Cr/Sol (0) | 185 Cr/Sol (+45) |
 
-Ein Rang-2-Defizit bei niedrigem Uplink-Ausbau ist aus dem Phase-1-Reststand absorbierbar; Rang 3 erreicht mit Uplink Lv2+ eine neutrale bis positive Marge statt eines permanenten Bodens. Mit Cantina + Konsul liegt der Überschuss deutlich höher — der Konsul ist ein spürbarer, aber optionaler Vorteil. Beförderungskosten (`promotion_costs`) sind so gesetzt, dass mehrere gleichzeitige Rang-3-Aufstiege keinen Einmal-Schock erzeugen, der zusammen mit dem Upkeep-Sprung die Kasse leert.
+Ein Rang-2-Defizit bei niedrigem Uplink-Ausbau ist aus dem Phase-1-Reststand absorbierbar; Rang 3 erreicht mit Uplink Lv2+ eine neutrale bis positive Marge statt eines permanenten Bodens. Beförderungskosten (`promotion_costs`) sind so gesetzt, dass mehrere gleichzeitige Rang-3-Aufstiege keinen Einmal-Schock erzeugen, der zusammen mit dem Upkeep-Sprung die Kasse leert.
 
-**Offene Design-Frage (Owner-Entscheidung):** Sciencelab- und Hangar-Pfad sollen ein **eigenes** Credits-Einkommen bekommen, unabhängig davon, ob und wann die Cantina gebaut wird. Die Zahlenhebel oben nivellieren nur; sie ersetzen keinen fehlenden Kanal. Mechanismus nicht spezifiziert — ROADMAP „Offene Pfad-Paritäts-Fragen".
+**Offene Design-Frage (Owner-Entscheidung):** Alle drei Pfade — Analytik-Labor, Hangar **und** Cantina — brauchen weiterhin einen eigenen Credits-Wachstumshebel jenseits der pfadneutralen Grundeinnahmen oben (§4b markiert alle drei als ⚠️ offen bzw. nur opportunistisch gedeckt). Mechanismus nicht spezifiziert — ROADMAP „Offene Pfad-Paritäts-Fragen".
 
 ---
 


### PR DESCRIPTION
## Summary
- Owner-Fragen F1 (Agrardom Level vs. Instanz), F2 (Instanz-Zerstörung bei Decay), F3 (Nexus-Schulden) aus dem Implementierungsstand-Audit entschieden
- GDD.md an ~9 Stellen live editiert (§3, §4b, §4c, §7, §12, §13, §15, §18.2, §18.5)
- ROADMAP.md: F1-F3 als beantwortet markiert, A8 obsolet, neue Umsetzungs-Tasks A19-A23, C1/C2/C9 entschieden
- Reine Doku-Änderung — keine Code-/Config-Änderung, Umsetzung folgt in separatem PR

## Entscheidungen
- **F1**: Agrardom bleibt Level-Gebäude (kein Instanz-Umbau)
- **F2**: Instanzen werden nie gelöscht; neu: Effekte/Boni gehen bei SP=0 aus, kehren erst ab ~50% Reparatur zurück (Hangar-Schiffe bleiben binärer Sonderfall)
- **F3**: `nexus_debt` bleibt eigenes Ledger; Berater-Upkeep-Defizit soll künftig hineinfließen statt geklemmt zu werden; Konsul-Handelsvertrag ersatzlos gestrichen (Pfad-Paritätsverletzung); Berater-Beförderung wird von automatisch auf manuell umgestellt

## Test plan
- [x] Nur Doku-Dateien geändert (docs/GDD.md, ROADMAP.md, CHANGELOG.md) — kein Code-Pfad betroffen, TDD nicht anwendbar