### PR TITLE
docs: Owner-Fragen F4-F8 entschieden, GDD/ROADMAP nachgezogen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-09-08
+
+- Docs: Owner-Fragen F4-F8 aus dem Implementierungsstand-Audit entschieden und im GDD nachgetragen (§3, §4, §8b, §10, §12, §13.7, §4c) — Harvester Konstant-Yield-Spec wird umgesetzt inkl. später nachzuholender §13.7-Neuherleitung (F4/A16), Kanal-2-Nexus-Handelsschiffe gestrichen und in eine verzögerte Uplink-Direktimport-Variante (3-5 Sole, Lieferzeit nur über Uplink-Station-Level reduzierbar) überführt (F5/A12), Roguelike-Kenntnis-Teilmenge pro Run ersatzlos gestrichen (F6/A10, Risiko fehlender essentieller Kenntnisse bei nur 7 Stück), Phase-1-Bedingung bestätigt wie im Code implementiert — nur irreführender Docblock-Kommentar in `RunProgressService::checkPhase1Completion()` korrigiert (F7/C4), Playtest-Instrumentierungsplan freigegeben (F8/A17, `docs/playtest-instrumentation-plan.md` überarbeitet: Regolith-Pfad-Attribution nach Mechanismen, Organika-Verbrauch in Hunger- vs. Mission-Dispatch-Anteil aufgeschlüsselt). Nebenbefund: GDD-Aussage "Pfad C trägt keinen Regolith-Hebel" korrigiert (Corvan-Kauf ist ein realer, nicht-dedizierter Weg). ROADMAP.md entsprechend markiert, neue Umsetzungs-Tasks A24-A33. Reine Doku-Änderung (bis auf den Kommentar-Fix), Umsetzung folgt separat.
+
 ## 2026-09-07
 
 - Docs: Owner-Fragen F1-F3 aus dem Implementierungsstand-Audit entschieden und im GDD nachgetragen (§3, §4b, §4c, §7, §12, §13, §15, §18.2, §18.5) — Agrardom bleibt Level-Gebäude (F1/C9), Decay-Instanzen werden nie gelöscht, Effekte kehren erst ab ~50% Reparatur zurück (F2/C2), Nexus-Schulden bleiben eigenes `nexus_debt`-Ledger und Berater-Upkeep-Defizit fließt künftig hinein statt zu klemmen (F3/C1), Konsul-Handelsvertrag ersatzlos gestrichen (Pfad-Paritätsverletzung), Berater-Beförderung wird von automatisch auf manuell umgestellt. ROADMAP.md entsprechend markiert (A8 obsolet, neue Umsetzungs-Tasks A19-A23). Reine Doku-Änderung, Umsetzung folgt separat.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,11 +11,11 @@ Quelle: `docs/audit-implementierungsstand-2026-09-06.md` (Kategorien A + C, Absc
 - [x] **F1 Agrardom: Level oder Instanz?** ✅ 2026-09-07 (C9) — Entschieden: bleibt Level, Config unverändert (max_level=3), keine Instanz-Umstellung. Einziger Task war die GDD-Korrektur (game-designer, parallel in Bearbeitung).
 - [x] **F2 Instanz-Zerstörung bei Decay** ✅ 2026-09-07 (C2) — Entschieden: Instanzen werden nie gelöscht (bestätigter Ist-Zustand, kein Codeänderung nötig). NEU beschlossen: Reparatur-Hysterese ersetzt binäres `status_points > 0`-Modell — Effekte/Boni fallen bei 0 Status Points aus und kehren erst ab ~50 % Reparatur zurück. Hangar-Schiffe bleiben bewusster binärer Sonderfall (nicht anfassen). Umsetzungs-Tasks siehe **A19/A20**.
 - [x] **F3 Upkeep-Defizit → Nexus-Schulden?** ✅ 2026-09-07 (C1) — Entschieden: `nexus_debt` bleibt bestehen, Upkeep-Defizit fließt künftig hinein statt zu verpuffen. Konsul-„Handelsvertrag" entfällt ersatzlos. Berater-Beförderung wird von automatisch auf manuell (spielerausgelöst) umgestellt. Umsetzungs-Tasks siehe **A21/A22/A23** (drei zusammenhängende, aber separat umsetzbare Tasks — keiner ist Voraussetzung für einen anderen, aber A21 sollte zuerst gehen, da A8 daran hängt).
-- [ ] **F4 Harvester Konstant-Yield-Spec** (A16) — zurückziehen oder umsetzen? Betrifft §13.7-Sockelrechnung
-- [ ] **F5 Kanal 2 Nexus-Handelsschiffe** (A12) — streichen zugunsten Werkstoff-Direktimport?
-- [ ] **F6 Roguelike-Kenntnis-Teilmenge pro Run** (A10) — noch gewollt? §8b-Argumentation hängt daran
-- [ ] **F7 Phase-1-Bedingung** „2 Produktionsgebäude" vs. „2 Nicht-CC-Gebäude" (C4) — seit 08-13 offen
-- [ ] **F8 Playtest-Instrumentierung** (A17) — `docs/playtest-instrumentation-plan.md` freigeben?
+- [x] **F4 Harvester Konstant-Yield-Spec** ✅ 2026-09-08 (A16) — Entschieden: Spec wird umgesetzt (konstante Rate statt Rampen-Formel), inkl. §13.7-Neuherleitung. GDD wird parallel nachgezogen (§4c Formel, §13.7 als veraltet markiert). Umsetzungs-Tasks siehe **A24/A25/A26/A27**.
+- [x] **F5 Kanal 2 Nexus-Handelsschiffe** ✅ 2026-09-08 (A12) — Entschieden: Kanal 2 wird gestrichen, Funktion wandert in einen Uplink-Direktimport für Nicht-Werkstoff-Ressourcen (Lieferzeit 3-5 Sol, reduzierbar über Uplink-Station-Level als einzigen Hebel). Werkstoff-Sofortkauf bleibt unverändert. Umsetzungs-Tasks siehe **A28/A29**.
+- [x] **F6 Roguelike-Kenntnis-Teilmenge pro Run** ✅ 2026-09-08 (A10) — Entschieden: wird komplett gestrichen, auch nicht abgeschwächt (bei nur 7 Kenntnissen zu hohes Risiko einer essentiellen Kenntnis-Lücke pro Run). GDD wird bereinigt (§10-Abschnitt entfernt, §8b-Begründung angepasst/gestrichen). Kein neuer Umsetzungs-Task — reine Streichung.
+- [x] **F7 Phase-1-Bedingung** ✅ 2026-09-08 „2 Produktionsgebäude" vs. „2 Nicht-CC-Gebäude" (C4) — Entschieden: Code (`RunProgressService::checkPhase1Completion()`, zählt jedes Nicht-CC-Gebäude ≥ Lv2) ist korrekt und bleibt unverändert; irreführender Docblock-Kommentar bereits gefixt. Kein neuer Umsetzungs-Task.
+- [x] **F8 Playtest-Instrumentierung** ✅ 2026-09-08 freigegeben (A17) — `docs/playtest-instrumentation-plan.md` ist vollständig überarbeitet (alle 3 Unterentscheidungen entschieden). Umsetzungs-Tasks siehe **A30/A31/A32/A33**.
 
 ### A — Design vorhanden, Implementierung fehlt (TDD-Pflicht)
 
@@ -28,20 +28,30 @@ Quelle: `docs/audit-implementierungsstand-2026-09-06.md` (Kategorien A + C, Absc
 - [ ] **A7 Nexus-Milestones**: Sol-90-Letzte-Warnung, Fristverkürzung auf Sol 95 nach Sanktion (§15); toten Config-Block `run.nexus_milestones` verdrahten oder entfernen — Mittel
 - [x] **A8** ✅ 2026-09-07 — Nexus-Schulden-Rückzahlungs-Sondermechanik (§18.2) erledigt sich strukturell durch F3-Entscheidung (`nexus_debt` bleibt als laufender Fehlbetrags-Topf, keine separate Rückzahlungsmechanik nötig) — obsolet, kein eigener Task mehr
 - [ ] **A9 Nexus-Boni** ahead-of-curve (§15) — Niedrig, Design-Frage (A.4) zuerst
-- [ ] **A10 Kenntnis-Teilmenge pro Run** (§10) — nach F6
+- [x] **A10** ✅ 2026-09-08 — Kenntnis-Teilmenge pro Run (§10) erledigt sich strukturell durch F6-Entscheidung (Streichung, kein Umsetzungsauftrag) — obsolet, kein eigener Task mehr
 - [ ] **A11 Uplink-Station Lv2/Lv3**: Händler-Frequenz (Lv2), Kolonialbericht/Meta-Bonus (Lv3) definieren oder streichen; Lv1 „Verwaltungsanfragen" klären — Mittel
-- [ ] **A12 Kanal 2 Nexus-Handelsschiffe** — nach F5
+- [x] **A12** ✅ 2026-09-08 — Kanal 2 Nexus-Handelsschiffe erledigt sich strukturell durch F5-Entscheidung (Streichung zugunsten Uplink-Direktimport) — obsolet, kein eigener Task mehr, siehe A28/A29
 - [ ] **A13 Handelsposten „Konsul-Effizienz"** (§4) — Text streichen oder AP-Rabatt implementieren — Klein
 - [ ] **A14 Notreparatur** CC/Wohnhabitat (§7) — implementieren oder aus GDD streichen — Klein
 - [ ] **A15 Kolonisten-Framing** für Supply in der UI (§6) — Klein
-- [ ] **A16 Konstant-Yield-Spec** — nach F4
-- [ ] **A17 Playtest-Instrumentierung** 11 Metriken in `RunReport` — nach F8
+- [x] **A16** ✅ 2026-09-08 — Konstant-Yield-Spec entschieden (F4: umsetzen) — Umsetzungs-Tasks siehe A24/A25/A26/A27
+- [x] **A17** ✅ 2026-09-08 — Playtest-Instrumentierung 11 Metriken in `RunReport` freigegeben (F8) — Umsetzungs-Tasks siehe A30/A31/A32/A33
 - [ ] **A18** `mission_perimeter_patrol` in `config/missions.php` aufnehmen (§8b) — Klein
 - [ ] **A19 Reparatur-Hysterese: Schwellenwert einbauen** (nach F2, §7) — neuen Config-Wert (~50 %, z.B. `game.decay.effect_restore_threshold`) anlegen und an der/den Stelle(n) verdrahten, die Gebäude-Boni aktuell binär über `status_points > 0` gaten (u.a. `TrustService` — exakte Fundstellen von game-developer per Grep ermitteln, ggf. weitere Services betroffen). Effekt „aus bei 0, zurück ab ~50 % Reparatur", nicht mehr binär. TDD: Test zuerst (Zustandsübergänge 0 → <50 % → ≥50 %). — Mittel
 - [ ] **A20 Reparatur-Hysterese: Kaskaden-Schutz** (nach F2, §7, vor A19 zu klären) — Design-Klärung + Balance-Dämpfung gegen Abwärtsspirale (negativer Supply-Puffer → Trust runter → mehr Verfall → noch weniger Trust) VOR der A19-Implementierung; sonst Risiko eines Spiralen-Bugs (Softlock-Gefahr). Owner-Entscheidung zum Dämpfungsmechanismus einholen, dann Umsetzung + Regressionstest. — Mittel, Design-Frage zuerst
 - [ ] **A21 Nexus-Schulden: Upkeep-Defizit einspeisen** (nach F3, §13.1/§18.2) — `GameTick::processAdvisorUpkeep()`: `MAX(0, credits - upkeep)`-Klemme entfernen, Fehlbetrag stattdessen zu `nexus_debt` addieren. Dazu `nexus_debt_fail_threshold` (aktuell 12000) neu kalibrieren, da eine zusätzliche laufende Schuldenquelle hinzukommt. TDD: Test zuerst (Defizit-Szenario erhöht `nexus_debt` statt zu verpuffen; Threshold-Grenzfall). — Mittel
 - [ ] **A22 Konsul-„Handelsvertrag" entfernen** (nach F3, §15) — `config/game.php → credits.consul_contract_income_per_rank` löschen, zugehörige GameTick-Berechnung (~Zeile 1588ff) entfernen, `docs/game-reference.md` Konsul-Rang-Tabelle korrigieren (Pflicht-Checkliste vor Merge, ADR 0004). TDD: bestehende Tests, die den Contract-Income prüfen, anpassen/entfernen, ggf. Regressionstest „kein Contract-Income mehr" ergänzen. Unabhängig von A21/A23 umsetzbar. — Klein
 - [ ] **A23 Berater-Beförderung: automatisch → manuell** (nach F3, §13) — `GameTick::processAdvisorPromotions()` von Auto-Beförderung auf spielerausgelösten Trigger umstellen; neuer Endpoint (backend-coder) + UI-Trigger im Berater-Screen (ui-specialist), Spieler kann Beförderung bei erreichtem Threshold beliebig aufschieben. Cross-Cutting zwischen backend-coder und ui-specialist. TDD: Service-/Endpoint-Test zuerst (kein Auto-Trigger mehr im Tick; manueller Endpoint befördert nur bei erfülltem Threshold). Unabhängig von A21/A22 umsetzbar. — Mittel
+- [ ] **A24 Harvester Konstant-Yield: `GameTick::harvesterYield()` umstellen** (nach F4, §4c) — Rampen-Formel entfernen, auf konstante Rate laut Spec `docs/superpowers/specs/2026-08-10-harvester-constant-yield-design.md` umstellen; bestehende Tests umschreiben. TDD: Test zuerst. — Mittel
+- [ ] **A25 Harvester Konstant-Yield: `sols_remaining`-Berechnung + Serialisierung** (nach A24) — neue Methode (z.B. in `ColonyTileService`), Ergebnis am Tile-Endpoint mitliefern. TDD: Test zuerst. — Klein/Mittel
+- [ ] **A26 Harvester Konstant-Yield: UI „≈N Sole bis Erschöpfung"** (nach A25) — Anzeige im Tile-Panel (`hexview.blade.php`), Warnfarbe bei ≤3 Sole verbleibend — ui-specialist. — Klein
+- [ ] **A27 §13.7-Neuherleitung nach Playtest** (nach A24-A26, eigenständig, spät liegend) — Sockel-Durchschnitt ~12,9 → ~17 Rg/Sol bei regolith_normal neu herleiten, Baupreise/Guard-Rails prüfen. Explizit NICHT Teil des A24-A26-Sofort-Umbaus, erst nach Playtest-Feedback. — Mittel, spät
+- [ ] **A28 Uplink-Direktimport für Nicht-Werkstoff-Ressourcen** (nach F5, §4) — neue Uplink-Direktimport-Variante: Anfrage+Bezahlung sofort, Lieferung nach 3-5 Sol (Basiswert), reduzierbar durch Uplink-Station-Level (Lv1/2/3, einziger Hebel, kein Konsul-Rang/Kenntnis-Hebel). Bestehende Werkstoff-Sofortkauf-Variante bleibt unverändert. TDD: Test zuerst. — Mittel
+- [ ] **A29 GDD-Restvorkommen INNN im alten Kanal-2-Text bereinigen** (nach A28/GDD-Edit) — prüfen ob nach dem GDD-Edit noch Restverweise auf das entfernte INNN-System übrig sind, sonst als erledigt streichen. — Klein
+- [ ] **A30 Playtest-Instrumentierung Phase B1 — Extended Snapshots** (nach F8, kritischer Pfad, Owner: game-developer/qa-tester) — AP-Breakdown, Building-Level+AP-Spend, Regolith-/Organika-Quellen inkl. neuer `organika_consumption`-Aufschlüsselung, Supply-Snapshot, Harvester-Move-Tracking; siehe Phasen B1a-B1e in `docs/playtest-instrumentation-plan.md`. TDD: Test zuerst. — Groß
+- [ ] **A31 Playtest-Instrumentierung Phase B2 — Post-Lauf-Aggregation** (nach A30, kritischer Pfad) — Projekt-Metriken, Regolith-Pfad-Attribution nach Mechanismen, 0-AP-Filter. TDD: Test zuerst. — Mittel
+- [ ] **A32 Playtest-Instrumentierung Phase C — Dashboard-Erweiterung** (nach A31, kritischer Pfad, Owner: ui-specialist) — mind. 3 Charts als MVP (AP, Regolith, Supply), 4 weitere iterativ. — Mittel
+- [ ] **A33 Playtest-Instrumentierung Phase D — Summary-Tabellen-Erweiterung** (parallel zu A32, Owner: ui-specialist) — siehe Plan. — Klein/Mittel
 - [ ] **T7 Encounter-Reste**: Geologische Instabilität + Seuchenausbruch in `SolReportService::eventsGroup()` (B12) — Klein
 
 ### C — Doku widerspricht Code (Entscheidung, dann GDD oder Code anpassen)
@@ -49,7 +59,7 @@ Quelle: `docs/audit-implementierungsstand-2026-09-06.md` (Kategorien A + C, Absc
 - [x] **C1** ✅ 2026-09-07 — §13.1 „Upkeep-Verlust läuft über `nexus_debt`" — entschieden: GDD-Text bestätigt sich als Zielzustand, Umsetzung fehlt noch (Code-Gap, siehe A21)
 - [x] **C2** ✅ 2026-09-07 — §7 Instanz-Zerstörung vs. Level-0-Ruine — entschieden: nie löschen (Ist-Zustand bestätigt), zusätzlich neue Reparatur-Hysterese für Effekt-Rückkehr ab ~50 % beschlossen (siehe A19/A20); GDD §7 bereits parallel aktualisiert
 - [x] **C3** ✅ 2026-09-06 (GDD-Konsolidierung) — §4 Uplink Lv2 „Tiefenscan 1 Sol weniger" → Code: Scan-AP 2 → 1; Text angleichen
-- [ ] **C4** §15/§18.4 Phase-1-Bedingung — nach F7
+- [x] **C4** ✅ 2026-09-08 — §15/§18.4 Phase-1-Bedingung — entschieden (F7): Code (`RunProgressService::checkPhase1Completion()`) ist korrekt und bleibt unverändert, irreführender Docblock-Kommentar bereits gefixt
 - [x] **C5** ✅ 2026-09-06 (GDD-Konsolidierung) — §15 Fail States / Gnadenfrist auf Phase-2-Sol-Basis und Instant-Trust-Fail umschreiben (§18.5-TODO seit 06-28) — zusammen mit A7
 - [ ] **C6** §6 Supply-Cap Wohnhabitat: „pro Einheit" vs. Σ Level × 8; Ziel-Cap nach Tier-System neu prüfen (Stufe 1d, `cap_max` 200)
 - [x] **C7** ✅ 2026-09-06 (GDD-Konsolidierung) — §8b Missionstabelle: `mission_aid_transport` ungegatet, `mission_harvester_salvage` ergänzen, Lieferzeiten 1/2/3

--- a/app/Services/RunProgressService.php
+++ b/app/Services/RunProgressService.php
@@ -76,7 +76,10 @@ class RunProgressService
      *
      * Conditions (GDD §15):
      *  1. Command Center (building_id = 25) at level >= 3.
-     *  2. At least 2 production buildings (building_id != 25) at level >= 2.
+     *  2. At least 2 non-CC buildings (building_id != 25, any type, not just
+     *     production) at level >= 2. Confirmed intentional (Owner-Frage F7,
+     *     ROADMAP 2026-09-08) — the looser "any building" condition is correct,
+     *     not a bug.
      *  3. At least 3 active advisors (colony assigned, not on cooldown).
      */
     public function checkPhase1Completion(Run $run): bool

--- a/docs/GDD.md
+++ b/docs/GDD.md
@@ -258,7 +258,7 @@ Daraus folgt zwingend `Preis(Regolith) < Preis(Organika) < Preis(Werkstoffe)` un
 
 Im Singleplayer gibt es keinen Spieler-zu-Spieler-Handel. Werkstoffe können **nicht lokal produziert** werden — die Kolonie ist zu klein zum Veredeln. Es gibt drei Bezugswege, die bewusst eine Hierarchie bilden:
 
-1. **Nexus-Direktimport (Sicherheitsnetz, garantiert):** Über die **Uplink-Station Lv1** (eine der aktiven Nexus-Anfragen, siehe §4) kann jederzeit eine beliebige Menge Werkstoffe gegen Credits gekauft werden — deterministisch, immer verfügbar, aber zu einem **festen, spürbar höheren Preis** als der Cantina-Spotpreis (siehe `docs/game-reference.md#werkstoff-preise`). Dies ist das Anti-Lock-Netz: ohne diesen garantierten Weg wäre jede Werkstoff-Baukostenanforderung potenziell hart blockierbar.
+1. **Nexus-Direktimport (Sicherheitsnetz, garantiert):** Über die **Uplink-Station Lv1** (eine der aktiven Nexus-Anfragen, siehe §4) kann jederzeit eine beliebige Menge Werkstoffe gegen Credits gekauft werden — deterministisch, **sofort verfügbar**, aber zu einem **festen, spürbar höheren Preis** als der Cantina-Spotpreis (siehe `docs/game-reference.md#werkstoff-preise`). Dies ist das Anti-Lock-Netz: ohne diesen garantierten Weg wäre jede Werkstoff-Baukostenanforderung potenziell hart blockierbar. Für alle anderen Ressourcen bietet dieselbe Nexus-Anfrage eine verzögerte Variante (Bezahlung sofort, Lieferung nach einigen Solen, §4) — Werkstoffe bleiben bei der Sofort-Lieferung, weil sie das einzige echte Progression-Lock-Risiko tragen.
 2. **Cantina (opportunistisch, günstiger):** Zufällige, zeitgebundene Kaufangebote zum niedrigeren Marktpreis (Kanal 1, §12). Belohnung fürs aufmerksame Spielen, aber **nie garantiert** — daher nie die einzige Quelle.
 3. **Events (Bonus):** Liefern Werkstoffe als Bonus, immer mit Wahlmöglichkeit, nie kostenlos und nie als einzige Quelle.
 
@@ -395,13 +395,15 @@ Wenn ein Gebäude durch Decay ein Level verliert, gibt die Kolonie automatisch e
 
 ### Uplink-Station (uplinkStation) — Mechanik
 
-Die Uplink-Station ist das einzige Kommunikationsgebäude der Kolonie — 1 Instanz, Lv1–3. **Ohne Uplink-Station Lv1 sind aktive Nexus-Anfragen gesperrt** (Werkstoff-Direktimport, Handelsschiff anfordern, Verwaltungsanfragen). Eingehende Nexus-Funk-Nachrichten des Nexus (Milestones, Warnungen) kommen immer an — diese sind nicht abhängig vom Gebäude.
+Die Uplink-Station ist das einzige Kommunikationsgebäude der Kolonie — 1 Instanz, Lv1–3. **Ohne Uplink-Station Lv1 sind aktive Nexus-Anfragen gesperrt** (Direktimport, Verwaltungsanfragen). Eingehende Nexus-Funk-Nachrichten des Nexus (Milestones, Warnungen) kommen immer an — diese sind nicht abhängig vom Gebäude.
 
 | Level | CC-Voraussetzung | Freischaltet / Effekt |
 |-------|-----------------|----------------------|
-| 1 | CC Lv2 | Aktive Nexus-Anfragen: **Werkstoff-Direktimport** (gegen Credits, immer verfügbar, fester Preis — siehe §3), Handelsschiff anfordern, Verwaltung |
-| 2 | CC Lv3 | Tiefenscan kostet weniger AP (`ColonyTileService`); *geplant:* Reisender Händler erscheint häufiger (ROADMAP A11) |
-| 3 | CC Lv5 | Run-Abschluss-Aktion: Kolonialbericht senden → Meta-Bonus für nächsten Run |
+| 1 | CC Lv2 | Aktive Nexus-Anfragen: **Direktimport** (Werkstoffe gegen Credits, fester Preis, sofort verfügbar, siehe §3; alle anderen Ressourcen gegen Credits, fester Preis, verzögerte Lieferung, Basiswert 3–5 Sole, siehe unten), außerdem Verwaltungsanfragen |
+| 2 | CC Lv3 | Tiefenscan kostet weniger AP (`ColonyTileService`); Direktimport-Lieferzeit für Nicht-Werkstoffe sinkt; *geplant:* Reisender Händler erscheint häufiger (ROADMAP A11) |
+| 3 | CC Lv5 | Direktimport-Lieferzeit für Nicht-Werkstoffe sinkt weiter; Run-Abschluss-Aktion: Kolonialbericht senden → Meta-Bonus für nächsten Run |
+
+**Direktimport für Nicht-Werkstoff-Ressourcen (Owner-Entscheidung F5, 2026-09-08):** Anfrage und Bezahlung passieren sofort wie beim Werkstoff-Direktimport, die Lieferung selbst braucht jedoch mehrere Sole (Basiswert 3–5 Sole auf Lv1). Der **einzige** Hebel zur Verkürzung ist das Uplink-Station-Level selbst — bewusst kein zusätzlicher Hebel über Konsul-Rang, Kenntnisse oder situative Boni, um den Direktimport als reine Infrastrukturfrage zu halten. Dieser Weg ersetzt das gestrichene Konzept „Nexus-Handelsschiffe" (§12) als Sicherheitsnetz für nicht lokal beschaffbare Ressourcenmengen.
 
 **Baukosten Lv1:** Ausschließlich Regolith + Credits — keine Werkstoffe, um einen Zirkelschluss zu vermeiden (Werkstoffe über Nexus anfordern setzt das Gebäude voraus).
 
@@ -669,7 +671,7 @@ Der Harvester (Regolith) und der Agrardom (Organika) sind der **gemeinsame Socke
 
 ### Pfad-C-Hebel: Credits statt Regolith
 
-**Pfad C trägt keinen Regolith-Hebel.** Ein Organika→Regolith-Tausch als Pfad-C-Hebel ist ausgeschlossen — er würde das knappere gegen das häufigere Gut tauschen (Knappheitsordnung §3). Die Regolith-Lücke der Zielkolonie schließen Pfad A (`geology`) und Pfad B (`mission_supply_run`) gemeinsam (§13.7). Der Engpass, gegen den Pfad C als „Pfad der Flexibilität" antritt, ist Credits — und die Kolonie produziert strukturelle Organika-Überschüsse (§4a), die über diesen Hebel monetarisiert werden.
+**Pfad C hat keinen dedizierten Regolith-Hebel.** Ein Organika→Regolith-Tausch als Pfad-C-Hebel ist ausgeschlossen — er würde das knappere gegen das häufigere Gut tauschen (Knappheitsordnung §3). Die Regolith-Lücke der Zielkolonie schließen strukturell Pfad A (`geology`) und Pfad B (`mission_supply_run`) gemeinsam (§13.7). Der Engpass, gegen den Pfad C als „Pfad der Flexibilität" antritt, ist Credits — und die Kolonie produziert strukturelle Organika-Überschüsse (§4a), die über diesen Hebel monetarisiert werden. Opportunistisch bleibt dem Spieler dennoch ein Nebenweg offen: Der Reisende Händler (Corvan) führt im Alltagsgeschäft auch Credits→Regolith-Kaufangebote, sodass eine Cantina-lastige Kolonie ihre Credits-Überschüsse bei Bedarf in Regolith umwandeln kann. Das ist kein struktureller Ersatz für A/B (Angebot ist unzuverlässig, an Losgröße und Kaufkraft gebunden) und ändert nichts an der Designabsicht — Pfad C bleibt ohne eigenen, planbaren Regolith-Wachstumshebel —, macht aber die Formulierung „trägt keinen Regolith-Hebel" zu absolut.
 
 **Mechanik: Organika-Verkauf als Angebotstyp des Reisenden Händlers.** Neben Kauf (Credits→Ressource) und Tausch (Ressource↔Ressource) gibt es den **Verkauf** (Organika→Credits), eng gefasst nur für Organika — Regolith- und Werkstoff-Verkauf bleiben außen vor, damit kein Umweg zur Regolith-Beschaffung entsteht.
 
@@ -751,10 +753,12 @@ Damit entsteht die gewollte Schleife: fördern → Ertrag sinkt → Umzug lohnt 
 #### Erschöpfungskurve und Umzugstakt
 
 ```
-Ertrag = Frischwert × (0,5 + 0,5 × Restvorkommen / resource_max)
+Ertrag = Frischwert, solange Restvorkommen > 0, sonst 0
 ```
 
-Ein Tile beginnt beim vollen Frischwert und fällt bis zum Ausschöpfen auf die **Hälfte** — nie auf null, damit ein vergessener Harvester nicht schlagartig stillsteht. Bei erschöpftem Vorkommen: Produktion 0, der Umzug ist erzwungen. Ein `poor`-Tile erreicht den Boden früher als ein `normal`-Tile — derselbe Mechanismus, keine Sonderregel.
+Ein Tile fördert **konstant zum Frischwert**, bis das Vorkommen aufgebraucht ist — kein Abschwächen zur Mitte hin. Bei erschöpftem Vorkommen: harter Cutoff auf Produktion 0, der Umzug ist erzwungen. Ein `poor`-Tile erreicht den Boden früher als ein `normal`-Tile — derselbe Mechanismus, keine Sonderregel.
+
+**Owner-Entscheidung (2026-08-10):** Vorher fiel der Ertrag mit sinkendem Restvorkommen bis auf die Hälfte des Frischwerts ab. Das war für den Spieler zu schwer zu durchschauen (unterschiedliche Förderrate pro Tick, ohne dass sich am Tile sichtbar etwas geändert hatte). Eine konstante Rate ist berechenbar; als Ausgleich für den Verlust der Vorwarnung durch die abfallende Kurve zeigt das Tile-Panel neu einen serverseitig berechneten „≈N Sole bis Erschöpfung"-Countdown (serverseitig, weil Geologie-Bonus und Vertrauens-Multiplikator nur dort zuverlässig bekannt sind). Herleitung: `docs/superpowers/specs/2026-08-10-harvester-constant-yield-design.md`.
 
 | Fall | Harvester |
 |---|---|
@@ -1263,8 +1267,6 @@ Exakte Kosten (Navigation-AP, Organika-Proviant, Zusatzmaterialien), Distanzen, 
 
 > **Idee (festgehalten 2026-07-04, später konzipieren):** Bar-Begegnungen (Cantina-NPCs) können Missions-Varianten mit verbesserten Boni oder veränderten Parametern anbieten — als Alternative für den Pfad Hangar-first → Cantina-second (vor dem Labor). Ziel: verschiedene Spielweisen gleichwertig halten (Roguelike-Varianz). Noch nicht designt.
 
-**Roguelike-Varianz gratis:** Da pro Run nur eine Teilmenge der Kenntnisse verfügbar ist (§10), fehlen in manchen Runs 2–3 der kenntnis-gebundenen Missionen (Prospektion, Datensammelflug, Handelsfahrt, Hilfsgütertransport, Trümmerbergung, Patrouille, Fernexpedition) — jede Missionsökonomie spielt sich pro Run anders, ohne Zusatzsystem. 6 der 7 Kenntnisse gaten je 1–2 Missionen; Agronomie bleibt frei als Reserve für spätere Missionstypen.
-
 **Kenntnis-Skalierung — Erfahrung senkt den Proviantbedarf:** Eine einzige, spielweite Regel:
 
 ```
@@ -1390,6 +1392,8 @@ Ein Ereignis kündigt sich 1 Sol vorher als `colony_log`-Eintrag an (Kategorie �
 | trade | Handel & Logistik | Trade & Logistics |
 | defense | Verteidigung & Überlebenstaktik | Defence & Survival Tactics |
 
+**Alle 7 Kenntnisse sind in jedem Run verfügbar** — endgültiger Zustand, keine offene Design-Frage mehr (Owner-Entscheidung F6, 2026-09-08). Eine roguelike-typische Teilmengen-Auswahl pro Run wurde geprüft und verworfen: Bei nur 7 Kenntnissen wäre das Risiko zu hoch, dass ein Run ohne eine essentielle Kenntnis auskommen müsste. Die Roguelike-Varianz des Spiels trägt sich über andere Systeme (Startbedingungen, Encounter-Würfe, Bar-Angebote, Berater-Erfolgschancen), nicht über die Kenntnisverfügbarkeit.
+
 ### Level-Modell ohne Decay
 
 Kenntnisse verwenden das **Level-Modell (Lv1–5)** — identisch zu Gebäuden, aber **ohne Decay**. Einmal erforschtes Wissen bleibt permanent. Es gibt keinen SP-Verfall auf Kenntnissen — das wäre thematisch unlogisch (Wissen verfällt nicht). Die natürliche Begrenzung erfolgt über AP-Knappheit und Rundenstruktur.
@@ -1418,12 +1422,6 @@ Bereits implementierte Effekte (`config/knowledge.php`):
 Nicht jede Kenntnis trägt zwingend einen mechanischen Effekt dieser Art — alle Kenntnisse tragen zusätzlich einheitlich zum Supply-Cap-Wachstum bei (§7). Welche Kenntnis welchen Effekt trägt und in welcher Höhe, ist ausschließlich in `config/knowledge.php` gepflegt; Lookup-Tabelle: `docs/game-reference.md#kenntnisse-7-levelup-kosten-effekte`.
 
 > **TODO Design:** Weitere Kenntnis-Effekte (insbesondere für Kenntnisse ohne eigenen mechanischen Effekt bislang) sind offen für spätere Balancing-Passes — nach Playtest, wenn klar ist, welche Lücken am meisten drücken.
-
-### Roguelike-Variabilität
-
-Pro Run ist nicht der vollständige Kenntnisbaum verfügbar — nur eine zufällige Teilmenge (z.B. 5 von 7). Das erzeugt unterschiedliche Spezialisierungspfade ohne das System komplexer zu machen, analog zum variablen Spielfeld bei Catan.
-
-> **TODO Implementierung:** Run-Mechanik mit zufälliger Kenntnisauswahl — ausstehend für Phase 3 Run-Struktur (§15).
 
 ### Kolonisten-Ausbildung (Design-Konzept, Phase 4+)
 
@@ -1530,23 +1528,7 @@ Exakte Erfolgschancen und Bonussätze: siehe `config/game.php → bar` (`negotia
 
 ---
 
-### Kanal 2: Nexus-Handelsschiffe (Fallback, teuer, garantiert)
-
-> **Status: nicht implementiert, Owner-Frage F5 (ROADMAP):** Der Werkstoff-Direktimport über die Uplink-Station (§3, §4) deckt die Sicherheitsnetz-Funktion bereits ab. Entscheidung offen, ob dieser Kanal gestrichen oder als Direktimport umdefiniert wird.
-
-Nexus schickt auf Anfrage offizielle Handelsschiffe. Immer verfügbar — auch ohne Händler-Berater, auch ohne Bar. Das Sicherheitsnetz gegen Progression-Locks.
-
-Lieferzeit und Preisaufschlag hängen vom Konsul-Rang ab — ohne Berater sind beide nachteilig. Höhere Ränge senken beide Parameter (schnellere Lieferung, bessere Konditionen). Exakte Werte: siehe `config/game.php`.
-
-**Anfrage-Mechanik:** Der Spieler sendet eine Anfrage über den Nexus-Funk (Nachricht an "Nexus Command"). Nexus antwortet nach 1–3 Solen (abhängig vom Konsul-Rang) mit einem Protokoll-Ereignis, das die Lieferung bestätigt und die Ressourcen direkt zur Kolonie transferiert. Kein eigenes Fleet-Objekt — das Nexus-Schiff erscheint nicht auf der Karte.
-
-**Ablauf:**
-1. Spieler öffnet den Nexus-Funk → "Nexus-Handelsschiff anfordern" → wählt Ressource + Menge
-2. Credits-Betrag wird sofort eingefroren (reserviert)
-3. Nach Lieferzeit: Protokoll-Ereignis "Nexus-Lieferung eingetroffen", Ressourcen gutgeschrieben, Credits abgebucht
-4. Kann nur 1 offene Anfrage gleichzeitig haben
-
----
+> **Kanal 2 gestrichen (Owner-Entscheidung F5, 2026-09-08):** Das früher hier vorgesehene, nie implementierte Konzept „Nexus-Handelsschiffe" (Anfrage über Nexus-Funk, Lieferung nach 1–3 Solen) entfällt ersatzlos. Seine Sicherheitsnetz-Funktion — verzögerte, aber garantierte Lieferung gegen Credits, auch für Ressourcen, die nicht sofort verfügbar sind — übernimmt stattdessen die erweiterte Direktimport-Variante der Uplink-Station (§3, §4).
 
 ### Kanal 3: Reisender Händler (selten, hochwertig)
 
@@ -1733,7 +1715,7 @@ Der Harvester hat **kein Level-Up** (`max_level = 1`). Er liefert je Standort ei
 | **Sockel (alle Pfade)** | Harvester, 1 Instanz (§4c) | keine (passiv), Umzüge kosten AP |
 | **A — Analytik** | Kenntnis `geology` erhöht die Harvester-Ausbeute je Level (`game.geology_harvester_bonus_per_level`, kumulativ) | einmalig hoch (AP bis zum Ziellevel), danach null laufende Kosten |
 | **B — Hangar** | Frachter auf `mission_supply_run` (Regolith je Umlauf, `config/missions.php`) | laufend: Navigation-AP, Organika-Proviant, Verschleiß |
-| **C — Cantina** | **kein Regolith-Hebel** — Pfad C liefert Credits (§4b „Pfad-C-Hebel") | — |
+| **C — Cantina** | kein dedizierter Hebel — Pfad C liefert Credits (§4b „Pfad-C-Hebel"); opportunistischer Credits→Regolith-Kauf via Corvan möglich | — |
 
 Die Profile sind bewusst gegensätzlich: **Analytik** verbessert den Sockel selbst — teuer im Aufbau, danach dauerhaft geschenkt, keine Logistik. **Hangar** legt einen zweiten Strom daneben — billig im Einstieg, aber jeden Sol Aufwand. **Cantina** kauft zu und wandelt Überschuss in Credits — maximal flexibel, an Credits und Angebotslage gebunden. Ob A und B die Regolith-Lücke der Zielkolonie tatsächlich schließen, rechnet §13.7 nach.
 
@@ -2084,6 +2066,8 @@ Dieses Konzept — "Fog of Information" — ist analog zum Fog of War in der Exp
 
 Von der Designabsicht her hergeleitet statt aus Bestandswerten fortgeschrieben. Der Satz ist Owner-Entscheidung; die Werte stehen in `config/buildings.php` und `config/game.php`, Lookup in `docs/game-reference.md`. Dieses Kapitel hält die Herleitung fest, damit Playtest-Befunde gegen die richtige Stellschraube laufen.
 
+> ⚠️ **Veraltet (seit F4, 2026-09-08):** Der Harvester fördert nicht mehr über eine Rampe, sondern konstant zum Frischwert bis zur Erschöpfung (§4c). Das hebt den effektiven Sockel-Durchschnitt gegenüber dem hier gerechneten Zyklusmittel spürbar an — die gesamte Bilanz unten (Sockel-Anteil, Hebel-Zielgröße, G2/G6-Prozentsätze) rechnet noch mit dem alten Rampen-Zyklusmittel und ist nicht mehr aktuell. Owner-Entscheidung: keine Neuherleitung jetzt, sondern erst nach dem nächsten Playtest-Batch, als eigenes Vorhaben. Bau-Preise, `decay_rate`-Klassen und Guard-Rails (G2/G4/G6/G7) bleiben bis dahin unverändert, gelten aber als zu überprüfen.
+
 #### Das Spielgefühl — zuerst, ohne Zahlen
 
 Jede Zahl unten ist auf eine dieser Aussagen zurückführbar. Wo das nicht gelingt, ist sie willkürlich und gehört ersetzt.
@@ -2106,7 +2090,7 @@ Jede Zahl unten ist auf eine dieser Aussagen zurückführbar. Wo das nicht gelin
 
 | Wert | Festlegung | folgt aus |
 |---|---|---|
-| Harvester-Ertrag | Frischwert je Tile-Stufe (`rich`/`normal`/`poor`), fallend mit der Erschöpfung (§4c), `max_level = 1` | G7 |
+| Harvester-Ertrag | Frischwert je Tile-Stufe (`rich`/`normal`/`poor`), konstant bis zur Erschöpfung, dann harter Cutoff (§4c), `max_level = 1` | G7 |
 | Reparatur | 1 Rg je SP (zusätzlich 1 AP je SP) | G2 + „eine Zahl, zwei Währungen" |
 | `decay_rate` | vier Klassen 0,40 / 0,60 / 0,80 / 1,20 | G2, G3 |
 | Errichtung (Lv0→1) | 70 Agrardom (Ramp-Gate-Ausnahme) / 95 alle drei Pfadgebäude | G4 (5–8 Sole) |
@@ -2152,7 +2136,7 @@ Rechnung über 80 Sole — die Fensterbreite entspricht der Phase-2-Sol-80-Konve
 Zielkolonie-Bedarf ≈ 835 (Errichtungen) + 720 (Level-Ups) + 240 (Reibung, ~15 %) ≈ 1.795 Rg
 ```
 
-**2. Sockel-Einnahmen** aus der Erschöpfungskurve, Standardfall 1 Instanz auf `regolith_normal` inklusive Transit-Sole: Zyklusmittel **~12,9 Rg/Sol**, konstant über den Run.
+**2. Sockel-Einnahmen** aus der Erschöpfungskurve, Standardfall 1 Instanz auf `regolith_normal` inklusive Transit-Sole: Zyklusmittel **~12,9 Rg/Sol**, konstant über den Run. *(Veraltet — Rampen-Zyklusmittel, siehe Hinweis am Kapitelanfang. Mit konstanter Förderrate liegt der Sockel-Durchschnitt höher; Neuherleitung steht aus.)*
 
 ```
 Sockel-Einnahmen = 12,9 Rg/Sol × 80 Sole ≈ 1.032 Rg
@@ -2182,7 +2166,7 @@ Merkregel, aus der Gegenrichtung: **ein reifer Pfad-Hebel ist etwa 60 % eines Ha
 |---|---|---|
 | A — Analytik | `geology`, kumuliert max 12 | 12 Rg/Sol |
 | B — Hangar | `mission_supply_run`, ~6,25 Rg/Sol je Frachter | 6,25 Rg/Sol (1 Schiff), skaliert mit der Flotte |
-| C — Cantina | kein Regolith-Hebel (§4b) | 0 |
+| C — Cantina | kein dedizierter Hebel (§4b), opportunistischer Kauf via Corvan | 0 (nicht planbar/strukturell) |
 
 ```
 A + B (1 Frachter) = 18,25 Rg/Sol  ≥  14,1 Rg/Sol benötigt

--- a/docs/playtest-instrumentation-plan.md
+++ b/docs/playtest-instrumentation-plan.md
@@ -27,7 +27,7 @@
 | 5 | **Instandhaltungsanteil am Pool** | ❌ | AP-Breakdown: `repair_spent / total` (B1a) |
 | 6 | **Regolith-Bilanz** (Quelle-Breakdown) | Nur total | Snapshot: Quelle-Attribution pro Sol (B1c) |
 | 7 | **Supply-Auslastung** (used/cap + Sole über Cap) | ❌ | Snapshot: Supply-Berechnung (B1d) |
-| 8 | **Sole mit 0 AP je Domäne** | ❌ | Nachberechnung: Filter über Snapshots (B2c) |
+| 8 | **Sole mit 0 AP gesamt** (Domänen-Aufschlüsselung moot, s. B2c) | ❌ | Nachberechnung: Filter über Snapshots (B2c) |
 | 9 | **Regolith-Durchsatz je Pfad** (Frachter/Geologie/Cantina) | ❌ | Nachberechnung: Quelle-Aggregation nach Pfad (B2b) |
 | 10 | **Harvester-Umzüge** pro Run | ❌ | Snapshot: Positionen + Action-Log-Filter (B1e) |
 | 11 | **Organika-Bilanz** (Quelle-Breakdown) | Nur total | Snapshot: wie Regolith (B1c) |
@@ -55,7 +55,11 @@ Alle Tasks sind im Test-Harness (RunReport::snapshot()), keine Game-Logic-Änder
 #### B1c: Regolith- & Organika-Quellen
 - Klassifiziere jede Action im Log nach Quelle (harvester, mission, trade, event)
 - Speichere: `'regolith_sources' => ['harvester' => 8, 'mission' => 2, ...]`
-- **Test (TDD):** Quellen-Summen = Bestandsdelta (Anfang–Ende Sol)
+- **Organika-Verbrauch (entschieden, F8/3):** Es gibt zwei getrennte Verbrauchswege mit unterschiedlichem Timing, die die Attribution getrennt ausweisen muss, sonst verzerrt eine reine Sol-Snapshot-Momentaufnahme die Bilanz zwischen zwei Snapshots:
+  - `hunger_consumed` — `GameTick::processFoodConsumption()`, ein Abzug pro Tick, nach Produktion, vor Trust-Berechnung (End-of-Sol)
+  - `mission_dispatch_consumed` — `HangarService::dispatch()` → `organikaCostFor()`, sofort bei Spieleraktion, kann mehrmals pro Sol auftreten, asynchron zum Tick
+  - Speichere: `'organika_sources' => [...Zufluss wie oben...], 'organika_consumption' => {hunger_consumed, mission_dispatch_consumed}`
+- **Test (TDD):** Quellen-Summen = Bestandsdelta (Anfang–Ende Sol); für Organika zusätzlich: Zufluss − (`hunger_consumed` + `mission_dispatch_consumed`) = Delta
 
 #### B1d: Supply-Snapshot
 - Berechne `supply_used` (sum aller Gebäude-Kosten), `supply_cap` (GDD §6 Formel)
@@ -78,11 +82,15 @@ Alle Tasks sind im Test-Harness (RunReport::snapshot()), keine Game-Logic-Änder
 - **Test (TDD):** Multi-Sol-Accumulation korrekt
 
 #### B2b: Regolith-Pfad-Attribution (Metrik 9)
-- Klassifiziere nach Pfad: A (Frachter/mission), B (Geologie/harvester), C (Cantina/trade)
+- **Pfad-Definition (entschieden, F8/1):** Mechanismen-Klassifikation, nicht Kenntnisse — deckt sich 1:1 mit der GDD-Pfad-Struktur:
+  - **Pfad A** = geology-Kenntnis-Bonus auf Harvester-Ertrag, bereits separat berechnet in `GameTick::harvesterYield()`
+  - **Pfad B** = `mission_supply_run`-Frachtermission
+  - **Pfad C** = Cantina/Corvan-Regolith-Kauf
 - Aggregiere über Run
 - **Test (TDD):** Summe ≈ (final − start + consumed)
 
 #### B2c: Sole mit 0 AP (Metrik 8)
+- **Domänen-Aufschlüsselung (entschieden, F8/2):** obsolet/moot — AP-Domänen (Bau/Forschung/Handel/Navigation getrennt) existieren seit der AP-Pool-Konsolidierung (2026-08-02, GDD §13.1) nicht mehr, es gibt nur noch einen gemeinsamen Pool. Eine Domänen-Spalte ist technisch nicht mehr möglich. Metrik 8 bleibt "Sole mit 0 AP gesamt".
 - Filter Snapshots: zähle wo `ap_unspent <= 0`
 - Speichere: count + Liste der Sole-Nummern
 - **Test (TDD):** count ≤ total sols
@@ -133,11 +141,11 @@ B1a (AP) → B1b (Buildings) → B2a (Projekte) → C (Dashboard)
 
 | Phase | Aufwand | TDD |
 |---|---|---|
-| B1 (Snapshots) | 8h | 5h |
+| B1 (Snapshots) | 8.5h (B1c +0.5h für getrennte Organika-Verbrauchsattribution, F8/3) | 5.5h |
 | B2 (Aggregation) | 3.5h | 2h |
 | C (Dashboard) | 6h | — |
 | D (Summary) | 1h | — |
-| **Total** | **~22h** | **~7h** |
+| **Total** | **~22.5h** | **~7.5h** |
 
 ---
 
@@ -151,11 +159,13 @@ B1a (AP) → B1b (Buildings) → B2a (Projekte) → C (Dashboard)
 
 ---
 
-## Offene Owner-Entscheidungen
+## Owner-Entscheidungen (F8, 2026-09-08)
 
-1. **Pfad-Definition (Metrik 9):** Mechanismen (Frachter/Geologie/Cantina) oder Kenntnisse?
-2. **0-AP nach Domäne (Metrik 8):** Für Zukunft vorbereiten?
-3. **Organika-Consumption:** Dynamisch per Aktion oder nur End-of-Sol?
+Alle drei Punkte entschieden, Details inline in B1c und B2b/B2c vermerkt:
+
+1. Pfad-Definition (Metrik 9): Mechanismen-Klassifikation (Frachter/Geologie/Cantina) — siehe B2b.
+2. 0-AP nach Domäne (Metrik 8): moot, AP-Domänen existieren seit der Pool-Konsolidierung nicht mehr — siehe B2c.
+3. Organika-Consumption: zwei getrennte Kategorien (`hunger_consumed`, `mission_dispatch_consumed`) — siehe B1c.
 
 ---
 


### PR DESCRIPTION
## Summary
- Owner-Fragen F4-F8 aus dem Implementierungsstand-Audit entschieden (F1-F3 bereits per PR #313 gemerged)
- GDD.md nachgezogen (§3, §4, §8b, §10, §12, §13.7, §4c)
- ROADMAP.md: F4-F8 als entschieden/freigegeben markiert, neue Umsetzungs-Tasks A24-A33
- `docs/playtest-instrumentation-plan.md` überarbeitet (alle 3 offenen Unterentscheidungen entschieden)
- `RunProgressService::checkPhase1Completion()`: irreführender Docblock-Kommentar korrigiert (kein Logikwechsel)

## Entscheidungen
- **F4**: Harvester Konstant-Yield-Spec wird umgesetzt (Rampen-Formel → konstante Rate + Cutoff), §13.7-Sockelrechnung als veraltet markiert, Neuherleitung folgt nach Playtest
- **F5**: Kanal-2-Nexus-Handelsschiffe gestrichen, Funktion wandert in eine neue Uplink-Direktimport-Variante (3-5 Sole Lieferzeit für Nicht-Werkstoff-Ressourcen, einziger Reduktionshebel: Uplink-Station-Level)
- **F6**: Roguelike-Kenntnis-Teilmenge pro Run ersatzlos gestrichen (Risiko fehlender essentieller Kenntnisse bei nur 7 Stück)
- **F7**: Phase-1-Bedingung im Code bestätigt wie implementiert (jedes Nicht-CC-Gebäude zählt, nicht nur Produktionsgebäude) — nur der Kommentar war irreführend
- **F8**: Playtest-Instrumentierungsplan freigegeben; Regolith-Pfad-Attribution nach Mechanismen, Organika-Verbrauch in Hunger-/Mission-Dispatch-Anteil aufgeschlüsselt; Nebenbefund GDD "Pfad C trägt keinen Regolith-Hebel" korrigiert

## Test plan
- [x] Larastan lief im Pre-Commit-Hook durch (0 Fehler)
- [x] Einziger Codepfad-Eingriff ist ein Kommentar (`RunProgressService.php`), kein Verhaltensänderung — kein neuer Test nötig